### PR TITLE
Remove numbered labels from the build page

### DIFF
--- a/build.html
+++ b/build.html
@@ -37,10 +37,10 @@
       </section>
       <section class="section">
         <div class="container grid-2">
-          <article class="timeline" data-glow><small>01</small><h3>Adaptive workspaces</h3><p>Return to a project and recover the layout, notes, references, and likely tools together instead of rebuilding them by hand.</p></article>
-          <article class="timeline" data-glow><small>02</small><h3>Embedded guidance</h3><p>Bring assistance into the interface itself through hover states, previews, and contextual nudges rather than a detached assistant box.</p></article>
-          <article class="timeline" data-glow><small>03</small><h3>Personalized skins</h3><p>Let users alter the visual environment through direct settings and, later, image based skin generation that keeps usability intact.</p></article>
-          <article class="timeline" data-glow><small>04</small><h3>Plastic interface behavior</h3><p>Allow tools, panels, and layout priorities to shift based on habit, preference, and explicit choice without turning into chaos.</p></article>
+          <article class="timeline" data-glow><h3>Adaptive workspaces</h3><p>Return to a project and recover the layout, notes, references, and likely tools together instead of rebuilding them by hand.</p></article>
+          <article class="timeline" data-glow><h3>Embedded guidance</h3><p>Bring assistance into the interface itself through hover states, previews, and contextual nudges rather than a detached assistant box.</p></article>
+          <article class="timeline" data-glow><h3>Personalized skins</h3><p>Let users alter the visual environment through direct settings and, later, image based skin generation that keeps usability intact.</p></article>
+          <article class="timeline" data-glow><h3>Plastic interface behavior</h3><p>Allow tools, panels, and layout priorities to shift based on habit, preference, and explicit choice without turning into chaos.</p></article>
         </div>
       </section>
       <section class="section">


### PR DESCRIPTION
## Summary
- remove the `01–04` numbering from the build page cards
- keep the page structure, copy, and layout otherwise unchanged
- make the build page read more cleanly, especially on mobile

## Changes
- `build.html`
  - removes the numeric `<small>` labels from the four timeline cards
  - leaves the headings and body copy intact

## Intent
This is a small cleanup to match the simpler presentation direction used on the whitepaper page. The cards already communicate clearly through their headings, so the numbering was unnecessary visual clutter.