### PR TITLE
Add canonical and social metadata to core pages

### DIFF
--- a/build.html
+++ b/build.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - What We Are Building</title>
   <meta name="description" content="What EthereonLabs is building now: adaptive workspaces, embedded guidance, personalized skins, and continuity based design." />
+  <link rel="canonical" href="https://ethereonlabs.com/build" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - What We Are Building" />
+  <meta property="og:description" content="What EthereonLabs is building now: adaptive workspaces, embedded guidance, personalized skins, and continuity based design." />
+  <meta property="og:url" content="https://ethereonlabs.com/build" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - What We Are Building" />
+  <meta name="twitter:description" content="What EthereonLabs is building now: adaptive workspaces, embedded guidance, personalized skins, and continuity based design." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/continuity.html
+++ b/continuity.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Continuity</title>
   <meta name="description" content="A grounded explanation of continuity as the practical core of the EthereonLabs direction." />
+  <link rel="canonical" href="https://ethereonlabs.com/continuity" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Continuity" />
+  <meta property="og:description" content="A grounded explanation of continuity as the practical core of the EthereonLabs direction." />
+  <meta property="og:url" content="https://ethereonlabs.com/continuity" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Continuity" />
+  <meta name="twitter:description" content="A grounded explanation of continuity as the practical core of the EthereonLabs direction." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/index.html
+++ b/index.html
@@ -5,6 +5,32 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Adaptive digital environments</title>
   <meta name="description" content="EthereonLabs is building practical prototypes for AI guided workspaces, adaptive interfaces, and personalized digital environments." />
+  <link rel="canonical" href="https://ethereonlabs.com/" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Adaptive digital environments" />
+  <meta property="og:description" content="EthereonLabs is building practical prototypes for AI guided workspaces, adaptive interfaces, and personalized digital environments." />
+  <meta property="og:url" content="https://ethereonlabs.com/" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Adaptive digital environments" />
+  <meta name="twitter:description" content="EthereonLabs is building practical prototypes for AI guided workspaces, adaptive interfaces, and personalized digital environments." />
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "name": "EthereonLabs",
+          "url": "https://ethereonlabs.com/"
+        },
+        {
+          "@type": "Organization",
+          "name": "EthereonLabs",
+          "url": "https://ethereonlabs.com/"
+        }
+      ]
+    }
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/lumina.html
+++ b/lumina.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Lumina environment</title>
   <meta name="description" content="A fuller explanation of Lumina as the broader environment beneath the EthereonLabs continuity and adaptive interface work." />
+  <link rel="canonical" href="https://ethereonlabs.com/lumina" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Lumina environment" />
+  <meta property="og:description" content="A fuller explanation of Lumina as the broader environment beneath the EthereonLabs continuity and adaptive interface work." />
+  <meta property="og:url" content="https://ethereonlabs.com/lumina" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Lumina environment" />
+  <meta name="twitter:description" content="A fuller explanation of Lumina as the broader environment beneath the EthereonLabs continuity and adaptive interface work." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/rse-whitepaper.html
+++ b/rse-whitepaper.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Referential Spiral Equation White Paper</title>
   <meta name="description" content="Web edition of the Referential Spiral Equation white paper." />
+  <link rel="canonical" href="https://ethereonlabs.com/rse-whitepaper" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Referential Spiral Equation White Paper" />
+  <meta property="og:description" content="Web edition of the Referential Spiral Equation white paper." />
+  <meta property="og:url" content="https://ethereonlabs.com/rse-whitepaper" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Referential Spiral Equation White Paper" />
+  <meta name="twitter:description" content="Web edition of the Referential Spiral Equation white paper." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/rse.html
+++ b/rse.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Recursive Spiral Equation</title>
   <meta name="description" content="A grounded explanation of the Recursive Spiral Equation as a conceptual framework within EthereonLabs." />
+  <link rel="canonical" href="https://ethereonlabs.com/rse" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Recursive Spiral Equation" />
+  <meta property="og:description" content="A grounded explanation of the Recursive Spiral Equation as a conceptual framework within EthereonLabs." />
+  <meta property="og:url" content="https://ethereonlabs.com/rse" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Recursive Spiral Equation" />
+  <meta name="twitter:description" content="A grounded explanation of the Recursive Spiral Equation as a conceptual framework within EthereonLabs." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- add canonical tags and social preview metadata to the site's core public pages
- build this cleanly on top of current `main`, after `robots.txt` and `sitemap.xml` were already merged
- avoid the stale branch conflict from PR #28 by recutting the metadata changes onto current main

## Changes
- `index.html`
- `build.html`
- `lumina.html`
- `continuity.html`
- `rse.html`
- `rse-whitepaper.html`

## What this adds
- canonical URLs for the core pages
- Open Graph title, description, URL, and site name metadata
- Twitter card title and description metadata
- basic `WebSite` and `Organization` JSON-LD on the homepage

## Why this PR exists
PR #28 became stale and conflicted after `main` moved. This PR carries the same page-metadata intent, but is rebased cleanly on the current state of the site so it should be straightforward to merge.