### PR TITLE
Stage promote-v2 notes for live page updates

### DIFF
--- a/promote-v2/README.md
+++ b/promote-v2/README.md
@@ -1,0 +1,14 @@
+# Promote v2
+
+This folder stages the next live-page refinements for EthereonLabs.
+
+Planned root targets:
+- build.html
+- about.html
+- contact.html
+- sitemap.xml
+
+Goals:
+- thread specimen and Lumina more clearly through the public site
+- shift contact toward early interest and collaboration
+- strengthen the build/about framing without losing the grounded tone

--- a/promote-v2/about-notes.md
+++ b/promote-v2/about-notes.md
@@ -1,0 +1,11 @@
+# about.html v2 notes
+
+Direction:
+- preserve the clean explanation of EthereonLabs
+- add one stronger bridge to Lumina as the longer horizon
+- keep the tone grounded and practical
+
+Suggested additions:
+- a long horizon framing section
+- direct links to lumina.html and specimen.html
+- clearer distinction between what is visible now and what the deeper environmental direction means

--- a/promote-v2/build-notes.md
+++ b/promote-v2/build-notes.md
@@ -1,0 +1,11 @@
+# build.html v2 notes
+
+Direction:
+- keep the existing grounded framing
+- add a clearer proof layer pointing to specimen.html and lumina.html
+- make the page feel less like a placeholder and more like a real public build map
+
+Suggested additions:
+- short section for visual proof
+- stronger statement about the first believable wedge into continuity based computing
+- clear links to specimen and Lumina pages

--- a/promote-v2/contact-notes.md
+++ b/promote-v2/contact-notes.md
@@ -1,0 +1,12 @@
+# contact.html v2 notes
+
+Direction:
+- shift the page from generic contact toward early interest and collaboration
+- keep it direct and human
+- avoid pretending a full signup system already exists
+
+Suggested additions:
+- early interest path
+- collaboration path
+- direct email fallback
+- links back to specimen.html and lumina.html so people can understand the project before writing

--- a/promote-v2/sitemap-notes.md
+++ b/promote-v2/sitemap-notes.md
@@ -1,0 +1,7 @@
+# sitemap.xml v2 notes
+
+Add:
+- lumina.html
+- specimen.html
+
+Keep the live sitemap aligned with the actual public pages so search and indexing have the right map of the site.


### PR DESCRIPTION
This PR stages the next live-page promotion notes in the promote-v2 folder.

Included:
- promote-v2/README.md
- promote-v2/build-notes.md
- promote-v2/about-notes.md
- promote-v2/contact-notes.md
- promote-v2/sitemap-notes.md

Purpose:
- guide the next pass on build.html, about.html, contact.html, and sitemap.xml
- thread specimen and Lumina more clearly through the public site
- shift contact toward early interest and collaboration