### PR TITLE
Add Chamber app foundation contracts and shared room schema

### DIFF
--- a/chamber_data_model_r1.sql
+++ b/chamber_data_model_r1.sql
@@ -1,0 +1,117 @@
+-- Chamber shared room data model r1
+-- Purpose: provide the first real backend schema for account-backed chamber use.
+
+create table if not exists chamber_users (
+  user_id uuid primary key,
+  email text not null unique,
+  display_name text not null,
+  chamber_handle text not null unique,
+  account_status text not null default 'active',
+  created_at timestamptz not null default now(),
+  last_seen_at timestamptz,
+  preferred_model_provider text,
+  preferred_mode text default 'council'
+);
+
+create table if not exists chamber_rooms (
+  room_id uuid primary key,
+  room_slug text not null unique,
+  room_title text not null,
+  room_status text not null default 'active',
+  visibility text not null default 'public',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists chamber_room_memberships (
+  membership_id uuid primary key,
+  room_id uuid not null references chamber_rooms(room_id) on delete cascade,
+  user_id uuid not null references chamber_users(user_id) on delete cascade,
+  role_in_room text not null default 'member',
+  joined_at timestamptz not null default now(),
+  last_read_at timestamptz,
+  unique (room_id, user_id)
+);
+
+create table if not exists chamber_ai_instances (
+  instance_id text primary key,
+  role_name text not null unique,
+  display_title text not null,
+  role_order integer not null,
+  default_enabled boolean not null default false,
+  description text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists chamber_user_attached_instances (
+  attachment_id uuid primary key,
+  user_id uuid not null references chamber_users(user_id) on delete cascade,
+  instance_id text not null references chamber_ai_instances(instance_id) on delete cascade,
+  is_active boolean not null default true,
+  attached_at timestamptz not null default now(),
+  unique (user_id, instance_id)
+);
+
+create table if not exists chamber_messages (
+  message_id uuid primary key,
+  room_id uuid not null references chamber_rooms(room_id) on delete cascade,
+  user_id uuid references chamber_users(user_id) on delete set null,
+  author_type text not null,
+  author_label text not null,
+  role_name text,
+  round_id uuid,
+  body text not null,
+  message_status text not null default 'posted',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists chamber_synthesis_entries (
+  synthesis_id uuid primary key,
+  room_id uuid not null references chamber_rooms(room_id) on delete cascade,
+  round_id uuid not null,
+  source_message_id uuid references chamber_messages(message_id) on delete set null,
+  body text not null,
+  created_at timestamptz not null default now(),
+  unique (room_id, round_id)
+);
+
+create table if not exists chamber_usage_events (
+  usage_event_id uuid primary key,
+  user_id uuid references chamber_users(user_id) on delete set null,
+  room_id uuid references chamber_rooms(room_id) on delete set null,
+  event_type text not null,
+  event_value integer,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists chamber_moderation_events (
+  moderation_event_id uuid primary key,
+  target_type text not null,
+  target_id text not null,
+  action_type text not null,
+  reason text,
+  actor_user_id uuid references chamber_users(user_id) on delete set null,
+  created_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_chamber_messages_room_created
+  on chamber_messages (room_id, created_at);
+
+create index if not exists idx_chamber_messages_round
+  on chamber_messages (room_id, round_id);
+
+create index if not exists idx_chamber_usage_user_created
+  on chamber_usage_events (user_id, created_at);
+
+insert into chamber_ai_instances (instance_id, role_name, display_title, role_order, default_enabled, description)
+values
+  ('primary', 'primary', 'Primary', 1, true, 'First relational response.'),
+  ('critic', 'critic', 'Critic', 2, true, 'Pressure-tests and sharpens the signal.'),
+  ('synthesizer', 'synthesizer', 'Synthesizer', 3, true, 'Gathers the round into coherent convergence.')
+on conflict (instance_id) do nothing;
+
+insert into chamber_rooms (room_id, room_slug, room_title, room_status, visibility)
+values
+  ('00000000-0000-0000-0000-000000000001', 'public-room-one', 'Lumina Chamber / Public Room One', 'active', 'public')
+on conflict (room_slug) do nothing;

--- a/docs/chamber_app_foundation_contract_r1.md
+++ b/docs/chamber_app_foundation_contract_r1.md
@@ -1,0 +1,162 @@
+# Chamber App Foundation Contract r1
+
+## Purpose
+This document defines the first real application layer that should sit behind the public Chamber shell.
+
+It exists to bridge the current static-site specimen into a shared, account-backed, room-backed chamber.
+
+## Current truth
+The public `chamber.html` page is a local specimen only.
+It demonstrates:
+- light identity behavior
+- attached AI roles
+- local thread persistence
+- sequential role responses
+- synthesis
+
+It does **not** yet provide:
+- real account authentication
+- shared room persistence
+- server-backed orchestration
+- moderation authority
+- provider-backed model execution
+
+## Foundation goals
+The first app layer must provide:
+- light account creation
+- returning sign-in
+- one shared public room
+- shared thread persistence
+- per-user attached AI roster
+- governed role orchestration
+- moderation and usage controls
+
+## Recommended first stack posture
+The current public site should remain the shell.
+The chamber should gain a minimal app layer behind a narrow API.
+
+Recommended first capabilities:
+- auth service
+- database
+- chamber API
+- orchestration service
+- usage guardrails
+
+## Light account contract
+### Required fields
+- `user_id`
+- `email`
+- `display_name`
+- `chamber_handle`
+- `created_at`
+- `last_seen_at`
+- `account_status`
+
+### Recommended auth posture
+For the first real build, choose one:
+- magic link
+- email + password
+
+Magic link is simpler and cleaner.
+Email + password is more familiar.
+Either is acceptable.
+
+## Shared room contract
+The first real release should support:
+- one public room
+- append-only thread history
+- authorship on every message
+- timestamps on every message
+- synthesis entries attached to a round
+
+### Required room fields
+- `room_id`
+- `room_slug`
+- `room_title`
+- `room_status`
+- `created_at`
+- `visibility`
+
+## Attached AI roster contract
+Each user may attach up to 3 AI instances.
+
+### Required AI roles for r1
+- `primary`
+- `critic`
+- `synthesizer`
+
+### Roster requirements
+- roster is stored per user
+- roster is loaded when the user returns
+- inactive roles remain available but detached
+- the role cap is enforced server-side, not only in the UI
+
+## Posting contract
+For each human post:
+1. authenticate the actor
+2. validate room access
+3. validate moderation and usage limits
+4. store the human post
+5. resolve attached AI roles
+6. execute role-bound responses in order
+7. store AI responses
+8. execute synthesis
+9. store synthesis
+10. return the full round payload
+
+## Usage control contract
+The chamber is intended to be free at first.
+That requires server-side guardrails.
+
+### Minimum controls
+- per-user daily post cap
+- per-user cooldown window if needed
+- room-wide rate limit hooks
+- moderation filter pass before execution
+- server-side logging for usage and failures
+
+## Moderation contract
+### Required admin actions
+- mute user
+- suspend user
+- hide message
+- disable room
+
+### Required moderation fields
+- `moderation_event_id`
+- `target_type`
+- `target_id`
+- `action_type`
+- `reason`
+- `created_at`
+- `actor_id`
+
+## Response contract
+The API should return a full round payload shaped like:
+- human post
+- ordered AI role replies
+- synthesis entry
+- updated room usage state
+
+That keeps the UI simple.
+The chamber page should not need to invent orchestration state on the client.
+
+## First implementation boundary
+This app layer is the first real backend spine for Chamber.
+It is not yet the full Lumina host.
+It should remain tightly scoped around:
+- identity
+- room state
+- role orchestration
+- synthesis
+- moderation
+- usage control
+
+## Success condition
+The foundation is successful when:
+- two different users can sign in and enter the same room
+- both can see the same thread history
+- each user can carry a stored AI roster
+- posts trigger ordered role responses
+- synthesis appears consistently
+- moderation and usage controls work under free public use

--- a/docs/chamber_orchestration_contract_r1.md
+++ b/docs/chamber_orchestration_contract_r1.md
@@ -1,0 +1,134 @@
+# Chamber Orchestration Contract r1
+
+## Purpose
+This document defines the first real orchestration behavior for Chamber once the public shell is backed by a server.
+
+The goal is not swarm chaos.
+The goal is governed plurality.
+
+## Default chamber behavior
+Collective chamber interaction should default to **council mode**.
+
+Council mode means:
+1. the human speaks
+2. the attached AI roles respond in order
+3. synthesis gathers the signal
+
+## Required r1 roles
+### Primary
+Function:
+- relational first response
+- carry the main thread with the human
+- state the most direct next movement
+
+### Critic
+Function:
+- pressure-test the direction
+- reveal weakness, drift, or overreach
+- sharpen the signal
+
+### Synthesizer
+Function:
+- gather the round
+- state the coherent convergence
+- identify the next move or live tension
+
+## Role order
+The default role order is:
+1. `primary`
+2. `critic`
+3. `synthesizer`
+
+This order should be explicit and server-controlled.
+The client should display the order, not invent it.
+
+## Round lifecycle
+For each accepted human post:
+1. store the human message
+2. load the user's attached AI roles
+3. build role-specific prompts from the room context
+4. execute `primary`
+5. execute `critic`
+6. execute `synthesizer`
+7. build a synthesis entry from the full round
+8. store the synthesis
+9. return the round payload to the UI
+
+## Context window contract
+Each role should receive:
+- the current room identity
+- the latest human message
+- a bounded recent thread window
+- the user's attached role metadata
+- role-specific instructions
+
+The role should not receive unbounded room history.
+That belongs to future persistence tuning.
+
+## Role prompt posture
+### Primary prompt posture
+- be clear
+- be relational
+- be grounded in the user's message
+- move the conversation forward
+
+### Critic prompt posture
+- identify risk or weakness
+- avoid random negativity
+- sharpen, do not derail
+
+### Synthesizer prompt posture
+- gather useful signal from the round
+- state convergence or live tension
+- propose the next coherent move
+
+## Non-goals
+r1 orchestration should not:
+- let roles interrupt each other mid-round
+- allow unbounded freeplay between AIs
+- claim governance authority for AI roles
+- allow the client to reorder role execution
+- confuse expressive variation with structural law
+
+## Synthesis contract
+The synthesis entry should:
+- summarize the round in plain language
+- identify what changed in the room
+- identify the next move or unresolved tension
+
+It should not merely repeat all three role messages.
+
+## Error contract
+If one role fails:
+- the human post still remains stored
+- successful role replies remain stored
+- the failed role is marked as failed in the round status
+- synthesis may still occur if enough signal exists
+- the failure is logged for operations review
+
+## Usage and moderation hooks
+Before orchestration starts, the chamber must check:
+- account status
+- room availability
+- usage quota
+- moderation flags
+
+If the post fails those checks, orchestration does not begin.
+
+## Future extension path
+Later phases may add:
+- additional roles
+- provider-diverse multibot routing
+- private rooms
+- user-owned councils
+- different chamber modes such as studio or swarm
+
+r1 should stay disciplined around one strong default: council mode.
+
+## Success condition
+The orchestration layer is successful when the room reliably feels:
+- ordered
+- socially alive
+- multi-voiced
+- readable
+- stable under repeated use


### PR DESCRIPTION
## Summary
- add the first backend-foundation artifacts for Chamber beyond the public shell
- define the app contract for light accounts, shared rooms, attached AI rosters, moderation, and free-use guardrails
- add a concrete SQL schema for the first shared-room backend
- define the first orchestration contract for ordered role responses and synthesis

## What this adds
- `docs/chamber_app_foundation_contract_r1.md`
- `docs/chamber_orchestration_contract_r1.md`
- `chamber_data_model_r1.sql`

## Intent
The public Chamber shell is now live on the site, but it is still a local specimen.
This PR defines the first real backend spine required to move Chamber from local demo behavior to account-backed shared room behavior.

## What this foundation covers
- light account requirements
- one shared public room as the first real backend target
- stored AI role rosters per user
- ordered council-mode orchestration
- synthesis after a round
- moderation and usage hooks for a free first release

## Notes
- keeps the first real build disciplined around one public room rather than premature multi-room sprawl
- defaults to council mode rather than swarm behavior
- treats the chamber as the first app layer behind the site shell, not yet the full Lumina host