### PR TITLE
Add bridge runner for repo-native Lumina return and host behavior

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/REPO_NATIVE_BOOTSTRAP_NOTE.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/REPO_NATIVE_BOOTSTRAP_NOTE.md
@@ -10,6 +10,8 @@ These repo-native files supersede the earlier bootstrap-only imports when you wa
 - `runtime/sea_trials_set_one_repo_native_r1.py`
 - `runtime/project_return_repo_native_r1.py`
 - `runtime/workspace_host_repo_native_r1.py`
+- `runtime/lumina_return_host_repo_native_bridge_r1.py`
+- `runtime/runtime_runner_return_host_bridge_r1.py`
 
 ## Why they exist
 
@@ -20,8 +22,9 @@ They preserve the earlier bootstrap work while correcting practical gaps:
 3. package-oriented import behavior inside the repository
 4. project return without guessing
 5. bounded workspace-host restoration
+6. bridge-based activation of the repo-native return/host layer without risky surgery to the main runner
 
 ## Guidance
 
 Use the repo-native runner and repo-native sea-trials files as the preferred entry points for ongoing Lumina OS work on this branch.
-Use the repo-native return and workspace-host files when the task is about restoring active project stance rather than runtime legality alone.
+Use the return/host bridge runner when the task is about restoring active project stance through the bootstrap-local repo-native layer rather than the older spike path.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json
@@ -8,13 +8,7 @@
       "module_path": "runtime_spine_r1.py",
       "status": "active",
       "category": "structural",
-      "allowed_modes": [
-        "Continuity",
-        "Sandbox",
-        "DryDock",
-        "Observation",
-        "Canon"
-      ],
+      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
       "mutation_scope": "session",
       "requires_validation": false,
       "authority_boundary": "Owns active session state, checkpoints, and turn continuity only.",
@@ -27,13 +21,7 @@
       "module_path": "runtime_spine_r1.py",
       "status": "active",
       "category": "structural",
-      "allowed_modes": [
-        "Continuity",
-        "Sandbox",
-        "DryDock",
-        "Observation",
-        "Canon"
-      ],
+      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "Owns legality checks for transitions, mutation permission, and promotion gating.",
@@ -46,12 +34,7 @@
       "module_path": "runtime_spine_r1.py",
       "status": "active",
       "category": "structural",
-      "allowed_modes": [
-        "Continuity",
-        "Sandbox",
-        "DryDock",
-        "Observation"
-      ],
+      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation"],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "Builds bounded, replayable context bundles and separates core from supplemental Ethereonic context.",
@@ -64,13 +47,7 @@
       "module_path": "input_integrity_layer_r1.py",
       "status": "active",
       "category": "structural",
