### PR TITLE
Add Chamber local Postgres bootstrap lane

### DIFF
--- a/chamber-app/.env.postgres.example
+++ b/chamber-app/.env.postgres.example
@@ -1,0 +1,6 @@
+PORT=8787
+CHAMBER_PUBLIC_ROOM_SLUG=public-room-one
+SESSION_TTL_HOURS=168
+CHAMBER_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:8787,http://127.0.0.1:8787,https://ethereonlabs.com
+CHAMBER_STORE_MODE=postgres
+DATABASE_URL=postgres://chamber:chamber@localhost:5432/chamber

--- a/chamber-app/README.md
+++ b/chamber-app/README.md
@@ -3,7 +3,7 @@
 This directory is the first actual backend scaffold for auth and shared room persistence behind the public Chamber shell.
 
 ## Status
-Scaffold only, now with switchable persistence modes.
+Scaffold only, now with switchable persistence modes and a local Postgres bootstrap lane.
 
 It is intended to do four things now:
 - create a narrow backend lane for light account behavior
@@ -28,6 +28,7 @@ It is **not** yet a production backend.
 - switchable store factory
 - memory store
 - Postgres store scaffold
+- local Docker Compose Postgres path
 
 ## Persistence modes
 ### Memory
@@ -40,14 +41,33 @@ It is **not** yet a production backend.
 - persists users, sessions, room messages, role attachments, and synthesis-backed room history
 - is the first durable path for shared Chamber use
 
+## Local Postgres quick path
+From `chamber-app/`:
+
+```bash
+npm install
+npm run db:up
+cp .env.postgres.example .env
+npm run dev:postgres
+```
+
+Useful database helpers:
+- `npm run db:up`
+- `npm run db:down`
+- `npm run db:reset`
+- `npm run db:logs`
+
 ## Current durable path
 The durable route is:
 - apply `../chamber_data_model_r1.sql`
 - apply `../chamber_sessions_extension_r1.sql`
 - run the app with `CHAMBER_STORE_MODE=postgres`
 
+The Docker Compose lane does this automatically on first initialization.
+
 ## Environment
-Copy `.env.example` to `.env` and adjust if needed.
+Copy `.env.example` to `.env` for memory mode.
+Copy `.env.postgres.example` to `.env` for local Postgres mode.
 
 Important values:
 - `CHAMBER_STORE_MODE=memory|postgres`

--- a/chamber-app/docker-compose.postgres.yml
+++ b/chamber-app/docker-compose.postgres.yml
@@ -1,0 +1,23 @@
+services:
+  chamber-postgres:
+    image: postgres:16
+    container_name: chamber-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: chamber
+      POSTGRES_USER: chamber
+      POSTGRES_PASSWORD: chamber
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U chamber -d chamber"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - chamber_postgres_data:/var/lib/postgresql/data
+      - ../chamber_data_model_r1.sql:/docker-entrypoint-initdb.d/001_chamber_data_model.sql:ro
+      - ../chamber_sessions_extension_r1.sql:/docker-entrypoint-initdb.d/002_chamber_sessions_extension.sql:ro
+
+volumes:
+  chamber_postgres_data:

--- a/chamber-app/package.json
+++ b/chamber-app/package.json
@@ -6,9 +6,14 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/server.ts",
+    "dev:postgres": "CHAMBER_STORE_MODE=postgres tsx watch src/server.ts",
     "start": "node dist/server.js",
     "build": "tsc -p tsconfig.json",
-    "check": "tsc -p tsconfig.json --noEmit"
+    "check": "tsc -p tsconfig.json --noEmit",
+    "db:up": "docker compose -f docker-compose.postgres.yml up -d",
+    "db:down": "docker compose -f docker-compose.postgres.yml down",
+    "db:reset": "docker compose -f docker-compose.postgres.yml down -v",
+    "db:logs": "docker compose -f docker-compose.postgres.yml logs -f chamber-postgres"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/docs/chamber_local_postgres_runbook_r1.md
+++ b/docs/chamber_local_postgres_runbook_r1.md
@@ -1,0 +1,85 @@
+# Chamber Local Postgres Runbook r1
+
+## Purpose
+This runbook gives Chamber a repeatable local SQL-mode path.
+
+The immediate goal is to make it easy to:
+- start a local Postgres instance
+- let the schema initialize automatically
+- run the Chamber app in `postgres` mode
+- verify that the live shell can talk to durable shared state
+
+## Files involved
+- `chamber-app/docker-compose.postgres.yml`
+- `chamber-app/.env.postgres.example`
+- `chamber_data_model_r1.sql`
+- `chamber_sessions_extension_r1.sql`
+
+## First-time setup
+From `chamber-app/`:
+
+```bash
+docker compose -f docker-compose.postgres.yml up -d
+```
+
+This does three things:
+- starts Postgres locally
+- creates the `chamber` database
+- applies the Chamber schema and session extension on first initialization
+
+## Backend environment
+Copy the Postgres example env into place:
+
+```bash
+cp .env.postgres.example .env
+```
+
+That sets:
+- `CHAMBER_STORE_MODE=postgres`
+- `DATABASE_URL=postgres://chamber:chamber@localhost:5432/chamber`
+
+## Run the Chamber backend in SQL mode
+```bash
+npm install
+npm run dev:postgres
+```
+
+## Verify health
+```bash
+curl http://localhost:8787/health
+```
+
+The returned health payload should report:
+- `service: chamber-app-scaffold`
+- `storeMode: postgres`
+
+## Verify shell connection
+Once the backend is running:
+- open the Chamber page
+- ensure the client is configured to point at the backend
+- sign up with email + chamber handle
+- post a message
+- refresh and confirm the message history remains
+
+## Expected persistence checks
+The following should survive backend restarts when Postgres remains up:
+- users
+- sessions that are still valid
+- attached role preferences
+- room history
+- synthesis-backed rounds
+
+## Stop the local database
+```bash
+docker compose -f docker-compose.postgres.yml down
+```
+
+## Reset the local database volume completely
+```bash
+docker compose -f docker-compose.postgres.yml down -v
+```
+
+That removes the stored Chamber Postgres volume and causes the init SQL files to run again on next startup.
+
+## Why this matters
+This is the first local path where Chamber becomes durably shared rather than merely lively for one process lifetime.


### PR DESCRIPTION
## Summary
- add a local Docker Compose Postgres path for Chamber
- add a Postgres-mode environment example for the Chamber app
- add a local runbook for bringing Chamber up in SQL mode
- add developer scripts and README updates so the SQL lane is easy to use

## What this adds
- `chamber-app/docker-compose.postgres.yml`
- `chamber-app/.env.postgres.example`
- `docs/chamber_local_postgres_runbook_r1.md`

## What this updates
- `chamber-app/package.json`
- `chamber-app/README.md`

## What this does
- starts a local Postgres instance with Chamber schema initialization mounted automatically
- gives the app a clear `.env` example for Postgres mode
- adds package scripts for database up/down/reset/logs and Postgres dev mode
- documents the exact local sequence for verifying Chamber durability against SQL mode

## Why this matters now
The Chamber shell is live, the backend scaffold exists, the shell can talk to it, and the dual-store runtime now provides a real SQL-backed path.
This PR makes that path runnable locally without improvisation.

## Next likely move
After this PR, the sharpest next step is to run the Chamber stack end-to-end in Postgres mode and then patch the public site discoverability links so humans can find the room more easily.