### PR TITLE
Add canonical and social metadata to secondary pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - About</title>
   <meta name="description" content="About EthereonLabs, a creative research and development effort exploring adaptive digital environments." />
+  <link rel="canonical" href="https://ethereonlabs.com/about" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - About" />
+  <meta property="og:description" content="About EthereonLabs, a creative research and development effort exploring adaptive digital environments." />
+  <meta property="og:url" content="https://ethereonlabs.com/about" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - About" />
+  <meta name="twitter:description" content="About EthereonLabs, a creative research and development effort exploring adaptive digital environments." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Contact</title>
   <meta name="description" content="Contact EthereonLabs and express early interest as the adaptive environment prototype direction moves forward." />
+  <link rel="canonical" href="https://ethereonlabs.com/contact" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Contact" />
+  <meta property="og:description" content="Contact EthereonLabs and express early interest as the adaptive environment prototype direction moves forward." />
+  <meta property="og:url" content="https://ethereonlabs.com/contact" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Contact" />
+  <meta name="twitter:description" content="Contact EthereonLabs and express early interest as the adaptive environment prototype direction moves forward." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/explore.html
+++ b/explore.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Explore</title>
   <meta name="description" content="A guide to the live EthereonLabs pages and what each one is for." />
+  <link rel="canonical" href="https://ethereonlabs.com/explore" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Explore" />
+  <meta property="og:description" content="A guide to the live EthereonLabs pages and what each one is for." />
+  <meta property="og:url" content="https://ethereonlabs.com/explore" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Explore" />
+  <meta name="twitter:description" content="A guide to the live EthereonLabs pages and what each one is for." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/lexicon.html
+++ b/lexicon.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Lexicon</title>
   <meta name="description" content="A public lexicon of working analogies and conceptual shortcuts used throughout EthereonLabs." />
+  <link rel="canonical" href="https://ethereonlabs.com/lexicon" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Lexicon" />
+  <meta property="og:description" content="A public lexicon of working analogies and conceptual shortcuts used throughout EthereonLabs." />
+  <meta property="og:url" content="https://ethereonlabs.com/lexicon" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Lexicon" />
+  <meta name="twitter:description" content="A public lexicon of working analogies and conceptual shortcuts used throughout EthereonLabs." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/principles.html
+++ b/principles.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Principles</title>
   <meta name="description" content="Core design principles guiding the EthereonLabs adaptive environment direction." />
+  <link rel="canonical" href="https://ethereonlabs.com/principles" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Principles" />
+  <meta property="og:description" content="Core design principles guiding the EthereonLabs adaptive environment direction." />
+  <meta property="og:url" content="https://ethereonlabs.com/principles" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Principles" />
+  <meta name="twitter:description" content="Core design principles guiding the EthereonLabs adaptive environment direction." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/roadmap.html
+++ b/roadmap.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Roadmap</title>
   <meta name="description" content="A grounded roadmap for the EthereonLabs adaptive environment direction." />
+  <link rel="canonical" href="https://ethereonlabs.com/roadmap" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Roadmap" />
+  <meta property="og:description" content="A grounded roadmap for the EthereonLabs adaptive environment direction." />
+  <meta property="og:url" content="https://ethereonlabs.com/roadmap" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Roadmap" />
+  <meta name="twitter:description" content="A grounded roadmap for the EthereonLabs adaptive environment direction." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/specimen.html
+++ b/specimen.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Interface specimen</title>
   <meta name="description" content="A first public interface specimen for the EthereonLabs adaptive environment direction." />
+  <link rel="canonical" href="https://ethereonlabs.com/specimen" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Interface specimen" />
+  <meta property="og:description" content="A first public interface specimen for the EthereonLabs adaptive environment direction." />
+  <meta property="og:url" content="https://ethereonlabs.com/specimen" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Interface specimen" />
+  <meta name="twitter:description" content="A first public interface specimen for the EthereonLabs adaptive environment direction." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/updates.html
+++ b/updates.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Updates</title>
   <meta name="description" content="Project updates for the EthereonLabs website reset and adaptive environment prototype direction." />
+  <link rel="canonical" href="https://ethereonlabs.com/updates" />
+  <meta property="og:site_name" content="EthereonLabs" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="EthereonLabs - Updates" />
+  <meta property="og:description" content="Project updates for the EthereonLabs website reset and adaptive environment prototype direction." />
+  <meta property="og:url" content="https://ethereonlabs.com/updates" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Updates" />
+  <meta name="twitter:description" content="Project updates for the EthereonLabs website reset and adaptive environment prototype direction." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- extend the first SEO groundwork pass to the site's secondary public pages
- add canonical tags and share-preview metadata to the remaining public-facing pages that were not covered in PR #28
- keep all visible layout and copy unchanged

## Changes
- updated pages
  - `about.html`
  - `updates.html`
  - `explore.html`
  - `contact.html`
  - `specimen.html`
  - `roadmap.html`
  - `principles.html`
  - `lexicon.html`

## What this adds
- canonical URLs for each of the secondary pages
- Open Graph title, description, URL, and site name metadata
- Twitter card title and description metadata

## Intent
This completes the same metadata treatment already applied to the core entry pages, so the broader public site has more consistent crawl signals and cleaner link-preview behavior across both main and secondary destinations.