### PR TITLE
Add Chamber v1 product spec and phased build plan

### DIFF
--- a/docs/chamber_v1_build_plan.md
+++ b/docs/chamber_v1_build_plan.md
@@ -1,0 +1,242 @@
+# Chamber v1 Phased Build Plan
+
+## Purpose
+This document turns the Chamber v1 concept into an execution path that can move from static-site direction to first public multi-presence room.
+
+## Guiding constraint
+Build the smallest real thing that can become socially alive.
+Do not overbuild the first release.
+
+## Current situation
+The EthereonLabs website is currently a static public shell with shared pages, shared styling, and shared client-side JavaScript.
+The chamber therefore needs an app layer rather than more static copy alone.
+
+## Phase 0 — Decisions and naming
+### Goal
+Freeze the minimum first-release shape before code expands.
+
+### Required decisions
+- confirm the page / product name
+  - Chamber
+  - Lumina Chamber
+  - Enter Lumina
+  - Harmonic Chamber
+- confirm whether **Harmonic Intelligence** is the public-facing experience term
+- confirm first-launch room count
+  - recommended: 1 public room
+- confirm AI instance cap per user
+  - recommended: 3
+- confirm first model provider
+- confirm light auth method
+  - recommended: magic link or email/password
+
+### Deliverables
+- approved terminology
+- approved v1 scope
+- approved UI zones
+- approved role list
+
+## Phase 1 — App foundation
+### Goal
+Create the minimum application layer required for real interaction.
+
+### Tasks
+- choose app stack that can coexist with the site
+- add backend hosting path
+- add database
+- add auth system
+- add environment configuration for secrets and provider keys
+- add basic analytics and error logging
+
+### Deliverables
+- app scaffold running
+- auth working
+- database connected
+- deployable preview environment
+
+## Phase 2 — Light accounts
+### Goal
+Give each human a persistent identity in the chamber.
+
+### Tasks
+- build signup flow
+- build sign-in flow
+- create display name / chamber handle
+- add sign-out
+- persist session state
+- add minimal account settings
+
+### Deliverables
+- user account creation
+- returning login
+- persistent display identity
+
+## Phase 3 — Chamber UI shell
+### Goal
+Create the BBS-style chamber frame.
+
+### Tasks
+- build chamber page route
+- build top bar
+- build participant / instance rail
+- build central thread area
+- build synthesis / status panel
+- build composer area
+- style the chamber so it feels like a room, not a generic chat app
+
+### Deliverables
+- usable chamber page
+- responsive chamber layout
+- BBS-style visual language
+
+## Phase 4 — Room and thread persistence
+### Goal
+Store real room interaction.
+
+### Tasks
+- create room entity
+- create message entity
+- store human posts
+- load thread history
+- attach timestamps and authorship
+- support one public launch room
+
+### Deliverables
+- one persistent public room
+- thread storage and retrieval
+
+## Phase 5 — AI instance attachment
+### Goal
+Allow each human to bring a small governed council into the room.
+
+### Tasks
+- define AI instance schema
+- define instance roles
+- allow attach / detach of instances
+- enforce per-user AI cap
+- support default roster persistence
+
+### Recommended default roles
+- Primary
+- Critic
+- Synthesizer
+
+### Deliverables
+- attached AI roster per user
+- visible role labels
+- instance cap enforcement
+
+## Phase 6 — Orchestration engine
+### Goal
+Make the chamber actually feel like governed plurality.
+
+### Tasks
+- build per-role prompt templates
+- build response-order logic
+- build per-post orchestration flow
+- generate synthesis after AI replies
+- store AI replies and synthesis to the thread
+
+### Default round flow
+1. human posts
+2. attached instances resolve
+3. Primary responds
+4. Critic responds
+5. Synthesizer responds
+6. synthesis block is stored
+
+### Deliverables
+- real AI reply rounds
+- visible distinct voices by role
+- synthesis after each round
+
+## Phase 7 — Free-use guardrails
+### Goal
+Keep the chamber free without letting it melt down.
+
+### Tasks
+- add rate limiting
+- add daily message cap
+- add per-user / per-room cooldowns if needed
+- add moderation filter layer
+- add admin controls for mute / block / remove / disable
+- add usage and cost tracking
+
+### Deliverables
+- capped free public use
+- moderation controls
+- operational visibility into abuse and spend
+
+## Phase 8 — Site integration
+### Goal
+Make the chamber feel native to EthereonLabs rather than bolted on.
+
+### Tasks
+- add chamber entry point to site navigation or hero path
+- add public explanation page if needed
+- update contact / early-interest language if relevant
+- frame the chamber as the public social threshold-space of Lumina
+
+### Deliverables
+- integrated public entry path
+- coherent public-facing wording
+
+## Phase 9 — Soft launch
+### Goal
+Test with real people before broad exposure.
+
+### Tasks
+- invite a small first wave
+- observe posting behavior
+- tune role prompts
+- tune caps and moderation
+- watch cost and latency
+- refine chamber language and onboarding
+
+### Deliverables
+- stable first-wave usage
+- revised role tuning
+- launch-readiness assessment
+
+## Recommended MVP stack behavior
+### For the first public launch
+- one public room
+- light accounts
+- up to 3 AI instances per user
+- one backend model provider
+- role-based orchestration
+- synthesis enabled
+- free access with limits
+
+This is the fastest believable path to a real chamber.
+
+## What not to do too early
+Do not start with:
+- multiple public rooms
+- private rooms
+- provider-diverse multibot routing
+- social graph mechanics
+- deep profile systems
+- full Lumina OS claims on the website
+- unlimited free use
+
+## Practical order of implementation
+1. freeze product terms and scope
+2. choose stack
+3. scaffold app layer
+4. build light auth
+5. build one room and thread persistence
+6. build AI instance attachment
+7. build orchestration and synthesis
+8. add caps and moderation
+9. integrate with site shell
+10. soft launch to a small group
+
+## Suggested immediate next coding move
+After this planning PR, the next implementation PR should focus on:
+- app scaffold
+- light auth
+- chamber route shell
+- one-room persistence model
+
+That keeps momentum high while still starting from real infrastructure.

