### PR TITLE
Align Lumina bootstrap docs with repo-native return and host layer

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md
@@ -15,17 +15,19 @@ This folder is the GitHub bootstrap import for beginning **Lumina OS** from the 
 - Ethereonic layer registry helper
 - Psi-42 transceiver
 - sea-trials runner
+- repo-native project return proof
+- repo-native workspace host proof
 
 ## Current status
 
 The core substrate is now present on `main`.
 
-The remaining hardening priority is to make the bootstrap feel like a real repository checkout rather than a ChatGPT-container snapshot:
+The repo-native layer now includes first proofs that Lumina can:
 
-- repo-relative state and artifact paths
-- package-oriented intra-runtime imports
-- fuller Ψ-42 fidelity where possible
-- docs aligned to the live bootstrap state
+- return to the latest known state of a project without guessing
+- return with a bounded working surface around that project
+
+The remaining hardening priority is to absorb those return / host fields more deeply into the main runtime flow so active working stance becomes first-class runtime behavior rather than adjacent proof modules.
 
 ## Intent
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/README_IMPORT.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/README_IMPORT.md
@@ -18,6 +18,8 @@ Imported on branch: `lumina-os-bootstrap-ship-of-ethereon-v2`
 - Ethereonic layer registry helper
 - Psi-42 transceiver
 - sea-trials runner
+- repo-native project return proof
+- repo-native workspace host proof
 
 ## Intent
 
@@ -42,6 +44,7 @@ Use this directory as the substrate for:
 2. capability-routing hardening
 3. measured continuity work
 4. separation of Lumina OS substrate from Minerva OS inhabitation
+5. deeper merge of project return and workspace-host stance into the main runtime flow
 
 ## Source note
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/REPO_NATIVE_BOOTSTRAP_NOTE.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/REPO_NATIVE_BOOTSTRAP_NOTE.md
@@ -8,15 +8,20 @@ These repo-native files supersede the earlier bootstrap-only imports when you wa
 - `runtime/runtime_runner_repo_native_r1.py`
 - `runtime/psi42_transceiver_v1_6_full_local.py`
 - `runtime/sea_trials_set_one_repo_native_r1.py`
+- `runtime/project_return_repo_native_r1.py`
+- `runtime/workspace_host_repo_native_r1.py`
 
 ## Why they exist
 
-They preserve the earlier bootstrap work while correcting three practical gaps:
+They preserve the earlier bootstrap work while correcting practical gaps:
 
 1. repo-relative state and artifact paths
 2. a fuller local Ψ-42 implementation
 3. package-oriented import behavior inside the repository
+4. project return without guessing
+5. bounded workspace-host restoration
 
 ## Guidance
 
 Use the repo-native runner and repo-native sea-trials files as the preferred entry points for ongoing Lumina OS work on this branch.
+Use the repo-native return and workspace-host files when the task is about restoring active project stance rather than runtime legality alone.

--- a/START_HERE_LUMINA_OS.md
+++ b/START_HERE_LUMINA_OS.md
@@ -13,6 +13,7 @@ Primary guide files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README_IMPORT.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/REPO_NATIVE_BOOTSTRAP_NOTE.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`
 
 Primary runtime files inside that path:
 
@@ -24,6 +25,8 @@ Primary runtime files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/psi42_transceiver_v1_6.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_set_one_r1_merged.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/project_return_repo_native_r1.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/workspace_host_repo_native_r1.py`
 
 ## What this path is
 
@@ -39,12 +42,14 @@ It is the correct place to start when the task is about:
 - Ethereonic boundary enforcement
 - input integrity
 - Psi-42 as an instrument under boundary control
+- project return without guessing
+- bounded workspace-host restoration
 
 ## Current truth
 
 1. **Lumina OS governed substrate starts in the bootstrap path above.**
 2. **Chamber is a parallel app/public lane, not the same thing as the Lumina OS substrate.**
-3. **Root-level continuity / workspace-host files are newer exploratory work, but they do not replace the bootstrap substrate as the starting point for governed Lumina OS architecture.**
+3. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap now also contains first proofs for project return and workspace-host behavior.**
 4. **If you are trying to understand the Ship-derived runtime core, do not begin with Chamber. Begin with the bootstrap path.**
 
 ## Parallel lanes in this repository
@@ -67,8 +72,8 @@ It is the correct place to start when the task is about:
 
 1. Read this file.
 2. Open `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md`.
-3. Read `README_IMPORT.md` and `REPO_NATIVE_BOOTSTRAP_NOTE.md`.
-4. Inspect `runtime/` in that subtree.
+3. Read `README_IMPORT.md`, `REPO_NATIVE_BOOTSTRAP_NOTE.md`, and `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`.
+4. Inspect `runtime/` in that subtree, including the repo-native return and workspace-host modules.
 5. Only then branch outward into Chamber or root-level experimental work.
 
 ## Assistant note


### PR DESCRIPTION
Update the Lumina start and bootstrap docs so they reflect the merged repo-native project return and workspace host modules now present on main.