### PR TITLE
Add Chamber production config hook and deployment notes

### DIFF
--- a/assets/js/chamber.js
+++ b/assets/js/chamber.js
@@ -1,10 +1,15 @@
 (() => {
   const STORAGE_KEYS = {
     identity: 'ethereonlabs-chamber-identity',
+    sessionToken: 'ethereonlabs-chamber-session-token',
+    apiBase: 'ethereonlabs-chamber-api-base',
     instances: 'ethereonlabs-chamber-instances',
     thread: 'ethereonlabs-chamber-thread',
     synthesis: 'ethereonlabs-chamber-synthesis'
   };
+
+  const PUBLIC_ROOM_SLUG = 'public-room-one';
+  const DEFAULT_INSTANCE_ORDER = ['primary', 'critic', 'synthesizer'];
 
   const instanceDefs = [
     {
@@ -79,9 +84,11 @@
   const pulsePill = document.getElementById('chamberPulsePill');
 
   let identity = loadIdentity();
+  let sessionToken = localStorage.getItem(STORAGE_KEYS.sessionToken) || '';
   let activeInstances = loadInstances();
   let thread = loadThread();
   let synthesis = loadSynthesis();
+  let backend = { available: false, base: '', mode: 'local specimen' };
 
   function loadIdentity() {
     const raw = localStorage.getItem(STORAGE_KEYS.identity);
@@ -124,7 +131,7 @@
   }
 
   function saveThread() {
-    localStorage.setItem(STORAGE_KEYS.thread, JSON.stringify(thread.slice(-30)));
+    localStorage.setItem(STORAGE_KEYS.thread, JSON.stringify(thread.slice(-50)));
   }
 
   function loadSynthesis() {
@@ -150,14 +157,21 @@
       .replaceAll("'", '&#039;');
   }
 
+  function canonicalRoleOrder(roles) {
+    return DEFAULT_INSTANCE_ORDER.filter((role) => roles.includes(role));
+  }
+
   function renderIdentity() {
     identityEmail.value = identity.email || '';
     identityHandle.value = identity.handle || '';
 
     if (identity.handle || identity.email) {
-      identityState.innerHTML = `<strong>${escapeHtml(identity.handle || 'Visitor')}</strong><br>${escapeHtml(identity.email || 'local chamber shell identity active')}`;
+      const mode = backend.available ? 'connected' : 'local';
+      identityState.innerHTML = `<strong>${escapeHtml(identity.handle || 'Visitor')}</strong><br>${escapeHtml(identity.email || 'local chamber shell identity active')}<br><small>${escapeHtml(mode)} mode</small>`;
     } else {
-      identityState.textContent = 'No chamber identity stored yet. Enter a handle to anchor your presence in this shell.';
+      identityState.textContent = backend.available
+        ? 'No session active yet. Enter a handle and email to join the shared room.'
+        : 'No chamber identity stored yet. Enter a handle to anchor your presence in this shell.';
     }
   }
 
@@ -178,19 +192,6 @@
       card.querySelector('button').addEventListener('click', () => toggleInstance(instance.id));
       rosterRoot.appendChild(card);
     });
-  }
-
-  function toggleInstance(instanceId) {
-    const active = activeInstances.includes(instanceId);
-    if (active) {
-      activeInstances = activeInstances.filter((item) => item !== instanceId);
-    } else {
-      if (activeInstances.length >= 3) return;
-      activeInstances = [...activeInstances, instanceId];
-    }
-    saveInstances();
-    renderRoster();
-    updatePulse();
   }
 
   function renderThread() {
@@ -217,7 +218,8 @@
     const count = activeInstances.length;
     const handle = identity.handle || 'Visitor';
     modePill.textContent = count > 1 ? 'Mode: Council' : count === 1 ? 'Mode: Focused dialogue' : 'Mode: Human-only';
-    pulsePill.textContent = `Pulse: ${handle} with ${count} attached ${count === 1 ? 'instance' : 'instances'}`;
+    const source = backend.available ? 'shared room' : 'local specimen';
+    pulsePill.textContent = `Pulse: ${handle} with ${count} attached ${count === 1 ? 'instance' : 'instances'} / ${source}`;
   }
 
   function inferTopic(message) {
@@ -266,73 +268,260 @@
     return `The round converges on the same core: make the chamber feel inhabited, governed, and returnable.`;
   }
 
-  function addEntry(entry) {
-    thread = [...thread, entry].slice(-30);
-    saveThread();
-    renderThread();
-  }
-
-  function postRound(message) {
+  function localPostRound(message) {
     const handle = identity.handle || 'Visitor';
-    addEntry({
+    const entries = [{
       id: crypto.randomUUID(),
       kind: 'human',
       author: handle,
       title: 'Human post',
       text: message,
       createdAt: new Date().toISOString()
+    }];
+
+    canonicalRoleOrder(activeInstances).forEach((instanceId) => {
+      const instance = instanceDefs.find((item) => item.id === instanceId);
+      entries.push({
+        id: crypto.randomUUID(),
+        kind: `ai-${instanceId}`,
+        author: instance.title,
+        title: `${instance.title} / chamber response`,
+        text: roleResponse(instanceId, message),
+        createdAt: new Date().toISOString()
+      });
     });
 
-    let delay = 220;
-    activeInstances.forEach((instanceId) => {
-      window.setTimeout(() => {
-        const instance = instanceDefs.find((item) => item.id === instanceId);
-        addEntry({
-          id: crypto.randomUUID(),
-          kind: `ai-${instanceId}`,
-          author: instance.title,
-          title: `${instance.title} / chamber response`,
-          text: roleResponse(instanceId, message),
-          createdAt: new Date().toISOString()
-        });
-      }, delay);
-      delay += 260;
-    });
-
-    window.setTimeout(() => {
-      synthesis = synthesisResponse(message, handle);
-      saveSynthesis();
-      renderSynthesis();
-    }, delay + 120);
+    thread = [...thread, ...entries].slice(-50);
+    synthesis = synthesisResponse(message, handle);
+    saveThread();
+    saveSynthesis();
+    renderThread();
+    renderSynthesis();
   }
 
-  identityForm.addEventListener('submit', (event) => {
+  function normalizeMessage(message) {
+    let kind = 'human';
+    let title = 'Human post';
+    if (message.authorType === 'ai' && message.roleName) {
+      kind = `ai-${message.roleName}`;
+      title = `${message.authorLabel} / chamber response`;
+    }
+    if (message.authorType === 'synthesis') {
+      kind = 'ai-synthesizer';
+      title = 'Synthesis / gathered signal';
+    }
+
+    return {
+      id: message.messageId,
+      kind,
+      author: message.authorLabel,
+      title,
+      text: message.body,
+      createdAt: message.createdAt
+    };
+  }
+
+  async function detectBackend() {
+    const candidateSet = new Set();
+    const saved = localStorage.getItem(STORAGE_KEYS.apiBase);
+    if (saved) candidateSet.add(saved);
+    if (window.CHAMBER_API_BASE) candidateSet.add(window.CHAMBER_API_BASE);
+    if (window.location.origin && window.location.origin.startsWith('http')) {
+      candidateSet.add(window.location.origin);
+    }
+    candidateSet.add('http://localhost:8787');
+
+    for (const candidate of candidateSet) {
+      const base = candidate.replace(/\/$/, '');
+      try {
+        const response = await fetch(`${base}/health`, { headers: { Accept: 'application/json' } });
+        if (!response.ok) continue;
+        const payload = await response.json();
+        if (payload?.service === 'chamber-app-scaffold' && payload?.ok) {
+          localStorage.setItem(STORAGE_KEYS.apiBase, base);
+          return { available: true, base, mode: 'shared room' };
+        }
+      } catch (_error) {
+      }
+    }
+
+    return { available: false, base: '', mode: 'local specimen' };
+  }
+
+  async function fetchJson(path, options = {}) {
+    if (!backend.available || !backend.base) {
+      throw new Error('Backend unavailable');
+    }
+
+    const response = await fetch(`${backend.base}${path}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        ...(options.headers || {})
+      },
+      ...options
+    });
+
+    const payload = await response.json().catch(() => ({ ok: false, error: 'Invalid JSON response' }));
+    if (!response.ok || payload?.ok === false) {
+      throw new Error(payload?.error || `Request failed with status ${response.status}`);
+    }
+    return payload;
+  }
+
+  async function hydrateSession() {
+    if (!backend.available || !sessionToken) return false;
+    try {
+      const payload = await fetchJson(`/api/auth/session/${sessionToken}`);
+      identity = {
+        email: payload.user.email,
+        handle: payload.user.chamberHandle
+      };
+      activeInstances = canonicalRoleOrder(payload.user.attachedRoles || DEFAULT_INSTANCE_ORDER);
+      saveIdentity();
+      saveInstances();
+      renderIdentity();
+      renderRoster();
+      updatePulse();
+      return true;
+    } catch (_error) {
+      sessionToken = '';
+      localStorage.removeItem(STORAGE_KEYS.sessionToken);
+      return false;
+    }
+  }
+
+  async function loadBackendMessages() {
+    if (!backend.available) return false;
+    try {
+      const payload = await fetchJson(`/api/rooms/${PUBLIC_ROOM_SLUG}/messages`);
+      thread = (payload.messages || []).map(normalizeMessage);
+      if (!thread.length) {
+        thread = seedThread;
+      }
+      const latestSynthesis = [...(payload.messages || [])].reverse().find((message) => message.authorType === 'synthesis');
+      synthesis = latestSynthesis?.body || defaultSynthesis;
+      saveThread();
+      saveSynthesis();
+      renderThread();
+      renderSynthesis();
+      return true;
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  async function toggleInstance(instanceId) {
+    const active = activeInstances.includes(instanceId);
+    let nextRoles;
+    if (active) {
+      nextRoles = activeInstances.filter((item) => item !== instanceId);
+    } else {
+      if (activeInstances.length >= 3) return;
+      nextRoles = canonicalRoleOrder([...activeInstances, instanceId]);
+    }
+
+    if (backend.available && sessionToken) {
+      try {
+        const payload = await fetchJson(`/api/auth/session/${sessionToken}/roles`, {
+          method: 'PATCH',
+          body: JSON.stringify({ roles: nextRoles })
+        });
+        activeInstances = canonicalRoleOrder(payload.user.attachedRoles || nextRoles);
+      } catch (_error) {
+        return;
+      }
+    } else {
+      activeInstances = nextRoles;
+    }
+
+    saveInstances();
+    renderRoster();
+    updatePulse();
+  }
+
+  identityForm.addEventListener('submit', async (event) => {
     event.preventDefault();
     identity = {
       email: identityEmail.value.trim(),
       handle: identityHandle.value.trim()
     };
+
+    if (!identity.email || !identity.handle) {
+      renderIdentity();
+      return;
+    }
+
+    if (backend.available) {
+      try {
+        const payload = await fetchJson('/api/auth/signup', {
+          method: 'POST',
+          body: JSON.stringify({
+            email: identity.email,
+            displayName: identity.handle,
+            chamberHandle: identity.handle
+          })
+        });
+        sessionToken = payload.session.sessionToken;
+        localStorage.setItem(STORAGE_KEYS.sessionToken, sessionToken);
+        activeInstances = canonicalRoleOrder(payload.user.attachedRoles || DEFAULT_INSTANCE_ORDER);
+        await loadBackendMessages();
+      } catch (error) {
+        identityState.textContent = error instanceof Error ? error.message : 'Unable to enter chamber';
+        return;
+      }
+    }
+
     saveIdentity();
+    saveInstances();
     renderIdentity();
+    renderRoster();
     updatePulse();
   });
 
   identityClear.addEventListener('click', () => {
     identity = { email: '', handle: '' };
+    sessionToken = '';
+    localStorage.removeItem(STORAGE_KEYS.sessionToken);
     saveIdentity();
     renderIdentity();
     updatePulse();
   });
 
-  composerForm.addEventListener('submit', (event) => {
+  composerForm.addEventListener('submit', async (event) => {
     event.preventDefault();
     const message = composerInput.value.trim();
     if (!message) return;
-    postRound(message);
+
+    if (backend.available) {
+      if (!sessionToken) {
+        identityState.textContent = 'Enter the chamber with email and handle before posting to the shared room.';
+        return;
+      }
+
+      try {
+        await fetchJson(`/api/rooms/${PUBLIC_ROOM_SLUG}/messages`, {
+          method: 'POST',
+          body: JSON.stringify({ sessionToken, body: message })
+        });
+        await loadBackendMessages();
+      } catch (error) {
+        identityState.textContent = error instanceof Error ? error.message : 'Unable to post to chamber';
+        return;
+      }
+    } else {
+      localPostRound(message);
+    }
+
     composerInput.value = '';
   });
 
-  resetThread.addEventListener('click', () => {
+  resetThread.addEventListener('click', async () => {
+    if (backend.available) {
+      await loadBackendMessages();
+      return;
+    }
+
     thread = seedThread;
     synthesis = defaultSynthesis;
     saveThread();
@@ -341,9 +530,22 @@
     renderSynthesis();
   });
 
-  renderIdentity();
-  renderRoster();
-  renderThread();
-  renderSynthesis();
-  updatePulse();
+  async function init() {
+    backend = await detectBackend();
+    renderIdentity();
+    renderRoster();
+    renderThread();
+    renderSynthesis();
+    updatePulse();
+
+    if (backend.available) {
+      await hydrateSession();
+      await loadBackendMessages();
+      renderIdentity();
+      renderRoster();
+      updatePulse();
+    }
+  }
+
+  init();
 })();

--- a/assets/js/chamber_config.js
+++ b/assets/js/chamber_config.js
@@ -1,0 +1,1 @@
+window.CHAMBER_API_BASE = window.CHAMBER_API_BASE || '';

--- a/chamber-app/.env.example
+++ b/chamber-app/.env.example
@@ -1,4 +1,4 @@
 PORT=8787
-CHAMBER_APP_ORIGIN=http://localhost:8787
 CHAMBER_PUBLIC_ROOM_SLUG=public-room-one
 SESSION_TTL_HOURS=168
+CHAMBER_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:8787,http://127.0.0.1:8787,https://ethereonlabs.com

--- a/chamber-app/src/server.ts
+++ b/chamber-app/src/server.ts
@@ -6,14 +6,26 @@ import { ChamberMemoryStore } from './store.js';
 import type { ChamberRole } from './types.js';
 
 const port = Number(process.env.PORT || 8787);
-const origin = process.env.CHAMBER_APP_ORIGIN || `http://localhost:${port}`;
 const publicRoomSlug = process.env.CHAMBER_PUBLIC_ROOM_SLUG || 'public-room-one';
 const sessionTtlHours = Number(process.env.SESSION_TTL_HOURS || 168);
+const allowedOrigins = (process.env.CHAMBER_ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean);
 
 const store = new ChamberMemoryStore(publicRoomSlug);
 const app = express();
 
-app.use(cors({ origin: true, credentials: true }));
+app.use(cors({
+  origin(origin, callback) {
+    if (!origin || allowedOrigins.length === 0 || allowedOrigins.includes(origin)) {
+      callback(null, true);
+      return;
+    }
+    callback(new Error('Origin not allowed by Chamber scaffold CORS policy'));
+  },
+  credentials: true
+}));
 app.use(express.json());
 
 const signUpSchema = z.object({
@@ -48,12 +60,16 @@ function getActor(sessionToken: string) {
   return actor;
 }
 
+function roomPath(suffix = ''): string {
+  return `/api/rooms/${publicRoomSlug}${suffix}`;
+}
+
 app.get('/health', (_req, res) => {
   res.json({
     ok: true,
     service: 'chamber-app-scaffold',
-    origin,
     publicRoomSlug,
+    allowedOrigins,
     health: store.health()
   });
 });
@@ -108,15 +124,15 @@ app.patch('/api/auth/session/:sessionToken/roles', (req, res) => {
   return res.json({ ok: true, user });
 });
 
-app.get('/api/rooms/public-room-one', (_req, res) => {
+app.get(roomPath(), (_req, res) => {
   res.json({ ok: true, room: store.getPublicRoom() });
 });
 
-app.get('/api/rooms/public-room-one/messages', (_req, res) => {
+app.get(roomPath('/messages'), (_req, res) => {
   res.json({ ok: true, room: store.getPublicRoom(), messages: store.getMessages() });
 });
 
-app.post('/api/rooms/public-room-one/messages', (req, res) => {
+app.post(roomPath('/messages'), (req, res) => {
   const parsed = postSchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ ok: false, error: parsed.error.flatten() });

--- a/chamber.html
+++ b/chamber.html
@@ -175,6 +175,7 @@
   </div>
 
   <script src="assets/js/site.js"></script>
+  <script src="assets/js/chamber_config.js"></script>
   <script src="assets/js/chamber.js"></script>
 </body>
 </html>

--- a/docs/chamber_deployment_notes_r1.md
+++ b/docs/chamber_deployment_notes_r1.md
@@ -1,0 +1,76 @@
+# Chamber Deployment Notes r1
+
+## Purpose
+This note defines the first clean deployment path for the Chamber shell and the Chamber app scaffold.
+
+The immediate goal is simple:
+- keep the public Chamber shell live on the site
+- point it explicitly at a real backend when one is deployed
+- avoid relying only on backend auto-detection in production
+
+## Current reality
+The public Chamber page can already:
+- run as a local specimen
+- detect a live Chamber backend when one is reachable
+- fall back gracefully when no backend is available
+
+That behavior is useful during development.
+Production should be more explicit.
+
+## Client-side config hook
+The Chamber shell now has a dedicated client config file:
+- `assets/js/chamber_config.js`
+
+It should set:
+- `window.CHAMBER_API_BASE`
+
+### Example
+```js
+window.CHAMBER_API_BASE = 'https://your-chamber-api.example.com';
+```
+
+## Why this exists
+This makes production behavior clearer.
+The shell does not have to guess the backend origin first.
+It can still keep fallback behavior, but production should prefer explicit configuration.
+
+## Chamber app scaffold deployment notes
+The backend scaffold currently runs as a small Express + TypeScript app.
+It still uses in-memory persistence.
+
+That means it is suitable for:
+- local development
+- integration testing
+- first deployment wiring
+
+It is not yet durable production storage.
+
+## Minimum environment for the backend
+- `PORT`
+- `CHAMBER_PUBLIC_ROOM_SLUG`
+- `SESSION_TTL_HOURS`
+- `CHAMBER_ALLOWED_ORIGINS`
+
+### Example allowed origins
+- local dev shell origin
+- local backend origin
+- `https://ethereonlabs.com`
+
+## Recommended immediate deployment sequence
+1. deploy the Chamber app scaffold behind a stable origin
+2. set `CHAMBER_ALLOWED_ORIGINS` to include the public site
+3. set `window.CHAMBER_API_BASE` in `assets/js/chamber_config.js`
+4. verify signup, session restore, role sync, shared message load, and post-round flow
+5. only after that, swap the memory store toward SQL-backed persistence
+
+## Next durable step after deployment wiring
+The next architectural move should be:
+- replace the in-memory store with a store backed by `chamber_data_model_r1.sql`
+
+That is the real shift from integration scaffold to durable shared room.
+
+## Success condition
+This deployment pass is successful when:
+- the public Chamber page connects to the real backend without guessing
+- users can sign up and return through the shared room flow
+- the shell still degrades gracefully if the backend is temporarily unavailable


### PR DESCRIPTION
## Summary
- add a dedicated client-side config hook for the public Chamber shell
- update `chamber.html` to load that hook before the Chamber client
- add deployment notes describing how to point the public shell at a real backend explicitly

## What this adds
- `assets/js/chamber_config.js`
- `docs/chamber_deployment_notes_r1.md`
- updates `chamber.html`

## What this does
- gives the site a clean place to set `window.CHAMBER_API_BASE`
- lets the public shell prefer explicit backend configuration in production
- preserves graceful fallback behavior when no backend is configured or reachable
- documents the immediate deployment sequence for the live shell plus app scaffold

## Why this matters now
The Chamber shell and backend scaffold are already in place.
This PR makes the production path cleaner by moving from backend guesswork toward explicit configuration.

## Next likely move
After this PR, the sharpest next implementation step is swapping the in-memory Chamber store toward the SQL-backed persistence path defined in `chamber_data_model_r1.sql`.