--- a/docs/chamber_v1_product_spec.md
+++ b/docs/chamber_v1_product_spec.md
@@ -1,0 +1,219 @@
+# Chamber v1 Product Spec
+
+## Status
+Draft specification for first public build.
+
+## Intent
+Chamber v1 is the first social, public-facing specimen of Lumina on the EthereonLabs website.
+It is not the full Lumina host environment.
+It is the first believable social threshold-space shaped by Lumina principles.
+
+The goal is to make the website perform the project rather than merely describe it.
+
+## Core idea
+A human enters a public chamber, posts into a shared room, and may attach a small number of governed AI instances to participate in the conversation.
+
+The chamber should feel:
+- retro
+- social
+- alive
+- governed
+- legible
+- collaborative
+
+The chamber should not feel like:
+- a generic chatbot widget
+- a chaotic anonymous forum
+- a full operating system simulation
+- an overbuilt enterprise app
+
+## First-release scope
+Chamber v1 includes:
+- light account creation
+- one public chamber room at launch
+- one persistent human identity per account
+- up to 3 attached AI instances per human
+- one backend model provider initially
+- role-based AI orchestration
+- visible synthesis after a round of AI responses
+- a BBS-style interface frame
+- basic moderation and usage limits
+
+Chamber v1 does not initially include:
+- private rooms
+- direct messages
+- user-uploaded files
+- bring-your-own-model keys
+- provider-diverse multibot routing
+- advanced profile pages
+- social graph mechanics such as follows or likes
+- full Lumina OS runtime execution inside the website
+
+## Product framing
+### Structural frame
+- **Lumina** is the governed host direction.
+- **Chamber** is the public social threshold-space.
+- **Harmonic Intelligence** may be used as the public-facing term for structured human-plus-AI plurality inside the chamber.
+
+### Boundary reminder
+Public language may describe the chamber as social and multi-intelligence.
+Engineering implementation must still keep expressive framing distinct from structural enforcement.
+
+## Primary experience
+A user should be able to:
+1. create a light account
+2. enter the chamber
+3. choose a display name / chamber handle
+4. post a message into the public room
+5. attach 0 to 3 AI instances
+6. see each attached AI respond in a governed sequence
+7. see a synthesis block after the AI round
+8. return later and still find their identity and preferred AI configuration
+
+## Chamber interface
+The visual direction should be a BBS-style chamber, not a plain chat stream.
+
+### Layout zones
+1. **Top bar**
+   - chamber name
+   - room name
+   - account status
+   - chamber state / mode
+2. **Left or right participant rail**
+   - active humans
+   - attached AI instances
+   - roles for each AI instance
+3. **Central thread**
+   - human posts
+   - AI responses
+   - timestamps
+   - clear separation of voice and role
+4. **Synthesis / chamber status panel**
+   - current synthesis
+   - room pulse / status language
+   - usage hints or limits
+5. **Composer area**
+   - post input
+   - attach / detach AI instances
+   - submit controls
+
+## AI instance model
+### Initial instance cap
+Each human may attach up to 3 AI instances.
+
+### Initial default roles
+Recommended default roles:
+- **Primary** — main relational intelligence / first response
+- **Critic** — challenge, sharpen, test
+- **Synthesizer** — gather signal and state the next move
+
+Optional future roles:
+- Historian
+- Wildcard
+- Builder
+- Researcher
+
+### First-response order
+Recommended default sequence:
+1. Primary
+2. Critic
+3. Synthesizer
+
+This preserves clarity and reduces room noise.
+
+## Orchestration rules
+### Default rule
+Collective mode should behave like a council, not a swarm.
+
+### Round behavior
+For each qualifying human post:
+1. human post is stored
+2. attached AI instances are resolved
+3. role-bound prompts are constructed
+4. AI responses are generated in order
+5. synthesis is generated
+6. results are stored to the thread
+
+### Non-goals
+The chamber should not present AI plurality as hidden governance authority.
+Role orchestration is a product behavior, not a claim that the AIs govern the system.
+
+## Accounts
+### Light account creation
+Preferred first path:
+- email + password or magic link
+- display name / chamber handle
+- minimal account settings
+
+### Required user fields
+- user id
+- email
+- display name
+- created at
+- auth state
+- preferred default AI roster
+
+## Data model
+Initial entities:
+- users
+- rooms
+- room_memberships
+- messages
+- ai_instances
+- user_attached_instances
+- synthesis_entries
+- usage_events
+- moderation_events
+
+## Moderation and limits
+Required for a free first release:
+- rate limiting per user
+- daily message cap
+- per-room cooldown if necessary
+- content filtering / moderation pass
+- admin ability to mute, block, or disable
+
+## Technical posture
+### Phase-one stack goal
+Build the smallest real app layer that can sit alongside the current public site.
+
+The implementation should preserve the current site as the public shell while adding an interactive chamber route or sub-app.
+
+### Initial multibot strategy
+The first believable version should use one backend model provider and multiple governed AI roles.
+That gives the user the real experience of plurality without requiring immediate provider-diverse multibot infrastructure.
+
+## Free-use posture
+The chamber should launch free to use.
+
+Rationale:
+- social energy matters more than early monetization
+- a room needs people before it needs pricing
+- the chamber needs cultural legibility and shareability first
+
+Future monetization, if needed, can emerge around:
+- higher AI instance caps
+- private chambers
+- saved councils
+- deeper persistence
+- advanced customization
+- provider-diverse routing
+
+## Success criteria for Chamber v1
+Chamber v1 is successful if:
+- a user can sign up quickly
+- a user can enter the public room without confusion
+- the chamber feels socially alive
+- attached AI instances feel distinct and role-bound
+- synthesis improves readability rather than adding noise
+- the room remains governable under free public use
+- the chamber feels like a threshold-space into Lumina
+
+## Failure modes to watch
+- generic chatbot feel
+- anonymous chaos
+- multibot confusion without visible role clarity
+- runaway cost from free use
+- moderation weakness
+- UI clutter that destroys the chamber atmosphere
+- overclaiming the architecture before the build supports it


### PR DESCRIPTION
## Summary
- add a Chamber v1 product specification for the first public social specimen of Lumina
- add a phased build plan that takes the current static site toward a real chamber app layer
- define the first-release scope around light accounts, one public room, up to 3 attached AI instances per user, role-based orchestration, and synthesis

## What this adds
- `docs/chamber_v1_product_spec.md`
- `docs/chamber_v1_build_plan.md`

## Intent
This PR turns the chamber concept into an actionable build track.
It keeps the scope disciplined around the first believable public release rather than pretending the full Lumina host already exists on the site.

## Notes
- recommends light account creation over anonymous drop-in
- recommends a BBS-style chamber frame rather than a generic chat stream
- recommends a free first release with usage limits and moderation guardrails
- treats `Harmonic Intelligence` as potential public-facing experience language rather than hidden engineering law