-      "allowed_modes": [
-        "Continuity",
-        "Sandbox",
-        "DryDock",
-        "Observation",
-        "Canon"
-      ],
+      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "May annotate ambiguity, score candidate interpretations, and recommend clarification or halt behavior. May not alter governance law, canon state, or execute mutating actions on inferred intent alone.",
@@ -80,42 +57,27 @@
     {
       "capability_id": "continuity_restore_store",
       "name": "Continuity Restore Store",
-      "module_path": "continuity_restore_spike_r1.py",
+      "module_path": "project_return_repo_native_r1.py",
       "status": "experimental-active",
       "category": "structural",
-      "allowed_modes": [
-        "Continuity",
-        "Sandbox",
-        "DryDock",
-        "Observation",
-        "Canon"
-      ],
+      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
       "mutation_scope": "checkpoint",
       "requires_validation": false,
       "authority_boundary": "Owns project-scoped restore capture, latest-restore resolution, and checkpoint-linked return payloads only. Does not own governance law, canon lineage, or mode legality.",
-      "dependencies": [
-        "session_state_manager"
-      ],
+      "dependencies": ["session_state_manager"],
       "feature_flag": "ETHEREON_CONTINUITY_RESTORE"
     },
     {
       "capability_id": "lumina_workspace_host",
       "name": "Lumina Workspace Host",
-      "module_path": "lumina_workspace_host_spike_r1.py",
+      "module_path": "workspace_host_repo_native_r1.py",
       "status": "experimental-active",
       "category": "structural",
-      "allowed_modes": [
-        "Continuity",
-        "Sandbox",
-        "DryDock",
-        "Observation"
-      ],
+      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation"],
       "mutation_scope": "workspace",
       "requires_validation": false,
       "authority_boundary": "Owns bounded workspace panels, tool bindings, references, host snapshots, and host bundles only. Does not own governance law, canon lineage, checkpoint truth, or mode legality.",
-      "dependencies": [
-        "continuity_restore_store"
-      ],
+      "dependencies": ["continuity_restore_store"],
       "feature_flag": "ETHEREON_LUMINA_HOST"
     },
     {
@@ -124,15 +86,11 @@
       "module_path": "runtime_runner_r1_merged.py",
       "status": "experimental",
       "category": "expressive",
-      "allowed_modes": [
-        "Observation"
-      ],
+      "allowed_modes": ["Observation"],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "May evaluate continuity metrics but may not declare canon state or governance law.",
-      "dependencies": [
-        "session_state_manager"
-      ],
+      "dependencies": ["session_state_manager"],
       "feature_flag": "ETHEREON_OBSERVATION"
     },
     {
@@ -141,16 +99,11 @@
       "module_path": "psi42_transceiver_v1_6.py",
       "status": "experimental-active",
       "category": "expressive",
-      "allowed_modes": [
-        "Observation",
-        "Sandbox"
-      ],
+      "allowed_modes": ["Observation", "Sandbox"],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "Emits probe metrics and artifacts only; does not govern continuity, canon state, or runtime law.",
-      "dependencies": [
-        "session_state_manager"
-      ],
+      "dependencies": ["session_state_manager"],
       "feature_flag": "ETHEREON_PSI42"
     },
     {
@@ -159,17 +112,11 @@
       "module_path": "sea_trials_set_one_r1_merged.py",
       "status": "experimental",
       "category": "expressive",
-      "allowed_modes": [
-        "Observation",
-        "Sandbox",
-        "DryDock"
-      ],
+      "allowed_modes": ["Observation", "Sandbox", "DryDock"],
       "mutation_scope": "artifact",
       "requires_validation": true,
       "authority_boundary": "May read and emit resonance metadata; may not write governance state.",
-      "dependencies": [
-        "context_bundle_builder"
-      ],
+      "dependencies": ["context_bundle_builder"],
       "feature_flag": "ETHEREON_RESONANCE"
     },
     {
@@ -178,17 +125,11 @@
       "module_path": "psi42_transceiver_v1_6.py",
       "status": "experimental-active",
       "category": "expressive",
-      "allowed_modes": [
-        "Observation",
-        "Sandbox"
-      ],
+      "allowed_modes": ["Observation", "Sandbox"],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "Owns signal encoding, mitigation, adaptive probe steering, recovery metrics, recomposition reports, and probe artifacts only. Does not own canon state, governance, or primary continuity authority.",
-      "dependencies": [
-        "session_state_manager",
-        "psi42_probe_interface"
-      ],
+      "dependencies": ["session_state_manager", "psi42_probe_interface"],
       "feature_flag": "ETHEREON_PSI42"
     }
   ]

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_return_host_repo_native_bridge_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_return_host_repo_native_bridge_r1.py
@@ -1,0 +1,162 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    from .project_return_repo_native_r1 import ProjectReturnStore
+    from .workspace_host_repo_native_r1 import WorkspaceHostStore
+except Exception:
+    from project_return_repo_native_r1 import ProjectReturnStore
+    from workspace_host_repo_native_r1 import WorkspaceHostStore
+
+
+@dataclass
+class HostSnapshot:
+    snapshot_id: str
+
+
+class ContinuityRestoreStore:
+    """Compatibility bridge that presents the older spike-facing API over the repo-native project return store."""
+
+    def __init__(self, base_dir: str | Path):
+        self._store = ProjectReturnStore(base_dir)
+
+    def create_session(
+        self,
+        *,
+        project_id: str,
+        mode: str = "Continuity",
+        artifacts_in_scope: Optional[List[str]] = None,
+        workspace_state: Optional[Dict[str, Any]] = None,
+        continuation_notes: Optional[List[str]] = None,
+    ):
+        session = self._store.create_session(project_id=project_id, mode=mode, artifacts_in_scope=artifacts_in_scope)
+        if workspace_state is not None:
+            session.workspace_state = dict(workspace_state)
+        if continuation_notes is not None:
+            session.continuation_notes = list(continuation_notes)
+        self._store.save_session(session)
+        return session
+
+    def save_session(self, session) -> None:
+        self._store.save_session(session)
+
+    def write_checkpoint(self, session_id: str, label: str):
+        return self._store.write_checkpoint(session_id, label)
+
+    def project_return_payload(self, project_id: str) -> dict:
+        return self._store.project_return_payload(project_id)
+
+
+class LuminaWorkspaceHost:
+    """Compatibility bridge that presents the older spike-facing host API over the repo-native workspace host store."""
+
+    def __init__(self, base_dir: str | Path):
+        self._store = WorkspaceHostStore(base_dir)
+
+    def create_host_session(
+        self,
+        *,
+        project_id: str,
+        mode: str = "Continuity",
+        active_layout_id: str = "default-workspace",
+        focus_target: Optional[str] = None,
+        artifacts_in_scope: Optional[List[str]] = None,
+        linked_restore_checkpoint: Optional[str] = None,
+        continuation_notes: Optional[List[str]] = None,
+    ):
+        session = self._store.create_session(project_id=project_id, mode=mode, active_layout_id=active_layout_id)
+        session.focus_target = focus_target
+        session.artifacts_in_scope = list(artifacts_in_scope or [])
+        session.linked_restore_checkpoint = linked_restore_checkpoint
+        session.continuation_notes = list(continuation_notes or [])
+        self._store.save_session(session)
+        return session
+
+    def upsert_panel(
+        self,
+        host_session_id: str,
+        *,
+        panel_id: str,
+        panel_type: str,
+        title: str,
+        zone: str,
+        visible: bool = True,
+        priority: int = 50,
+        payload: Optional[Dict[str, Any]] = None,
+    ):
+        session = self._store.load_session(host_session_id)
+        panels = [row for row in session.panels if row.get("panel_id") != panel_id]
+        panels.append(
+            {
+                "panel_id": panel_id,
+                "panel_type": panel_type,
+                "title": title,
+                "zone": zone,
+                "visible": visible,
+                "priority": priority,
+                "payload": dict(payload or {}),
+            }
+        )
+        session.panels = sorted(panels, key=lambda item: (item.get("zone", ""), item.get("priority", 50), item.get("panel_id", "")))
+        self._store.save_session(session)
+        return session
+
+    def bind_tool(
+        self,
+        host_session_id: str,
+        *,
+        tool_id: str,
+        label: str,
+        launch_target: str,
+        context_keys: Optional[List[str]] = None,
+        pinned: bool = False,
+    ):
+        session = self._store.load_session(host_session_id)
+        tools = [row for row in session.tool_bindings if row.get("tool_id") != tool_id]
+        tools.append(
+            {
+                "tool_id": tool_id,
+                "label": label,
+                "launch_target": launch_target,
+                "context_keys": list(context_keys or []),
+                "pinned": pinned,
+            }
+        )
+        session.tool_bindings = sorted(tools, key=lambda item: (not item.get("pinned", False), item.get("label", "").casefold()))
+        self._store.save_session(session)
+        return session
+
+    def attach_reference(
+        self,
+        host_session_id: str,
+        *,
+        reference_id: str,
+        label: str,
+        source: str,
+        kind: str = "reference",
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
+        session = self._store.load_session(host_session_id)
+        refs = [row for row in session.references if row.get("reference_id") != reference_id]
+        refs.append(
+            {
+                "reference_id": reference_id,
+                "label": label,
+                "source": source,
+                "kind": kind,
+                "metadata": dict(metadata or {}),
+            }
+        )
+        session.references = sorted(refs, key=lambda item: (item.get("kind", ""), item.get("label", "").casefold()))
+        self._store.save_session(session)
+        return session
+
+    def write_host_snapshot(self, host_session_id: str, *, last_completed_action: Optional[str] = None):
+        bundle = self._store.write_snapshot(host_session_id)
+        return HostSnapshot(snapshot_id=f"host-{bundle['host_session_id']}")
+
+    def emit_host_bundle(self, project_id: str) -> dict:
+        path = self._store._bundle_path(project_id)
+        with path.open("r", encoding="utf-8") as f:
+            return __import__("json").load(f)

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_return_host_bridge_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_return_host_bridge_r1.py
@@ -1,0 +1,70 @@
+import argparse
+import json
+
+try:
+    from . import runtime_runner_r1_merged as runner_mod
+    from .lumina_return_host_repo_native_bridge_r1 import ContinuityRestoreStore, LuminaWorkspaceHost
+except Exception:
+    import runtime_runner_r1_merged as runner_mod
+    from lumina_return_host_repo_native_bridge_r1 import ContinuityRestoreStore, LuminaWorkspaceHost
+
+
+runner_mod.ContinuityRestoreStore = ContinuityRestoreStore
+runner_mod.LuminaWorkspaceHost = LuminaWorkspaceHost
+
+
+class ReturnHostBridgedRuntimeRunner(runner_mod.RuntimeRunner):
+    """Preferred repo-native runner when Lumina return/host behavior should use the bootstrap-local bridge layer."""
+
+    pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one tiny Ethereon runtime cycle with repo-native return/host bridging.")
+    parser.add_argument("--current-mode", default="Continuity")
+    parser.add_argument("--target-mode", default=None)
+    parser.add_argument("--action", default="sea_trial_cycle")
+    parser.add_argument("--action-type", default="transition", choices=sorted(runner_mod.VALID_ACTION_TYPES))
+    parser.add_argument("--target-is-canonical", action="store_true")
+    parser.add_argument("--repo-path", default=None)
+    parser.add_argument("--project-id", default=None)
+    parser.add_argument("--enable-flag", action="append", dest="feature_flags", default=[])
+    parser.add_argument("--artifact", action="append", dest="artifacts", default=[])
+    parser.add_argument("--note", action="append", dest="notes", default=[])
+    parser.add_argument("--lineage", default=None)
+    parser.add_argument("--overlay-json", default=None)
+    parser.add_argument("--runtime-config-json", default=None)
+    parser.add_argument("--promotion-json", default=None)
+    parser.add_argument("--raw-user-input", default=None)
+    parser.add_argument("--context-overrides-json", default=None)
+    return parser.parse_args()
+
+
+def _maybe_json(text):
+    if not text:
+        return None
+    return json.loads(text)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    runner = ReturnHostBridgedRuntimeRunner()
+    result = runner.run_cycle(
+        current_mode=args.current_mode,
+        target_mode=args.target_mode,
+        requested_action=args.action,
+        action_type=args.action_type,
+        artifacts=args.artifacts or None,
+        continuation_notes=args.notes or None,
+        canon_lineage_head=args.lineage,
+        ethereonic_overlay=_maybe_json(args.overlay_json),
+        enabled_feature_flags=args.feature_flags or None,
+        target_is_canonical=args.target_is_canonical,
+        promotion_payload=_maybe_json(args.promotion_json),
+        runtime_config=_maybe_json(args.runtime_config_json),
+        repo_path=args.repo_path,
+        raw_user_input=args.raw_user_input,
+        context_bundle_overrides=_maybe_json(args.context_overrides_json),
+        project_id=args.project_id,
+    )
+    print(json.dumps(result.to_dict(), indent=2))


### PR DESCRIPTION
Add a compatibility bridge and bridged runner so the existing bootstrap runtime flow can activate the repo-native project return and workspace host modules without large surgery to the main runner file. Also align the capability registry and repo-native bootstrap note with that preferred path.