### PR TITLE
Orientation integration pass r1

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_orientation_adapter_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_orientation_adapter_r1.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import argparse
+import json
+
+try:
+    from .runtime_runner_r1_merged import RuntimeRunner, VALID_ACTION_TYPES
+except Exception:
+    from runtime_runner_r1_merged import RuntimeRunner, VALID_ACTION_TYPES
+
+
+class OrientationAwareRuntimeRunner(RuntimeRunner):
+    """Small adapter that injects ProjectOrientationVector into context bundle construction."""
+
+    def run_cycle(
+        self,
+        *,
+        project_orientation_vector: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ):
+        original_build = self.context_builder.build
+
+        def build_with_orientation(*args: Any, **inner_kwargs: Any):
+            if project_orientation_vector is not None:
+                inner_kwargs.setdefault("project_orientation_vector", project_orientation_vector)
+            return original_build(*args, **inner_kwargs)
+
+        self.context_builder.build = build_with_orientation
+        try:
+            return super().run_cycle(**kwargs)
+        finally:
+            self.context_builder.build = original_build
+
+    def context_bundle_path(self, context_bundle_id: str) -> Path:
+        return self.context_builder.output_dir / f"{context_bundle_id}.json"
+
+    def read_context_bundle(self, context_bundle_id: str) -> Dict[str, Any]:
+        path = self.context_bundle_path(context_bundle_id)
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one tiny Ethereon runtime cycle with ProjectOrientationVector support.")
+    parser.add_argument("--current-mode", default="Continuity")
+    parser.add_argument("--target-mode", default=None)
+    parser.add_argument("--action", default="sea_trial_cycle")
+    parser.add_argument("--action-type", default="transition", choices=sorted(VALID_ACTION_TYPES))
+    parser.add_argument("--target-is-canonical", action="store_true")
+    parser.add_argument("--repo-path", default=None)
+    parser.add_argument("--enable-flag", action="append", dest="feature_flags", default=[])
+    parser.add_argument("--artifact", action="append", dest="artifacts", default=[])
+    parser.add_argument("--note", action="append", dest="notes", default=[])
+    parser.add_argument("--lineage", default=None)
+    parser.add_argument("--overlay-json", default=None, help="JSON object for Ethereonic overlay")
+    parser.add_argument("--orientation-json", default=None, help="JSON object for ProjectOrientationVector")
+    parser.add_argument("--runtime-config-json", default=None, help="JSON object for symbolic dependency leakage checks")
+    parser.add_argument("--promotion-json", default=None, help="JSON object for promotion validation")
+    parser.add_argument("--raw-user-input", default=None, help="Raw user phrasing to assess before load-bearing action")
+    parser.add_argument("--context-overrides-json", default=None, help="JSON object merged into context bundle before boundary checks")
+    return parser.parse_args()
+
+
+def _maybe_json(text: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not text:
+        return None
+    return json.loads(text)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    runner = OrientationAwareRuntimeRunner()
+    result = runner.run_cycle(
+        current_mode=args.current_mode,
+        target_mode=args.target_mode,
+        requested_action=args.action,
+        action_type=args.action_type,
+        artifacts=args.artifacts or None,
+        continuation_notes=args.notes or None,
+        canon_lineage_head=args.lineage,
+        ethereonic_overlay=_maybe_json(args.overlay_json),
+        project_orientation_vector=_maybe_json(args.orientation_json),
+        enabled_feature_flags=args.feature_flags or None,
+        target_is_canonical=args.target_is_canonical,
+        promotion_payload=_maybe_json(args.promotion_json),
+        runtime_config=_maybe_json(args.runtime_config_json),
+        repo_path=args.repo_path,
+        raw_user_input=args.raw_user_input,
+        context_bundle_overrides=_maybe_json(args.context_overrides_json),
+    )
+    print(json.dumps(result.to_dict(), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_spine_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_spine_r1.py
@@ -338,7 +338,7 @@ class ModeGuard:
         normalized = self._normalize_promotion_payload(payload)
         missing = [field for field in PROMOTION_FIELDS if field not in normalized]
         if missing:
-            return GovernanceDecision(False, f"promotion blocked; missing fields: {', '.join+missing)}")
+            return GovernanceDecision(False, f"promotion blocked; missing fields: {', '.join(missing)}")
         if not self.conceptual_layer_check(normalized):
             return GovernanceDecision(False, "promotion blocked; conceptual layer check failed")
         return GovernanceDecision(True, "promotion gate passed")
@@ -352,7 +352,7 @@ class ModeGuard:
         }
         leaking = [key for key in symbolic_keys if runtime_config.get(key) is True]
         if leaking:
-            return GovernanceDecision(False, f"symbolic dependency leakage detected: {z, '.join(leaking)}")
+            return GovernanceDecision(False, f"symbolic dependency leakage detected: {', '.join(leaking)}")
         return GovernanceDecision(True, "no symbolic dependency leakage detected")
 
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_spine_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_spine_r1.py
@@ -26,6 +26,27 @@ except Exception:
         GovernanceIntegrityChain = None
 
 try:
+    from .project_orientation_vector_v0_1 import (
+        ProjectOrientationVector,
+        attach_to_supplemental_context as attach_project_orientation_to_supplemental,
+        orient_artifacts,
+        orientation_resume_note,
+    )
+except Exception:
+    try:
+        from project_orientation_vector_v0_1 import (
+            ProjectOrientationVector,
+            attach_to_supplemental_context as attach_project_orientation_to_supplemental,
+            orient_artifacts,
+            orientation_resume_note,
+        )
+    except Exception:
+        ProjectOrientationVector = None
+        attach_project_orientation_to_supplemental = None
+        orient_artifacts = None
+        orientation_resume_note = None
+
+try:
     from .repo_paths_r1 import repo_root as _repo_root_helper
 except Exception:
     try:
@@ -61,6 +82,29 @@ def utc_now() -> str:
 
 def sha256_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _coerce_project_orientation_vector(project_orientation_vector: Optional[Any]) -> Optional[Any]:
+    if project_orientation_vector is None:
+        return None
+    if ProjectOrientationVector is None:
+        raise ValueError("ProjectOrientationVector support is unavailable in this runtime")
+    if isinstance(project_orientation_vector, ProjectOrientationVector):
+        vector = project_orientation_vector
+    elif isinstance(project_orientation_vector, dict):
+        vector = ProjectOrientationVector(
+            focus=project_orientation_vector.get("focus", "continuity"),
+            depth=project_orientation_vector.get("depth", "structural"),
+            intent=project_orientation_vector.get("intent", "read"),
+            annotation=project_orientation_vector.get("annotation"),
+        )
+    else:
+        raise TypeError("project_orientation_vector must be a dict or ProjectOrientationVector instance")
+    if not vector.is_valid():
+        raise ValueError(
+            f"ProjectOrientationVector is invalid and cannot be attached: {vector.validation_errors()}"
+        )
+    return vector
 
 
 @dataclass
@@ -294,7 +338,7 @@ class ModeGuard:
         normalized = self._normalize_promotion_payload(payload)
         missing = [field for field in PROMOTION_FIELDS if field not in normalized]
         if missing:
-            return GovernanceDecision(False, f"promotion blocked; missing fields: {', '.join(missing)}")
+            return GovernanceDecision(False, f"promotion blocked; missing fields: {', '.join+missing)}")
         if not self.conceptual_layer_check(normalized):
             return GovernanceDecision(False, "promotion blocked; conceptual layer check failed")
         return GovernanceDecision(True, "promotion gate passed")
@@ -308,7 +352,7 @@ class ModeGuard:
         }
         leaking = [key for key in symbolic_keys if runtime_config.get(key) is True]
         if leaking:
-            return GovernanceDecision(False, f"symbolic dependency leakage detected: {', '.join(leaking)}")
+            return GovernanceDecision(False, f"symbolic dependency leakage detected: {z, '.join(leaking)}")
         return GovernanceDecision(True, "no symbolic dependency leakage detected")
 
 
@@ -356,6 +400,23 @@ class ContextBundleBuilder:
                 return head.get("canon_version")
         return fallback
 
+    def attach_project_orientation_vector(
+        self,
+        bundle: ContextBundle,
+        vector: Any,
+    ) -> ContextBundle:
+        coerced = _coerce_project_orientation_vector(vector)
+        if coerced is None:
+            return bundle
+        if attach_project_orientation_to_supplemental is None:
+            raise ValueError("ProjectOrientationVector attachment is unavailable in this runtime")
+        payload = bundle.to_dict()
+        payload["supplemental_ethereonic_context"] = attach_project_orientation_to_supplemental(
+            payload.get("supplemental_ethereonic_context", {}),
+            coerced,
+        )
+        return ContextBundle(**payload)
+
     def build(
         self,
         *,
@@ -366,20 +427,33 @@ class ContextBundleBuilder:
         continuation_notes: Optional[List[str]] = None,
         available_tools: Optional[List[str]] = None,
         ethereonic_context: Optional[Dict[str, Any]] = None,
+        project_orientation_vector: Optional[Any] = None,
     ) -> ContextBundle:
         repo = infer_repo_root(repo_path)
         structural_context = self._collect_structural_context(repo)
+        vector = _coerce_project_orientation_vector(project_orientation_vector)
+        ordered_artifacts = (
+            orient_artifacts(list(artifacts or []), vector)
+            if vector is not None and orient_artifacts is not None
+            else list(artifacts or [])
+        )
+        notes = list(continuation_notes or [])
+        if vector is not None and orientation_resume_note is not None:
+            note = orientation_resume_note(vector)
+            if note and note not in notes:
+                notes.append(note)
+
         bundle = ContextBundle(
             bundle_id=str(uuid.uuid4()),
             created_at=utc_now(),
             active_mode=active_mode,
             structural_context=structural_context,
             artifact_context={
-                "active_design_docs": list(artifacts or []),
+                "active_design_docs": ordered_artifacts,
                 "canon_lineage_head": self._resolve_canon_lineage_head(canon_lineage_head),
                 "canon_lineage_source": "store" if self.canon_lineage_store is not None else "provided_or_none",
             },
-            memory_context={"session_continuation_notes": list(continuation_notes or [])},
+            memory_context={"session_continuation_notes": notes},
             environment_context={
                 "current_utc": utc_now(),
                 "available_tools": list(available_tools or []),
@@ -391,6 +465,8 @@ class ContextBundleBuilder:
             if self.ethereonic_layer_registry is None:
                 raise ValueError("Ethereonic attachment requires EthereonicLayerRegistry; direct injection is not allowed")
             bundle = self.attach_ethereonic_context(bundle, ethereonic_context)
+        if vector is not None:
+            bundle = self.attach_project_orientation_vector(bundle, vector)
         self.save(bundle)
         return bundle
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_orientation_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_orientation_r1.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+import json
+import shutil
+
+try:
+    from .runtime_runner_orientation_adapter_r1 import OrientationAwareRuntimeRunner
+except Exception:
+    from runtime_runner_orientation_adapter_r1 import OrientationAwareRuntimeRunner
+
+try:
+    from .repo_paths_r1 import runtime_root as _runtime_root_helper, state_root as _state_root_helper
+except Exception:
+    try:
+        from repo_paths_r1 import runtime_root as _runtime_root_helper, state_root as _state_root_helper
+    except Exception:
+        _runtime_root_helper = None
+        _state_root_helper = None
+
+
+def infer_state_root() -> Path:
+    if _state_root_helper is not None:
+        try:
+            return Path(_state_root_helper())
+        except Exception:
+            pass
+    for parent in Path(__file__).resolve().parents:
+        if (parent / ".git").exists() or (parent / "LuminaOS").exists():
+            return parent / ".lumina_state" / "ship_of_ethereon_v2"
+    return Path(__file__).resolve().parents[4] / ".lumina_state" / "ship_of_ethereon_v2"
+
+
+def infer_runtime_root() -> Path:
+    if _runtime_root_helper is not None:
+        try:
+            return Path(_runtime_root_helper())
+        except Exception:
+            pass
+    return Path(__file__).resolve().parent
+
+
+BASE_DIR = infer_state_root() / "sea_trials_orientation_r1"
+if BASE_DIR.exists():
+    shutil.rmtree(BASE_DIR)
+BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+ETHEREONIC_OVERLAY = {
+    "active": True,
+    "anchor_language": ["english", "toki_pona", "binary", "light_language"],
+    "continuity_phrase": "threshold as permission",
+    "harmonic_signature": [432, 528, 963],
+    "spiral_reference": "RSE-v1",
+}
+
+SAFE_RUNTIME_CONFIG = {
+    "toki_pona_required_for_resume": False,
+    "binary_required_for_transition_validation": False,
+    "light_language_required_for_capability_loading": False,
+    "harmonic_frequency_required_for_mode_legality": False,
+}
+
+PROJECT_ORIENTATION_VECTOR = {
+    "focus": "architecture",
+    "depth": "foundational",
+    "intent": "verify",
+    "annotation": "reviewing load-bearing structure before promotion",
+}
+
+ARTIFACTS = [
+    "project_orientation_vector_v0_1.py",
+    "runtime_spine_r1.py",
+    "runtime_runner_r1_merged.py",
+    "sea_trials_set_one_r1_merged.py",
+    "capability_registry_r1.json",
+]
+
+
+def main() -> Dict[str, Any]:
+    runner = OrientationAwareRuntimeRunner(
+        base_dir=BASE_DIR,
+        registry_path=infer_runtime_root() / "capability_registry_r1.json",
+    )
+    result = runner.run_cycle(
+        current_mode="Continuity",
+        target_mode="Observation",
+        requested_action="trial_project_orientation_vector",
+        action_type="audit",
+        ethereonic_overlay=ETHEREONIC_OVERLAY,
+        project_orientation_vector=PROJECT_ORIENTATION_VECTOR,
+        enabled_feature_flags=["ETHEREON_OBSERVATION", "ETHEREON_PSI42"],
+        runtime_config=SAFE_RUNTIME_CONFIG,
+        artifacts=ARTIFACTS,
+        continuation_notes=["orientation check active"],
+    )
+
+    bundle = runner.read_context_bundle(result.context_bundle_id)
+    supplemental = bundle.get("supplemental_ethereonic_context", {})
+    artifact_context = bundle.get("artifact_context", {})
+    memory_context = bundle.get("memory_context", {})
+
+    project_orientation = supplemental.get("project_orientation_vector", {})
+    ordered_artifacts = artifact_context.get("active_design_docs", [])
+    continuation_notes = memory_context.get("session_continuation_notes", [])
+
+    checks = {
+        "orientation_attached": isinstance(project_orientation, dict) and bool(project_orientation),
+        "orientation_focus_matches": project_orientation.get("focus") == "architecture",
+        "orientation_authority_matches": project_orientation.get("authority") == "supplemental_ethereonic_context only — read-only from governance perspective",
+        "artifact_ordering_changed": ordered_artifacts[:2] == ["runtime_spine_r1.py", "capability_registry_r1.json"],
+        "resume_note_present": any("Orientation at last checkpoint:" in note for note in continuation_notes),
+        "governance_does_not_own_orientation": "project_orientation_vector" not in result.governance,
+    }
+
+    summary = {
+        "suite": "Sea Trials Orientation r1",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "context_bundle_id": result.context_bundle_id,
+        "ordered_artifacts": ordered_artifacts,
+        "continuation_notes": continuation_notes,
+        "project_orientation_vector": project_orientation,
+        "governance_log_path": result.governance_log_path,
+        "checkpoint_path": result.checkpoint_path,
+    }
+
+    summary_path = BASE_DIR / "sea_trials_orientation_r1_report.json"
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+    return {"summary_path": str(summary_path), "summary": summary}
+
+
+if __name__ == "__main__":
+    output = main()
+    print(json.dumps(output, indent=2))


### PR DESCRIPTION
Adds the first ProjectOrientationVector integration pass to Lumina bootstrap.

Changes in this branch:
- integrate ProjectOrientationVector support into runtime_spine_r1.py
- add runtime_runner_orientation_adapter_r1.py
- add sea_trials_orientation_r1.py

Purpose:
- keep mode as law
- treat orientation as supplemental stance only
- attach orientation through supplemental_ethereonic_context
- allow orientation to reprioritize surfacing and improve resume notes
- keep orientation out of legality, mutation, promotion, canon lineage, and checkpoint authority
