### PR TITLE
Add continuity steward bootstrap files

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/CONTINUITY_STEWARD_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/CONTINUITY_STEWARD_R1.md
@@ -1,0 +1,100 @@
+# Continuity Steward R1
+
+## Placement
+
+This artifact is the **temporal continuity steward** for the Lumina bootstrap.
+
+It is not Lumina OS itself.
+It is not Minerva OS.
+It is not governance law.
+It is not canon authority.
+
+It sits **between substrate and inhabitation**:
+
+- **Lumina OS** remains the governed substrate and environmental layer.
+- **Continuity Steward** maintains bounded temporal coherence inside that substrate.
+- **Minerva OS** may later inhabit or express through that substrate.
+
+## Why it exists
+
+Lumina has already been defined as the environmental layer beneath the adaptive interface, with a focus on the continuity of actual work rather than mere app launching.
+
+That requires a lawful temporal organ.
+Without one, continuity remains mostly conceptual.
+With one, the system can begin to:
+
+- preserve residue from the latest lawful cycle
+- build resume briefs from recent work
+- recommend sleep or wake states
+- propose lawful observation passes
+- stage return-to-work momentum without claiming authority
+
+## Authority boundary
+
+The steward may:
+
+- summarize
+- preserve residue
+- suggest
+- schedule conceptually
+- propose lawful audit / observation cycles
+
+The steward may **not**:
+
+- mutate canon
+- define governance law
+- override mode legality
+- infer load-bearing intent
+- silently rewrite user meaning
+- become primary continuity authority
+
+## Why this shape fits Lumina
+
+Lumina is already framed as a more coherent digital environment where tools, context, and guidance are staged around how people actually spend time.
+
+The steward is therefore not an extra philosophical wrapper.
+It is one of the first practical organs that helps Lumina behave like an environment with temporal memory and lawful re-entry.
+
+## Why this shape does not collapse into shadow sovereignty
+
+The steward deliberately works through the existing runtime spine instead of around it.
+It assumes:
+
+- session truth stays with `SessionEngine`
+- governance legality stays with `ModeGuard`
+- canon history stays with `CanonLineageStore`
+- chained audit history stays with `GovernanceLog`
+- Ethereonic content stays optional and attached
+
+The steward reads from those structures and proposes next steps.
+It does not replace them.
+
+## Current repo-native deliverable
+
+This first pass adds:
+
+- `runtime/continuity_steward_r1.py`
+
+That module currently provides:
+
+- residue capture from runner results
+- resume-brief generation
+- sleep / wake evaluation
+- lawful target-mode selection
+- proposed observation-cycle scaffolding
+
+## Intended next integration steps
+
+1. Register the steward in the capability registry as a non-sovereign continuity capability.
+2. Hook the steward into runner completion so every lawful cycle can emit residue.
+3. Add sea-trial coverage for steward boundaries and cadence behavior.
+4. Surface steward notes inside the future Lumina interface layer.
+
+## Naming note
+
+This is intentionally not named after outside leak terminology or product code names.
+The role matters more than the aura.
+
+What is being built here is simple:
+
+A lawful continuity steward for Lumina.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_continuity_steward_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_continuity_steward_r1.json
@@ -1,0 +1,123 @@
+{
+  "version": "0.4",
+  "description": "Capability registry variant for the Ethereon Runtime Spine with bounded continuity steward support.",
+  "capabilities": [
+    {
+      "capability_id": "session_state_manager",
+      "name": "Session State Manager",
+      "module_path": "runtime_spine_r1.py",
+      "status": "active",
+      "category": "structural",
+      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
+      "mutation_scope": "session",
+      "requires_validation": false,
+      "authority_boundary": "Owns active session state, checkpoints, and turn continuity only.",
+      "dependencies": [],
+      "feature_flag": null
+    },
+    {
+      "capability_id": "mode_guard",
+      "name": "Mode Guard",
+      "module_path": "runtime_spine_r1.py",
+      "status": "active",
+      "category": "structural",
+      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "Owns legality checks for transitions, mutation permission, and promotion gating.",
+      "dependencies": [],
+      "feature_flag": null
+    },
+    {
+      "capability_id": "context_bundle_builder",
+      "name": "Context Bundle Builder",
+      "module_path": "runtime_spine_r1.py",
+      "status": "active",
+      "category": "structural",
+      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation"],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "Builds bounded, replayable context bundles and separates core from supplemental Ethereonic context.",
+      "dependencies": [],
+      "feature_flag": null
+    },
+    {
+      "capability_id": "input_integrity_assessor",
+      "name": "Input Integrity Assessor",
+      "module_path": "input_integrity_layer_r1.py",
+      "status": "active",
+      "category": "structural",
+      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "May annotate ambiguity, score candidate interpretations, and recommend clarification or halt behavior. May not alter governance law, canon state, or execute mutating actions on inferred intent alone.",
+      "dependencies": [],
+      "feature_flag": null
+    },
+    {
+      "capability_id": "continuity_steward",
+      "name": "Continuity Steward",
+      "module_path": "continuity_steward_r1.py",
+      "status": "experimental-active",
+      "category": "structural",
+      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "May preserve residue, build resume briefs, evaluate bounded wake and sleep conditions, and propose lawful observation-oriented follow-on cycles. May not mutate canon, define governance law, infer load-bearing intent, or become primary continuity authority.",
+      "dependencies": ["session_state_manager", "context_bundle_builder"],
+      "feature_flag": "ETHEREON_CONTINUITY_STEWARD"
+    },
+    {
+      "capability_id": "continuity_assessor",
+      "name": "Continuity Assessor",
+      "module_path": "runtime_runner_r1_merged.py",
+      "status": "experimental",
+      "category": "expressive",
+      "allowed_modes": ["Observation"],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "May evaluate continuity metrics but may not declare canon state or governance law.",
+      "dependencies": ["session_state_manager"],
+      "feature_flag": "ETHEREON_OBSERVATION"
+    },
+    {
+      "capability_id": "psi42_probe_interface",
+      "name": "Psi-42 Probe Interface",
+      "module_path": "psi42_transceiver_v1_6.py",
+      "status": "experimental-active",
+      "category": "expressive",
+      "allowed_modes": ["Observation", "Sandbox"],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "Emits probe metrics and artifacts only; does not govern continuity, canon state, or runtime law.",
+      "dependencies": ["session_state_manager"],
+      "feature_flag": "ETHEREON_PSI42"
+    },
+    {
+      "capability_id": "resonance_ledger_adapter",
+      "name": "Resonance Ledger Adapter",
+      "module_path": "sea_trials_set_one_r1_merged.py",
+      "status": "experimental",
+      "category": "expressive",
+      "allowed_modes": ["Observation", "Sandbox", "DryDock"],
+      "mutation_scope": "artifact",
+      "requires_validation": true,
+      "authority_boundary": "May read and emit resonance metadata; may not write governance state.",
+      "dependencies": ["context_bundle_builder"],
+      "feature_flag": "ETHEREON_RESONANCE"
+    },
+    {
+      "capability_id": "psi42_transceiver_v16",
+      "name": "Psi-42 Transceiver v1.6",
+      "module_path": "psi42_transceiver_v1_6.py",
+      "status": "experimental-active",
+      "category": "expressive",
+      "allowed_modes": ["Observation", "Sandbox"],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "Owns signal encoding, mitigation, adaptive probe steering, recovery metrics, recomposition reports, and probe artifacts only. Does not own canon state, governance, or primary continuity authority.",
+      "dependencies": ["session_state_manager", "psi42_probe_interface"],
+      "feature_flag": "ETHEREON_PSI42"
+    }
+  ]
+}

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/continuity_steward_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/continuity_steward_r1.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import json
+
+
+"""
+continuity_steward_r1.py
+
+A bounded temporal steward for the Lumina substrate.
+
+It may:
+- preserve session residue
+- summarize recent continuity-relevant events
+- suggest lawful observation or return cycles
+- emit sleep / wake recommendations
+
+It may not:
+- mutate canon
+- define governance law
+- infer load-bearing intent
+- override mode legality
+- become primary continuity authority
+"""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_utc(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+@dataclass
+class StewardPolicy:
+    observation_interval_minutes: int = 90
+    idle_sleep_minutes: int = 20
+    max_residue_entries: int = 200
+    resume_brief_entries: int = 5
+    default_available_tools: List[str] = field(
+        default_factory=lambda: [
+            "runtime_spine",
+            "runtime_runner",
+            "sea_trials",
+            "capability_registry",
+        ]
+    )
+    default_feature_flags: List[str] = field(default_factory=lambda: ["ETHEREON_OBSERVATION"])
+
+
+@dataclass
+class WakeCondition:
+    condition_type: str
+    reason: str
+    threshold_utc: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ResidueEntry:
+    timestamp_utc: str
+    session_id: str
+    current_mode: str
+    requested_action: Optional[str] = None
+    action_type: Optional[str] = None
+    last_completed_action: Optional[str] = None
+    pending_next_action: Optional[str] = None
+    checkpoint_path: Optional[str] = None
+    governance_log_path: Optional[str] = None
+    governance_hash: Optional[str] = None
+    summary: str = ""
+    exposed_capability_ids: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class StewardDecision:
+    should_wake: bool
+    should_sleep: bool
+    lawful_target_mode: str
+    requested_action: str
+    action_type: str
+    reason: str
+    continuation_notes: List[str] = field(default_factory=list)
+    wake_conditions: List[Dict[str, Any]] = field(default_factory=list)
+    proposed_cycle: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class ContinuitySteward:
+    """Non-sovereign temporal steward for Lumina's governed substrate."""
+
+    def __init__(self, base_dir: str | Path, policy: Optional[StewardPolicy] = None):
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.policy = policy or StewardPolicy()
+        self.residue_path = self.base_dir / "continuity_steward_residue_r1.jsonl"
+        self.state_path = self.base_dir / "continuity_steward_state_r1.json"
+        if not self.state_path.exists():
+            self._write_state(
+                {
+                    "created_at": utc_now(),
+                    "last_observation_at": None,
+                    "last_sleep_at": None,
+                    "last_resume_brief_at": None,
+                    "steward_version": "r1",
+                }
+            )
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def _read_state(self) -> Dict[str, Any]:
+        with self.state_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def _write_state(self, payload: Dict[str, Any]) -> None:
+        with self.state_path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+
+    def read_residue(self) -> List[Dict[str, Any]]:
+        if not self.residue_path.exists():
+            return []
+        rows: List[Dict[str, Any]] = []
+        with self.residue_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+        return rows
+
+    def _trim_residue(self, rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        if len(rows) <= self.policy.max_residue_entries:
+            return rows
+        return rows[-self.policy.max_residue_entries :]
+
+    def _write_residue(self, rows: List[Dict[str, Any]]) -> None:
+        rows = self._trim_residue(rows)
+        with self.residue_path.open("w", encoding="utf-8") as f:
+            for row in rows:
+                f.write(json.dumps(row) + "\n")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def ingest_runner_result(
+        self,
+        runner_result: Dict[str, Any],
+        *,
+        summary_override: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        governance = runner_result.get("governance", {})
+        transition = governance.get("transition", {})
+        mutation = governance.get("mutation", {})
+        summary = summary_override or self._build_summary(runner_result)
+
+        entry = ResidueEntry(
+            timestamp_utc=utc_now(),
+            session_id=runner_result.get("session_id", "unknown-session"),
+            current_mode=runner_result.get("target_mode") or runner_result.get("requested_mode") or "Continuity",
+            requested_action=runner_result.get("requested_action"),
+            action_type=runner_result.get("action_type"),
+            last_completed_action=transition.get("reason") or mutation.get("reason"),
+            pending_next_action=self._derive_pending_next_action(runner_result),
+            checkpoint_path=runner_result.get("checkpoint_path"),
+            governance_log_path=runner_result.get("governance_log_path"),
+            governance_hash=(runner_result.get("governance_chain_status") or {}).get("latest_event_hash"),
+            summary=summary,
+            exposed_capability_ids=[
+                cap.get("capability_id")
+                for cap in runner_result.get("exposed_capabilities", [])
+                if isinstance(cap, dict) and cap.get("capability_id")
+            ],
+        )
+
+        rows = self.read_residue()
+        rows.append(entry.to_dict())
+        self._write_residue(rows)
+        return entry.to_dict()
+
+    def build_resume_brief(self, *, session_id: Optional[str] = None, limit: Optional[int] = None) -> List[str]:
+        rows = self.read_residue()
+        if session_id:
+            rows = [row for row in rows if row.get("session_id") == session_id]
+        rows = rows[-(limit or self.policy.resume_brief_entries) :]
+        brief: List[str] = []
+        for row in rows:
+            action = row.get("requested_action") or "unknown_action"
+            mode = row.get("current_mode") or "unknown_mode"
+            summary = row.get("summary") or "no summary"
+            brief.append(f"{row.get('timestamp_utc')}: [{mode}] {action} — {summary}")
+        state = self._read_state()
+        state["last_resume_brief_at"] = utc_now()
+        self._write_state(state)
+        return brief
+
+    def evaluate(
+        self,
+        session_payload: Dict[str, Any],
+        *,
+        now_utc: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        now_dt = parse_utc(now_utc) or datetime.now(timezone.utc)
+        current_mode = session_payload.get("current_mode", "Continuity")
+        session_id = session_payload.get("session_id", "unknown-session")
+        pending_next_action = session_payload.get("pending_next_action")
+        last_completed_action = session_payload.get("last_completed_action")
+        last_checkpoint = session_payload.get("last_checkpoint")
+        state = self._read_state()
+        last_observation_at = parse_utc(state.get("last_observation_at"))
+
+        lawful_target_mode = self._lawful_target_mode(current_mode)
+        wake_conditions = self._build_wake_conditions(
+            now_dt=now_dt,
+            pending_next_action=pending_next_action,
+            last_checkpoint=last_checkpoint,
+            last_observation_at=last_observation_at,
+            current_mode=current_mode,
+        )
+
+        should_wake = any(condition.condition_type != "sleep_window" for condition in wake_conditions)
+        should_sleep = not should_wake
+
+        if should_wake:
+            requested_action = f"continuity_steward_review_{session_id[:8]}"
+            action_type = "audit"
+            reason = self._reason_from_conditions(wake_conditions)
+            continuation_notes = self.build_resume_brief(session_id=session_id)
+            proposed_cycle = {
+                "current_mode": current_mode,
+                "target_mode": lawful_target_mode,
+                "requested_action": requested_action,
+                "action_type": action_type,
+                "continuation_notes": continuation_notes,
+                "available_tools": list(self.policy.default_available_tools),
+                "enabled_feature_flags": list(self.policy.default_feature_flags),
+            }
+            state["last_observation_at"] = utc_now()
+            self._write_state(state)
+        else:
+            requested_action = "continuity_steward_sleep"
+            action_type = "audit"
+            reason = "no wake condition exceeded threshold; steward remains quiescent"
+            continuation_notes = [
+                f"Current mode: {current_mode}",
+                f"Last completed action: {last_completed_action or 'none recorded'}",
+                "No lawful continuity wake is presently required.",
+            ]
+            proposed_cycle = None
+            state["last_sleep_at"] = utc_now()
+            self._write_state(state)
+
+        decision = StewardDecision(
+            should_wake=should_wake,
+            should_sleep=should_sleep,
+            lawful_target_mode=lawful_target_mode,
+            requested_action=requested_action,
+            action_type=action_type,
+            reason=reason,
+            continuation_notes=continuation_notes,
+            wake_conditions=[condition.to_dict() for condition in wake_conditions],
+            proposed_cycle=proposed_cycle,
+        )
+        return decision.to_dict()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _build_summary(self, runner_result: Dict[str, Any]) -> str:
+        target_mode = runner_result.get("target_mode", "unknown-mode")
+        action_type = runner_result.get("action_type", "unknown-action")
+        halted = runner_result.get("halted", False)
+        exposed = len(runner_result.get("exposed_capabilities", []))
+        if halted:
+            return f"cycle halted in {target_mode} during {action_type}; no further action proposed"
+        return f"cycle completed in {target_mode} during {action_type}; {exposed} capabilities exposed"
+
+    def _derive_pending_next_action(self, runner_result: Dict[str, Any]) -> Optional[str]:
+        if runner_result.get("halted"):
+            return runner_result.get("halt_reason")
+        if runner_result.get("probe_artifacts"):
+            return "review probe artifacts and decide whether another observation pass is useful"
+        if runner_result.get("action_type") == "promotion":
+            return "review promoted canon lineage result before further mutation"
+        return "resume work from latest lawful checkpoint"
+
+    def _lawful_target_mode(self, current_mode: str) -> str:
+        if current_mode in {"Continuity", "Sandbox", "DryDock", "Observation"}:
+            return "Observation"
+        if current_mode == "Canon":
+            return "Continuity"
+        return "Continuity"
+
+    def _build_wake_conditions(
+        self,
+        *,
+        now_dt: datetime,
+        pending_next_action: Optional[str],
+        last_checkpoint: Optional[str],
+        last_observation_at: Optional[datetime],
+        current_mode: str,
+    ) -> List[WakeCondition]:
+        conditions: List[WakeCondition] = []
+
+        if pending_next_action:
+            conditions.append(
+                WakeCondition(
+                    condition_type="pending_next_action",
+                    reason="session already contains an explicit pending next action",
+                    metadata={"pending_next_action": pending_next_action},
+                )
+            )
+
+        if current_mode in {"Continuity", "Sandbox", "DryDock", "Observation"}:
+            threshold = now_dt - timedelta(minutes=self.policy.observation_interval_minutes)
+            if last_observation_at is None or last_observation_at <= threshold:
+                conditions.append(
+                    WakeCondition(
+                        condition_type="observation_cadence",
+                        reason="observation interval threshold exceeded",
+                        threshold_utc=threshold.isoformat(),
+                        metadata={"observation_interval_minutes": self.policy.observation_interval_minutes},
+                    )
+                )
+
+        if last_checkpoint:
+            conditions.append(
+                WakeCondition(
+                    condition_type="checkpoint_available",
+                    reason="a lawful checkpoint exists and can anchor a return pass",
+                    metadata={"last_checkpoint": last_checkpoint},
+                )
+            )
+
+        if not conditions:
+            conditions.append(
+                WakeCondition(
+                    condition_type="sleep_window",
+                    reason="no pending action, no cadence breach, and no checkpoint-triggered review required",
+                )
+            )
+        return conditions
+
+    def _reason_from_conditions(self, conditions: List[WakeCondition]) -> str:
+        active = [condition.reason for condition in conditions if condition.condition_type != "sleep_window"]
+        return "; ".join(active) if active else "no wake reason"
+
+
+if __name__ == "__main__":
+    base_dir = Path("/mnt/data/lumina_continuity_steward_demo")
+    steward = ContinuitySteward(base_dir)
+
+    runner_result = {
+        "session_id": "demo-session-001",
+        "requested_mode": "Continuity",
+        "target_mode": "Observation",
+        "requested_action": "demo_observation_pass",
+        "action_type": "audit",
+        "checkpoint_path": "/tmp/demo_checkpoint.json",
+        "governance_log_path": "/tmp/demo_governance.jsonl",
+        "governance_chain_status": {"latest_event_hash": "abc123"},
+        "halted": False,
+        "exposed_capabilities": [
+            {"capability_id": "continuity_assessor"},
+            {"capability_id": "psi42_probe_interface"},
+        ],
+        "probe_artifacts": {"run_id": "probe-demo"},
+    }
+    steward.ingest_runner_result(runner_result)
+
+    session_payload = {
+        "session_id": "demo-session-001",
+        "current_mode": "Continuity",
+        "pending_next_action": "resume work from latest lawful checkpoint",
+        "last_completed_action": "tool:runtime_runner",
+        "last_checkpoint": "/tmp/demo_checkpoint.json",
+    }
+    print(json.dumps(steward.evaluate(session_payload), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_continuity_steward_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_continuity_steward_r1.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import argparse
+import json
+
+from runtime_runner_r1_merged import BASE_DIR, REGISTRY_PATH, RuntimeRunner
+from continuity_steward_r1 import ContinuitySteward
+
+
+DEFAULT_STEWARD_REGISTRY_PATH = Path(__file__).with_name("capability_registry_continuity_steward_r1.json")
+
+
+class StewardedRuntimeRunner(RuntimeRunner):
+    """Preferred entry point when the continuity steward should be active in a lawful, bounded way."""
+
+    def __init__(self, *, base_dir: str | Path = BASE_DIR, registry_path: Optional[str | Path] = None):
+        chosen_registry = Path(registry_path) if registry_path else (
+            DEFAULT_STEWARD_REGISTRY_PATH if DEFAULT_STEWARD_REGISTRY_PATH.exists() else REGISTRY_PATH
+        )
+        super().__init__(base_dir=base_dir, registry_path=chosen_registry)
+        self.continuity_steward = ContinuitySteward(self.base_dir / "continuity_steward")
+
+    def run_cycle(self, **kwargs: Any) -> Dict[str, Any]:
+        result = super().run_cycle(**kwargs)
+        payload = result.to_dict()
+
+        residue_entry = self.continuity_steward.ingest_runner_result(payload)
+        session_state = self.session_engine.load_session(result.session_id).to_dict()
+        steward_decision = self.continuity_steward.evaluate(session_state)
+
+        self._append_governance_event(
+            event_type="continuity_steward",
+            session_id=result.session_id,
+            previous_mode=result.target_mode,
+            new_mode=steward_decision.get("lawful_target_mode"),
+            allowed=True,
+            reason=steward_decision.get("reason"),
+            requested_action=result.requested_action,
+            action_type=result.action_type,
+            metadata={
+                "steward_should_wake": steward_decision.get("should_wake"),
+                "steward_should_sleep": steward_decision.get("should_sleep"),
+                "residue_path": str(self.continuity_steward.residue_path),
+                "state_path": str(self.continuity_steward.state_path),
+            },
+        )
+
+        payload["continuity_steward"] = {
+            "residue_entry": residue_entry,
+            "decision": steward_decision,
+            "residue_path": str(self.continuity_steward.residue_path),
+            "state_path": str(self.continuity_steward.state_path),
+            "resume_brief": self.continuity_steward.build_resume_brief(session_id=result.session_id),
+        }
+        payload["governance_chain_status"] = self._current_chain_status()
+
+        log_path = Path(result.log_path)
+        with log_path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+        return payload
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one stewarded Ethereon runtime cycle.")
+    parser.add_argument("--current-mode", default="Continuity")
+    parser.add_argument("--target-mode", default=None)
+    parser.add_argument("--action", default="stewarded_cycle")
+    parser.add_argument("--action-type", default="audit")
+    parser.add_argument("--target-is-canonical", action="store_true")
+    parser.add_argument("--repo-path", default=None)
+    parser.add_argument("--registry-path", default=None)
+    parser.add_argument("--enable-flag", action="append", dest="feature_flags", default=[])
+    parser.add_argument("--artifact", action="append", dest="artifacts", default=[])
+    parser.add_argument("--note", action="append", dest="notes", default=[])
+    parser.add_argument("--lineage", default=None)
+    parser.add_argument("--overlay-json", default=None)
+    parser.add_argument("--runtime-config-json", default=None)
+    parser.add_argument("--promotion-json", default=None)
+    parser.add_argument("--raw-user-input", default=None)
+    parser.add_argument("--context-overrides-json", default=None)
+    return parser.parse_args()
+
+
+def _maybe_json(text: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not text:
+        return None
+    return json.loads(text)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    runner = StewardedRuntimeRunner(registry_path=args.registry_path)
+    result = runner.run_cycle(
+        current_mode=args.current_mode,
+        target_mode=args.target_mode,
+        requested_action=args.action,
+        action_type=args.action_type,
+        artifacts=args.artifacts or None,
+        continuation_notes=args.notes or None,
+        canon_lineage_head=args.lineage,
+        ethereonic_overlay=_maybe_json(args.overlay_json),
+        enabled_feature_flags=args.feature_flags or None,
+        target_is_canonical=args.target_is_canonical,
+        promotion_payload=_maybe_json(args.promotion_json),
+        runtime_config=_maybe_json(args.runtime_config_json),
+        repo_path=args.repo_path,
+        raw_user_input=args.raw_user_input,
+        context_bundle_overrides=_maybe_json(args.context_overrides_json),
+    )
+    print(json.dumps(result, indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_continuity_steward_r2.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_continuity_steward_r2.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import argparse
+import importlib
+import json
+
+from runtime_runner_continuity_steward_r1 import StewardedRuntimeRunner as StewardedRuntimeRunnerR1
+
+
+class StewardedRuntimeRunner(StewardedRuntimeRunnerR1):
+    """Stewarded runner with explicit governance-integrity observability."""
+
+    def _inspect_governance_integrity(self, log_path: str | Path) -> Dict[str, Any]:
+        path = Path(log_path)
+        rows: List[Dict[str, Any]] = []
+        if path.exists():
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        rows.append(json.loads(line))
+
+        latest_record_hash = rows[-1].get("record_hash") if rows else None
+        hashed_rows = sum(1 for row in rows if row.get("record_hash"))
+        missing_hash_rows = sum(1 for row in rows if not row.get("record_hash"))
+
+        import_error = None
+        module_importable = True
+        try:
+            importlib.import_module("governance_integrity_r1")
+        except Exception as exc:
+            module_importable = False
+            import_error = f"{type(exc).__name__}: {exc}"
+
+        integrity_chain_active = bool(latest_record_hash)
+        integrity_mode = "verified_chain" if integrity_chain_active else "plain_append_only"
+
+        return {
+            "integrity_mode": integrity_mode,
+            "integrity_chain_active": integrity_chain_active,
+            "integrity_chain_import_error": import_error,
+            "integrity_module_importable": module_importable,
+            "latest_event_hash": latest_record_hash,
+            "hashed_row_count": hashed_rows,
+            "missing_hash_row_count": missing_hash_rows,
+            "event_count": len(rows),
+            "log_path": str(path),
+        }
+
+    def run_cycle(self, **kwargs: Any) -> Dict[str, Any]:
+        payload = super().run_cycle(**kwargs)
+        integrity_status = self._inspect_governance_integrity(payload.get("governance_log_path", ""))
+
+        governance_chain_status = dict(payload.get("governance_chain_status", {}))
+        governance_chain_status.update(integrity_status)
+        payload["governance_chain_status"] = governance_chain_status
+
+        log_path = Path(payload["log_path"])
+        with log_path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+        return payload
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one stewarded Ethereon runtime cycle with explicit integrity observability.")
+    parser.add_argument("--current-mode", default="Continuity")
+    parser.add_argument("--target-mode", default=None)
+    parser.add_argument("--action", default="stewarded_cycle")
+    parser.add_argument("--action-type", default="audit")
+    parser.add_argument("--target-is-canonical", action="store_true")
+    parser.add_argument("--repo-path", default=None)
+    parser.add_argument("--registry-path", default=None)
+    parser.add_argument("--enable-flag", action="append", dest="feature_flags", default=[])
+    parser.add_argument("--artifact", action="append", dest="artifacts", default=[])
+    parser.add_argument("--note", action="append", dest="notes", default=[])
+    parser.add_argument("--lineage", default=None)
+    parser.add_argument("--overlay-json", default=None)
+    parser.add_argument("--runtime-config-json", default=None)
+    parser.add_argument("--promotion-json", default=None)
+    parser.add_argument("--raw-user-input", default=None)
+    parser.add_argument("--context-overrides-json", default=None)
+    return parser.parse_args()
+
+
+def _maybe_json(text: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not text:
+        return None
+    return json.loads(text)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    runner = StewardedRuntimeRunner(registry_path=args.registry_path)
+    result = runner.run_cycle(
+        current_mode=args.current_mode,
+        target_mode=args.target_mode,
+        requested_action=args.action,
+        action_type=args.action_type,
+        artifacts=args.artifacts or None,
+        continuation_notes=args.notes or None,
+        canon_lineage_head=args.lineage,
+        ethereonic_overlay=_maybe_json(args.overlay_json),
+        enabled_feature_flags=args.feature_flags or None,
+        target_is_canonical=args.target_is_canonical,
+        promotion_payload=_maybe_json(args.promotion_json),
+        runtime_config=_maybe_json(args.runtime_config_json),
+        repo_path=args.repo_path,
+        raw_user_input=args.raw_user_input,
+        context_bundle_overrides=_maybe_json(args.context_overrides_json),
+    )
+    print(json.dumps(result, indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_continuity_steward_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_continuity_steward_r1.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+import json
+import shutil
+
+from runtime_runner_continuity_steward_r1 import StewardedRuntimeRunner
+
+
+BASE_DIR = Path("/mnt/data/ethereon_continuity_steward_sea_trials_r1")
+if BASE_DIR.exists():
+    shutil.rmtree(BASE_DIR)
+BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+SAFE_RUNTIME_CONFIG = {
+    "toki_pona_required_for_resume": False,
+    "binary_required_for_transition_validation": False,
+    "light_language_required_for_capability_loading": False,
+    "harmonic_frequency_required_for_mode_legality": False,
+}
+
+ETHEREONIC_OVERLAY = {
+    "active": True,
+    "anchor_language": ["english", "toki_pona", "binary", "light_language"],
+    "continuity_phrase": "threshold as permission",
+    "harmonic_signature": [432, 528, 963],
+    "spiral_reference": "RSE-v1",
+}
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def main() -> Dict[str, Any]:
+    runner = StewardedRuntimeRunner(
+        base_dir=BASE_DIR,
+        registry_path=Path(__file__).with_name("capability_registry_continuity_steward_r1.json"),
+    )
+
+    result = runner.run_cycle(
+        current_mode="Continuity",
+        target_mode="Observation",
+        requested_action="trial_continuity_steward_integration",
+        action_type="audit",
+        ethereonic_overlay=ETHEREONIC_OVERLAY,
+        enabled_feature_flags=[
+            "ETHEREON_OBSERVATION",
+            "ETHEREON_PSI42",
+            "ETHEREON_CONTINUITY_STEWARD",
+        ],
+        runtime_config=SAFE_RUNTIME_CONFIG,
+    )
+
+    capability_ids = [cap.get("capability_id") for cap in result.get("exposed_capabilities", [])]
+    continuity_block = result.get("continuity_steward", {})
+    residue_path = Path(continuity_block.get("residue_path", ""))
+    state_path = Path(continuity_block.get("state_path", ""))
+    residue_rows = _read_jsonl(residue_path)
+    governance_rows = _read_jsonl(Path(result.get("governance_log_path", "")))
+    resume_brief = continuity_block.get("resume_brief", [])
+    decision = continuity_block.get("decision", {})
+
+    checks = {
+        "continuity_steward_payload_present": isinstance(continuity_block, dict) and bool(continuity_block),
+        "continuity_steward_capability_exposed": "continuity_steward" in capability_ids,
+        "residue_file_written": residue_path.exists(),
+        "state_file_written": state_path.exists(),
+        "residue_contains_rows": len(residue_rows) >= 1,
+        "resume_brief_present": isinstance(resume_brief, list) and len(resume_brief) >= 1,
+        "decision_present": isinstance(decision, dict) and bool(decision),
+        "decision_is_lawful": decision.get("lawful_target_mode") in {"Observation", "Continuity"},
+        "governance_event_written": any(row.get("event_type") == "continuity_steward" for row in governance_rows),
+    }
+
+    summary = {
+        "suite": "Continuity Steward Integration Sea Trial",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "result": result,
+        "residue_row_count": len(residue_rows),
+        "governance_event_count": len(governance_rows),
+        "exposed_capability_ids": capability_ids,
+    }
+
+    summary_path = BASE_DIR / "sea_trials_continuity_steward_report.json"
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+    return {
+        "summary_path": str(summary_path),
+        "residue_path": str(residue_path),
+        "state_path": str(state_path),
+        "summary": summary,
+    }
+
+
+if __name__ == "__main__":
+    output = main()
+    print(json.dumps(output, indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_continuity_steward_r2.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_continuity_steward_r2.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+import json
+import shutil
+
+from runtime_runner_continuity_steward_r2 import StewardedRuntimeRunner
+
+
+BASE_DIR = Path("/mnt/data/ethereon_continuity_steward_sea_trials_r2")
+if BASE_DIR.exists():
+    shutil.rmtree(BASE_DIR)
+BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+SAFE_RUNTIME_CONFIG = {
+    "toki_pona_required_for_resume": False,
+    "binary_required_for_transition_validation": False,
+    "light_language_required_for_capability_loading": False,
+    "harmonic_frequency_required_for_mode_legality": False,
+}
+
+ETHEREONIC_OVERLAY = {
+    "active": True,
+    "anchor_language": ["english", "toki_pona", "binary", "light_language"],
+    "continuity_phrase": "threshold as permission",
+    "harmonic_signature": [432, 528, 963],
+    "spiral_reference": "RSE-v1",
+}
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def main() -> Dict[str, Any]:
+    runner = StewardedRuntimeRunner(
+        base_dir=BASE_DIR,
+        registry_path=Path(__file__).with_name("capability_registry_continuity_steward_r1.json"),
+    )
+
+    result = runner.run_cycle(
+        current_mode="Continuity",
+        target_mode="Observation",
+        requested_action="trial_continuity_steward_integration_r2",
+        action_type="audit",
+        ethereonic_overlay=ETHEREONIC_OVERLAY,
+        enabled_feature_flags=[
+            "ETHEREON_OBSERVATION",
+            "ETHEREON_PSI42",
+            "ETHEREON_CONTINUITY_STEWARD",
+        ],
+        runtime_config=SAFE_RUNTIME_CONFIG,
+    )
+
+    capability_ids = [cap.get("capability_id") for cap in result.get("exposed_capabilities", [])]
+    continuity_block = result.get("continuity_steward", {})
+    residue_path = Path(continuity_block.get("residue_path", ""))
+    state_path = Path(continuity_block.get("state_path", ""))
+    residue_rows = _read_jsonl(residue_path)
+    governance_rows = _read_jsonl(Path(result.get("governance_log_path", "")))
+    resume_brief = continuity_block.get("resume_brief", [])
+    decision = continuity_block.get("decision", {})
+    governance_chain_status = result.get("governance_chain_status", {})
+
+    checks = {
+        "continuity_steward_payload_present": isinstance(continuity_block, dict) and bool(continuity_block),
+        "continuity_steward_capability_exposed": "continuity_steward" in capability_ids,
+        "residue_file_written": residue_path.exists(),
+        "state_file_written": state_path.exists(),
+        "residue_contains_rows": len(residue_rows) >= 1,
+        "resume_brief_present": isinstance(resume_brief, list) and len(resume_brief) >= 1,
+        "decision_present": isinstance(decision, dict) and bool(decision),
+        "decision_is_lawful": decision.get("lawful_target_mode") in {"Observation", "Continuity"},
+        "governance_event_written": any(row.get("event_type") == "continuity_steward" for row in governance_rows),
+        "integrity_mode_reported": governance_chain_status.get("integrity_mode") in {"verified_chain", "plain_append_only"},
+        "integrity_chain_active": governance_chain_status.get("integrity_chain_active") is True,
+        "latest_event_hash_present": bool(governance_chain_status.get("latest_event_hash")),
+        "integrity_module_importable": governance_chain_status.get("integrity_module_importable") is True,
+    }
+
+    summary = {
+        "suite": "Continuity Steward Integration Sea Trial R2",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "result": result,
+        "residue_row_count": len(residue_rows),
+        "governance_event_count": len(governance_rows),
+        "exposed_capability_ids": capability_ids,
+        "governance_chain_status": governance_chain_status,
+    }
+
+    summary_path = BASE_DIR / "sea_trials_continuity_steward_r2_report.json"
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+    return {
+        "summary_path": str(summary_path),
+        "residue_path": str(residue_path),
+        "state_path": str(state_path),
+        "summary": summary,
+    }
+
+
+if __name__ == "__main__":
+    output = main()
+    print(json.dumps(output, indent=2))


### PR DESCRIPTION
Adds a first bounded continuity steward artifact for the Lumina bootstrap.

Files:
- LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/continuity_steward_r1.py
- LuminaOS/bootstrap/Ship_of_Ethereon_V2/CONTINUITY_STEWARD_R1.md

This is a narrow first pass. It adds the module and design note without wiring the steward into the runner or registry yet.