### PR TITLE
Add repo-native project return and workspace host proofs to Lumina bootstrap

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md
@@ -1,0 +1,40 @@
+# Return With Stance — Bootstrap Note R1
+
+This note marks the next architectural move for Lumina OS inside the governed bootstrap path.
+
+## What landed
+
+Two repo-native runtime modules now live inside the bootstrap runtime directory:
+
+- `runtime/project_return_repo_native_r1.py`
+- `runtime/workspace_host_repo_native_r1.py`
+
+## Why this matters
+
+The bootstrap already held runtime law, governance, canon lineage, and bounded context.
+
+What it did not yet hold inside the same path was the narrower pair of behaviors that make Lumina feel more like a host substrate than a static idea:
+
+1. a project can be left and resumed without guessing
+2. a project can return with a bounded working surface around it
+
+These new modules are the first repo-native proofs for those behaviors.
+
+## What they are not
+
+This is not yet a deep merge into `runtime_spine_r1.py` or `runtime_runner_r1_merged.py`.
+
+That deeper merge should come later, once the project-return and workspace-host payloads have been pressure-tested enough to justify becoming direct runtime law.
+
+## Current role
+
+For now, these modules do four useful things:
+
+- move continuity return into the bootstrap path
+- move workspace-host restoration into the bootstrap path
+- keep state repo-native through `repo_paths_r1.py`
+- define a cleaner bridge between continuity and host behavior
+
+## Next likely move
+
+When ready, the next hardening step is to absorb the project-return and workspace-host fields into the main session / runner flow so Lumina can restore not only legality and continuity, but active working stance as first-class runtime behavior.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/project_return_repo_native_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/project_return_repo_native_r1.py
@@ -1,0 +1,144 @@
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+import json
+import uuid
+
+try:
+    from .repo_paths_r1 import state_root as _state_root_helper
+except Exception:
+    try:
+        from repo_paths_r1 import state_root as _state_root_helper
+    except Exception:
+        _state_root_helper = None
+
+MODULE_SLUG = "project_return_repo_native_r1"
+HOST_MODULE_SLUG = "workspace_host_repo_native_r1"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def infer_state_root() -> Path:
+    if _state_root_helper is not None:
+        return Path(_state_root_helper()).resolve()
+    return Path(__file__).resolve().parent / "_runtime_state" / "ship_of_ethereon_v2"
+
+
+BASE_DIR = infer_state_root() / MODULE_SLUG
+
+
+@dataclass
+class SessionState:
+    session_id: str
+    started_at: str
+    project_id: str
+    current_mode: str = "Continuity"
+    artifacts_in_scope: list[str] = field(default_factory=list)
+    workspace_state: dict = field(default_factory=dict)
+    continuation_notes: list[str] = field(default_factory=list)
+    pending_next_action: str | None = None
+    last_completed_action: str | None = None
+    last_checkpoint: str | None = None
+    linked_host_bundle: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class ProjectReturnStore:
+    """Repo-native proof that Lumina can resume a project without guessing."""
+
+    def __init__(self, base_dir: str | Path = BASE_DIR):
+        self.base_dir = Path(base_dir)
+        self.session_dir = self.base_dir / "sessions"
+        self.checkpoint_dir = self.base_dir / "checkpoints"
+        self.restore_latest_dir = self.base_dir / "project_restores" / "latest"
+        self.host_bundle_dir = infer_state_root() / HOST_MODULE_SLUG / "host_bundles"
+        self.session_dir.mkdir(parents=True, exist_ok=True)
+        self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        self.restore_latest_dir.mkdir(parents=True, exist_ok=True)
+        self.host_bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _safe_slug(value: str) -> str:
+        slug = "".join(c if c.isalnum() or c in "-_" else "_" for c in value.strip())
+        return slug or "default-project"
+
+    def _session_path(self, session_id: str) -> Path:
+        return self.session_dir / f"{session_id}.json"
+
+    def _checkpoint_path(self, session_id: str, label: str) -> Path:
+        return self.checkpoint_dir / f"{session_id}__{self._safe_slug(label)}.json"
+
+    def _latest_restore_path(self, project_id: str) -> Path:
+        return self.restore_latest_dir / f"{self._safe_slug(project_id)}.json"
+
+    def _host_bundle_path(self, project_id: str) -> Path:
+        return self.host_bundle_dir / f"{self._safe_slug(project_id)}.json"
+
+    def create_session(self, project_id: str, mode: str = "Continuity", artifacts_in_scope=None) -> SessionState:
+        state = SessionState(
+            session_id=str(uuid.uuid4()),
+            started_at=utc_now(),
+            project_id=project_id.strip() or "default-project",
+            current_mode=mode,
+            artifacts_in_scope=list(artifacts_in_scope or []),
+            linked_host_bundle=str(self._host_bundle_path(project_id)) if self._host_bundle_path(project_id).exists() else None,
+        )
+        self.save_session(state)
+        return state
+
+    def save_session(self, state: SessionState) -> None:
+        state.linked_host_bundle = str(self._host_bundle_path(state.project_id)) if self._host_bundle_path(state.project_id).exists() else None
+        with self._session_path(state.session_id).open("w", encoding="utf-8") as f:
+            json.dump(state.to_dict(), f, indent=2)
+
+    def load_session(self, session_id: str) -> SessionState:
+        with self._session_path(session_id).open("r", encoding="utf-8") as f:
+            return SessionState(**json.load(f))
+
+    def write_checkpoint(self, session_id: str, label: str) -> Path:
+        state = self.load_session(session_id)
+        path = self._checkpoint_path(session_id, label)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump({"checkpoint_label": label, "created_at": utc_now(), "session_state": state.to_dict()}, f, indent=2)
+        state.last_checkpoint = str(path)
+        self.save_session(state)
+        with self._latest_restore_path(state.project_id).open("w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "project_id": state.project_id,
+                    "session_id": state.session_id,
+                    "checkpoint_path": str(path),
+                    "captured_at": utc_now(),
+                    "current_mode": state.current_mode,
+                    "artifacts_in_scope": state.artifacts_in_scope,
+                    "workspace_state": state.workspace_state,
+                    "continuation_notes": state.continuation_notes,
+                    "pending_next_action": state.pending_next_action,
+                    "last_completed_action": state.last_completed_action,
+                    "linked_host_bundle": state.linked_host_bundle,
+                },
+                f,
+                indent=2,
+            )
+        return path
+
+    def project_return_payload(self, project_id: str) -> dict:
+        latest_path = self._latest_restore_path(project_id)
+        if not latest_path.exists():
+            raise FileNotFoundError(project_id)
+        with latest_path.open("r", encoding="utf-8") as f:
+            latest_restore = json.load(f)
+        host_bundle = None
+        if self._host_bundle_path(project_id).exists():
+            with self._host_bundle_path(project_id).open("r", encoding="utf-8") as f:
+                host_bundle = json.load(f)
+        return {
+            "project_id": project_id,
+            "return_strategy": "checkpoint_plus_host" if host_bundle else "checkpoint_only",
+            "latest_restore": latest_restore,
+            "host_bundle": host_bundle,
+        }

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/workspace_host_repo_native_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/workspace_host_repo_native_r1.py
@@ -1,0 +1,133 @@
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+import json
+import uuid
+
+try:
+    from .repo_paths_r1 import state_root as _state_root_helper
+except Exception:
+    try:
+        from repo_paths_r1 import state_root as _state_root_helper
+    except Exception:
+        _state_root_helper = None
+
+MODULE_SLUG = "workspace_host_repo_native_r1"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def infer_state_root() -> Path:
+    if _state_root_helper is not None:
+        return Path(_state_root_helper()).resolve()
+    return Path(__file__).resolve().parent / "_runtime_state" / "ship_of_ethereon_v2"
+
+
+BASE_DIR = infer_state_root() / MODULE_SLUG
+
+
+@dataclass
+class HostSession:
+    host_session_id: str
+    started_at: str
+    project_id: str
+    current_mode: str = "Continuity"
+    active_layout_id: str = "default-workspace"
+    focus_target: str | None = None
+    panels: list[dict] = field(default_factory=list)
+    tool_bindings: list[dict] = field(default_factory=list)
+    references: list[dict] = field(default_factory=list)
+    continuation_notes: list[str] = field(default_factory=list)
+    artifacts_in_scope: list[str] = field(default_factory=list)
+    linked_restore_checkpoint: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class WorkspaceHostStore:
+    """Repo-native proof that Lumina can restore a bounded working surface."""
+
+    def __init__(self, base_dir: str | Path = BASE_DIR):
+        self.base_dir = Path(base_dir)
+        self.session_dir = self.base_dir / "host_sessions"
+        self.snapshot_latest_dir = self.base_dir / "host_snapshots" / "latest"
+        self.bundle_dir = self.base_dir / "host_bundles"
+        self.session_dir.mkdir(parents=True, exist_ok=True)
+        self.snapshot_latest_dir.mkdir(parents=True, exist_ok=True)
+        self.bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _safe_slug(value: str) -> str:
+        slug = "".join(c if c.isalnum() or c in "-_" else "_" for c in value.strip())
+        return slug or "default-project"
+
+    def _session_path(self, host_session_id: str) -> Path:
+        return self.session_dir / f"{host_session_id}.json"
+
+    def _latest_snapshot_path(self, project_id: str) -> Path:
+        return self.snapshot_latest_dir / f"{self._safe_slug(project_id)}.json"
+
+    def _bundle_path(self, project_id: str) -> Path:
+        return self.bundle_dir / f"{self._safe_slug(project_id)}.json"
+
+    def create_session(self, project_id: str, mode: str = "Continuity", active_layout_id: str = "default-workspace") -> HostSession:
+        session = HostSession(
+            host_session_id=str(uuid.uuid4()),
+            started_at=utc_now(),
+            project_id=project_id.strip() or "default-project",
+            current_mode=mode,
+            active_layout_id=active_layout_id,
+        )
+        self.save_session(session)
+        return session
+
+    def save_session(self, session: HostSession) -> None:
+        with self._session_path(session.host_session_id).open("w", encoding="utf-8") as f:
+            json.dump(session.to_dict(), f, indent=2)
+
+    def load_session(self, host_session_id: str) -> HostSession:
+        with self._session_path(host_session_id).open("r", encoding="utf-8") as f:
+            return HostSession(**json.load(f))
+
+    def set_surface(self, host_session_id: str, *, focus_target=None, panels=None, tool_bindings=None, references=None, continuation_notes=None, linked_restore_checkpoint=None) -> HostSession:
+        session = self.load_session(host_session_id)
+        if focus_target is not None:
+            session.focus_target = focus_target
+        if panels is not None:
+            session.panels = list(panels)
+        if tool_bindings is not None:
+            session.tool_bindings = list(tool_bindings)
+        if references is not None:
+            session.references = list(references)
+        if continuation_notes is not None:
+            session.continuation_notes = list(continuation_notes)
+        if linked_restore_checkpoint is not None:
+            session.linked_restore_checkpoint = linked_restore_checkpoint
+        self.save_session(session)
+        return session
+
+    def write_snapshot(self, host_session_id: str) -> dict:
+        session = self.load_session(host_session_id)
+        snapshot = {
+            "project_id": session.project_id,
+            "host_session_id": session.host_session_id,
+            "captured_at": utc_now(),
+            "current_mode": session.current_mode,
+            "active_layout_id": session.active_layout_id,
+            "focus_target": session.focus_target,
+            "panels": session.panels,
+            "tool_bindings": session.tool_bindings,
+            "references": session.references,
+            "continuation_notes": session.continuation_notes,
+            "artifacts_in_scope": session.artifacts_in_scope,
+            "linked_restore_checkpoint": session.linked_restore_checkpoint,
+        }
+        with self._latest_snapshot_path(session.project_id).open("w", encoding="utf-8") as f:
+            json.dump(snapshot, f, indent=2)
+        bundle = {"bundle_type": "lumina_host_workspace_r1", **snapshot}
+        with self._bundle_path(session.project_id).open("w", encoding="utf-8") as f:
+            json.dump(bundle, f, indent=2)
+        return bundle


### PR DESCRIPTION
Add repo-native bootstrap modules for project return and workspace host behavior, plus a note describing the intended next merge into the main runtime flow.