### PR TITLE
Add bounded Lumina self-guidance steward and self-guided bridge runner

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/SELF_GUIDANCE_STEWARD_NOTE_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/SELF_GUIDANCE_STEWARD_NOTE_R1.md
@@ -1,0 +1,80 @@
+# Self-Guidance Steward Note r1
+
+This note records the next architectural threshold for Lumina OS after return-with-stance.
+
+## What landed
+
+Lumina now has a bounded self-guidance steward in the bootstrap runtime path.
+
+Core additions:
+
+- `runtime/lumina_self_guidance_steward_r1.py`
+- `runtime/runtime_runner_self_guided_bridge_r1.py`
+- `runtime/sea_trials_lumina_self_guidance_r1.py`
+
+## What it does
+
+The steward reads:
+
+- project-return summaries
+- bounded workspace-host summaries
+- projected working stance
+
+It then emits:
+
+- `recommended_next_action`
+- `guidance_strategy`
+- `confidence_label`
+- `reasoning_brief`
+
+The advisory is attached to session and context-bundle surfaces so Lumina can resume with a likely next move already surfaced.
+
+## Why this matters
+
+Return-with-stance proved that Lumina could come back to a project without guessing and could restore a bounded working surface around it.
+
+The next missing threshold was not memory alone.
+It was orientation plus recommendation.
+
+This steward is the first bounded proof that Lumina can look at the project surface it restored and say, in effect:
+
+- this is where the work is pointed
+- this is the likeliest next thing to do
+- this recommendation is advisory, not law
+
+## What remains bounded
+
+Self-guidance does **not** become governance.
+
+It may not:
+
+- define mode legality
+- define mutation legality
+- define promotion legality
+- define canon lineage
+- define checkpoint legality
+- replace explicit user intent
+
+It is a steward, not a sovereign.
+
+## Current role
+
+At this stage, the self-guidance layer does five useful things:
+
+1. reads restored project-return state
+2. reads bounded host / workspace stance
+3. emits a non-governing next-step recommendation
+4. projects that recommendation into session and context surfaces
+5. leaves a governance trail that records execution without granting authority
+
+## Next likely move
+
+The next hardening step is to deepen:
+
+- checkpoint-triggered guidance refresh
+- richer recommendation logic from longer project history
+- UI consumption of advisory output
+- user-visible acceptance / rejection loops
+- future continuity between advisory memory and bounded tool orchestration
+
+without letting any of that become hidden governance authority.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.4",
-  "description": "Minimal capability registry for the Ethereon Runtime Spine, now including continuity restore and workspace-host handshake support under explicit authority boundaries.",
+  "version": "0.5",
+  "description": "Minimal capability registry for the Ethereon Runtime Spine, now including continuity restore, workspace-host handshake support, and bounded Lumina self-guidance under explicit authority boundaries.",
   "capabilities": [
     {
       "capability_id": "session_state_manager",
@@ -8,7 +8,13 @@
       "module_path": "runtime_spine_r1.py",
       "status": "active",
       "category": "structural",
-      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
+      "allowed_modes": [
+        "Continuity",
+        "Sandbox",
+        "DryDock",
+        "Observation",
+        "Canon"
+      ],
       "mutation_scope": "session",
       "requires_validation": false,
       "authority_boundary": "Owns active session state, checkpoints, and turn continuity only.",
@@ -21,7 +27,13 @@
       "module_path": "runtime_spine_r1.py",
       "status": "active",
       "category": "structural",
-      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
+      "allowed_modes": [
+        "Continuity",
+        "Sandbox",
+        "DryDock",
+        "Observation",
+        "Canon"
+      ],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "Owns legality checks for transitions, mutation permission, and promotion gating.",
@@ -34,7 +46,12 @@
       "module_path": "runtime_spine_r1.py",
       "status": "active",
       "category": "structural",
-      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation"],
+      "allowed_modes": [
+        "Continuity",
+        "Sandbox",
+        "DryDock",
+        "Observation"
+      ],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "Builds bounded, replayable context bundles and separates core from supplemental Ethereonic context.",
@@ -47,7 +64,13 @@
       "module_path": "input_integrity_layer_r1.py",
       "status": "active",
       "category": "structural",
-      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
+      "allowed_modes": [
+        "Continuity",
+        "Sandbox",
+        "DryDock",
+        "Observation",
+        "Canon"
+      ],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "May annotate ambiguity, score candidate interpretations, and recommend clarification or halt behavior. May not alter governance law, canon state, or execute mutating actions on inferred intent alone.",
@@ -60,11 +83,19 @@
       "module_path": "project_return_repo_native_r1.py",
       "status": "experimental-active",
       "category": "structural",
-      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation", "Canon"],
+      "allowed_modes": [
+        "Continuity",
+        "Sandbox",
+        "DryDock",
+        "Observation",
+        "Canon"
+      ],
       "mutation_scope": "checkpoint",
       "requires_validation": false,
       "authority_boundary": "Owns project-scoped restore capture, latest-restore resolution, and checkpoint-linked return payloads only. Does not own governance law, canon lineage, or mode legality.",
-      "dependencies": ["session_state_manager"],
+      "dependencies": [
+        "session_state_manager"
+      ],
       "feature_flag": "ETHEREON_CONTINUITY_RESTORE"
     },
     {
@@ -73,12 +104,40 @@
       "module_path": "workspace_host_repo_native_r1.py",
       "status": "experimental-active",
       "category": "structural",
-      "allowed_modes": ["Continuity", "Sandbox", "DryDock", "Observation"],
+      "allowed_modes": [
+        "Continuity",
+        "Sandbox",
+        "DryDock",
+        "Observation"
+      ],
       "mutation_scope": "workspace",
       "requires_validation": false,
       "authority_boundary": "Owns bounded workspace panels, tool bindings, references, host snapshots, and host bundles only. Does not own governance law, canon lineage, checkpoint truth, or mode legality.",
-      "dependencies": ["continuity_restore_store"],
+      "dependencies": [
+        "continuity_restore_store"
+      ],
       "feature_flag": "ETHEREON_LUMINA_HOST"
+    },
+    {
+      "capability_id": "lumina_self_guidance_steward",
+      "name": "Lumina Self-Guidance Steward",
+      "module_path": "lumina_self_guidance_steward_r1.py",
+      "status": "experimental-active",
+      "category": "structural",
+      "allowed_modes": [
+        "Continuity",
+        "Sandbox",
+        "DryDock",
+        "Observation"
+      ],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "Reads project-return summaries, working stance, and bounded host surfaces to recommend the next likely action. Advisory only; may not define governance law, canon lineage, checkpoint legality, or mode legality.",
+      "dependencies": [
+        "continuity_restore_store",
+        "lumina_workspace_host"
+      ],
+      "feature_flag": "ETHEREON_SELF_GUIDANCE"
     },
     {
       "capability_id": "continuity_assessor",
@@ -86,11 +145,15 @@
       "module_path": "runtime_runner_r1_merged.py",
       "status": "experimental",
       "category": "expressive",
-      "allowed_modes": ["Observation"],
+      "allowed_modes": [
+        "Observation"
+      ],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "May evaluate continuity metrics but may not declare canon state or governance law.",
-      "dependencies": ["session_state_manager"],
+      "dependencies": [
+        "session_state_manager"
+      ],
       "feature_flag": "ETHEREON_OBSERVATION"
     },
     {
@@ -99,11 +162,16 @@
       "module_path": "psi42_transceiver_v1_6.py",
       "status": "experimental-active",
       "category": "expressive",
-      "allowed_modes": ["Observation", "Sandbox"],
+      "allowed_modes": [
+        "Observation",
+        "Sandbox"
+      ],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "Emits probe metrics and artifacts only; does not govern continuity, canon state, or runtime law.",
-      "dependencies": ["session_state_manager"],
+      "dependencies": [
+        "session_state_manager"
+      ],
       "feature_flag": "ETHEREON_PSI42"
     },
     {
@@ -112,11 +180,17 @@
       "module_path": "sea_trials_set_one_r1_merged.py",
       "status": "experimental",
       "category": "expressive",
-      "allowed_modes": ["Observation", "Sandbox", "DryDock"],
+      "allowed_modes": [
+        "Observation",
+        "Sandbox",
+        "DryDock"
+      ],
       "mutation_scope": "artifact",
       "requires_validation": true,
       "authority_boundary": "May read and emit resonance metadata; may not write governance state.",
-      "dependencies": ["context_bundle_builder"],
+      "dependencies": [
+        "context_bundle_builder"
+      ],
       "feature_flag": "ETHEREON_RESONANCE"
     },
     {
@@ -125,11 +199,17 @@
       "module_path": "psi42_transceiver_v1_6.py",
       "status": "experimental-active",
       "category": "expressive",
-      "allowed_modes": ["Observation", "Sandbox"],
+      "allowed_modes": [
+        "Observation",
+        "Sandbox"
+      ],
       "mutation_scope": "none",
       "requires_validation": false,
       "authority_boundary": "Owns signal encoding, mitigation, adaptive probe steering, recovery metrics, recomposition reports, and probe artifacts only. Does not own canon state, governance, or primary continuity authority.",
-      "dependencies": ["session_state_manager", "psi42_probe_interface"],
+      "dependencies": [
+        "session_state_manager",
+        "psi42_probe_interface"
+      ],
       "feature_flag": "ETHEREON_PSI42"
     }
   ]

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_steward_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_steward_r1.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+
+FORBIDDEN_AUTHORITY_KEYS = {
+    "governance",
+    "canon_lineage",
+    "mode_guard",
+    "promotion",
+    "transition",
+    "record_hash",
+    "validation_reference",
+    "allowed",
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class SelfGuidanceAdvisory:
+    project_id: str
+    guidance_strategy: str
+    recommended_next_action: str
+    confidence_label: str
+    confidence_score: float
+    reasoning_brief: str
+    signals: Dict[str, Any] = field(default_factory=dict)
+    boundary_note: str = (
+        "Advisory only. May recommend what to surface or attempt next, "
+        "but may not define governance law, canon lineage, checkpoint legality, or mode legality."
+    )
+    generated_at: str = field(default_factory=utc_now)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["authority_safe"] = not any(key in payload for key in FORBIDDEN_AUTHORITY_KEYS)
+        return payload
+
+
+class LuminaSelfGuidanceSteward:
+    """
+    Advisory steward for repo-native Lumina return / host surfaces.
+
+    It reads project-return memory, bounded host state, and working stance,
+    then emits a non-governing next-step recommendation.
+    """
+
+    @staticmethod
+    def _latest_restore_view(resolved_project_return: Dict[str, Any]) -> Dict[str, Any]:
+        if "latest_restore" in resolved_project_return:
+            return dict(resolved_project_return.get("latest_restore") or {})
+        return dict(resolved_project_return or {})
+
+    def advise(
+        self,
+        *,
+        project_id: str,
+        requested_action: str,
+        current_mode: str,
+        target_mode: str,
+        resolved_project_return: Optional[Dict[str, Any]] = None,
+        resolved_host_bundle: Optional[Dict[str, Any]] = None,
+        working_stance: Optional[Dict[str, Any]] = None,
+    ) -> SelfGuidanceAdvisory:
+        resolved_project_return = dict(resolved_project_return or {})
+        resolved_host_bundle = dict(resolved_host_bundle or {})
+        working_stance = dict(working_stance or {})
+
+        latest_restore = self._latest_restore_view(resolved_project_return)
+        host_bundle = dict(resolved_host_bundle or {})
+
+        pending_next_action = latest_restore.get("pending_next_action")
+        focus_target = (
+            working_stance.get("focus_target")
+            or host_bundle.get("focus_target")
+            or requested_action
+        )
+        linked_host_bundle = latest_restore.get("linked_host_bundle")
+        open_panels = list(working_stance.get("open_panels") or host_bundle.get("panel_ids") or [])
+        pinned_tools = list(working_stance.get("pinned_tools") or host_bundle.get("pinned_tool_ids") or [])
+        reference_ids = list(working_stance.get("reference_ids") or host_bundle.get("reference_ids") or [])
+
+        if pending_next_action:
+            strategy = "pending_next_action"
+            recommended = str(pending_next_action)
+            confidence_label = "high"
+            confidence_score = 0.93
+            reasoning = (
+                "Project return already carries a pending next action, so the steward surfaces that "
+                "instead of guessing from weaker workspace signals."
+            )
+        elif linked_host_bundle and focus_target:
+            strategy = "host_focus_resume"
+            recommended = f"continue::{focus_target}"
+            confidence_label = "medium_high"
+            confidence_score = 0.81
+            reasoning = (
+                "A linked host bundle exists and exposes a bounded focus target, so the steward recommends "
+                "continuing from that scoped working surface."
+            )
+        elif focus_target:
+            strategy = "focus_target_resume"
+            recommended = f"continue::{focus_target}"
+            confidence_label = "medium"
+            confidence_score = 0.72
+            reasoning = (
+                "No explicit pending action was captured, so the steward falls back to the best available "
+                "focus target from working stance / host state."
+            )
+        else:
+            strategy = "requested_action_fallback"
+            recommended = f"continue::{requested_action}"
+            confidence_label = "low_medium"
+            confidence_score = 0.58
+            reasoning = (
+                "The steward found no stronger project-return or host cues, so it falls back to the current "
+                "requested action without claiming authority."
+            )
+
+        signals = {
+            "requested_action": requested_action,
+            "current_mode": current_mode,
+            "target_mode": target_mode,
+            "pending_next_action": pending_next_action,
+            "focus_target": focus_target,
+            "linked_host_bundle": linked_host_bundle,
+            "open_panels": open_panels,
+            "pinned_tools": pinned_tools,
+            "reference_ids": reference_ids,
+            "return_strategy": resolved_project_return.get("return_strategy"),
+        }
+
+        return SelfGuidanceAdvisory(
+            project_id=project_id,
+            guidance_strategy=strategy,
+            recommended_next_action=recommended,
+            confidence_label=confidence_label,
+            confidence_score=confidence_score,
+            reasoning_brief=reasoning,
+            signals=signals,
+        )
+
+    @staticmethod
+    def advisory_summary(advisory: SelfGuidanceAdvisory) -> Dict[str, Any]:
+        payload = advisory.to_dict()
+        return {
+            "project_id": payload["project_id"],
+            "guidance_strategy": payload["guidance_strategy"],
+            "recommended_next_action": payload["recommended_next_action"],
+            "confidence_label": payload["confidence_label"],
+            "confidence_score": payload["confidence_score"],
+            "reasoning_brief": payload["reasoning_brief"],
+            "boundary_note": payload["boundary_note"],
+        }

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_self_guided_bridge_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_self_guided_bridge_r1.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+try:
+    from . import runtime_runner_return_host_bridge_r1 as bridge_mod
+    from .lumina_self_guidance_steward_r1 import LuminaSelfGuidanceSteward
+except Exception:
+    import runtime_runner_return_host_bridge_r1 as bridge_mod
+    from lumina_self_guidance_steward_r1 import LuminaSelfGuidanceSteward
+
+
+class SelfGuidedReturnHostRuntimeRunner(bridge_mod.ReturnHostBridgedRuntimeRunner):
+    """Preferred Lumina runner when bounded self-guidance should ride on the repo-native return/host bridge."""
+
+    SELF_GUIDANCE_CAPABILITY_ID = "lumina_self_guidance_steward"
+    SELF_GUIDANCE_FEATURE_FLAG = "ETHEREON_SELF_GUIDANCE"
+
+    def _self_guidance_reports_dir(self) -> Path:
+        path = Path(self.base_dir) / "self_guidance_reports"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _context_bundle_path(self, context_bundle_id: str) -> Path:
+        return self.context_builder.output_dir / f"{context_bundle_id}.json"
+
+    @staticmethod
+    def _read_json(path: Path) -> Dict[str, Any]:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+    @staticmethod
+    def _write_json(path: Path, payload: Dict[str, Any]) -> None:
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+
+    def _emit_self_guidance_advisory(
+        self,
+        *,
+        result,
+        current_mode: str,
+        target_mode: str,
+        requested_action: str,
+    ) -> None:
+        capability_ids = {cap.get("capability_id") for cap in result.exposed_capabilities}
+        if self.SELF_GUIDANCE_CAPABILITY_ID not in capability_ids:
+            return
+
+        session_path = Path(result.session_path)
+        bundle_path = self._context_bundle_path(result.context_bundle_id)
+        if not session_path.exists() or not bundle_path.exists():
+            return
+
+        session_payload = self._read_json(session_path)
+        bundle_payload = self._read_json(bundle_path)
+
+        artifact_context = dict(bundle_payload.get("artifact_context") or {})
+        memory_context = dict(bundle_payload.get("memory_context") or {})
+
+        project_id = (
+            session_payload.get("project_id")
+            or artifact_context.get("active_project_id")
+            or self._resolve_lumina_project_id(None, requested_action, None)
+        )
+        working_stance = (
+            dict(session_payload.get("working_stance") or {})
+            or dict(artifact_context.get("working_stance_summary") or {})
+        )
+        resolved_project_return = dict(artifact_context.get("resolved_project_return") or {})
+        resolved_host_bundle = dict(artifact_context.get("resolved_host_bundle") or {})
+
+        steward = LuminaSelfGuidanceSteward()
+        advisory = steward.advise(
+            project_id=project_id,
+            requested_action=requested_action,
+            current_mode=current_mode,
+            target_mode=target_mode,
+            resolved_project_return=resolved_project_return,
+            resolved_host_bundle=resolved_host_bundle,
+            working_stance=working_stance,
+        )
+        advisory_payload = advisory.to_dict()
+        advisory_summary = steward.advisory_summary(advisory)
+
+        report_path = self._self_guidance_reports_dir() / f"{result.run_id}_self_guidance.json"
+        self._write_json(report_path, advisory_payload)
+
+        session_payload["self_guidance_advisory"] = advisory_summary
+        session_payload["recommended_next_action"] = advisory_summary["recommended_next_action"]
+        self._write_json(session_path, session_payload)
+
+        artifact_context["self_guidance_advisory_summary"] = advisory_summary
+        memory_context["recommended_next_action"] = advisory_summary["recommended_next_action"]
+        notes = list(memory_context.get("session_continuation_notes", []))
+        note = (
+            f"Self-guidance recommends: {advisory_summary['recommended_next_action']} "
+            f"({advisory_summary['confidence_label']})"
+        )
+        if note not in notes:
+            notes.append(note)
+        memory_context["session_continuation_notes"] = notes
+        bundle_payload["artifact_context"] = artifact_context
+        bundle_payload["memory_context"] = memory_context
+        self._write_json(bundle_path, bundle_payload)
+
+        result.governance["self_guidance_execution"] = {
+            "allowed": True,
+            "report_path": str(report_path),
+            "project_id": advisory_summary["project_id"],
+            "recommended_next_action": advisory_summary["recommended_next_action"],
+            "confidence_label": advisory_summary["confidence_label"],
+            "confidence_score": advisory_summary["confidence_score"],
+            "reasoning_brief": advisory_summary["reasoning_brief"],
+            "boundary_note": advisory_summary["boundary_note"],
+        }
+
+        self._append_governance_event(
+            event_type="self_guidance_advisory",
+            session_id=result.session_id,
+            previous_mode=target_mode,
+            new_mode=target_mode,
+            allowed=True,
+            reason="emitted bounded self-guidance advisory",
+            requested_action=requested_action,
+            action_type=result.action_type,
+            metadata={
+                "project_id": advisory_summary["project_id"],
+                "recommended_next_action": advisory_summary["recommended_next_action"],
+                "confidence_label": advisory_summary["confidence_label"],
+                "report_path": str(report_path),
+            },
+        )
+        result.governance_chain_status = self._current_chain_status()
+
+        log_path = Path(result.log_path)
+        if log_path.exists():
+            self._write_json(log_path, result.to_dict())
+
+    def run_cycle(
+        self,
+        *,
+        current_mode: str = "Continuity",
+        target_mode: Optional[str] = None,
+        requested_action: str = "sea_trial_cycle",
+        enabled_feature_flags: Optional[list[str]] = None,
+        artifacts: Optional[list[str]] = None,
+        **kwargs: Any,
+    ):
+        target_mode = target_mode or current_mode
+        feature_flags = list(enabled_feature_flags or [])
+        if self.SELF_GUIDANCE_FEATURE_FLAG not in feature_flags:
+            feature_flags.append(self.SELF_GUIDANCE_FEATURE_FLAG)
+
+        artifact_list = list(artifacts or [])
+        for artifact_name in [
+            "lumina_self_guidance_steward_r1.py",
+            "runtime_runner_self_guided_bridge_r1.py",
+            "sea_trials_lumina_self_guidance_r1.py",
+        ]:
+            if artifact_name not in artifact_list:
+                artifact_list.append(artifact_name)
+
+        result = super().run_cycle(
+            current_mode=current_mode,
+            target_mode=target_mode,
+            requested_action=requested_action,
+            enabled_feature_flags=feature_flags,
+            artifacts=artifact_list or None,
+            **kwargs,
+        )
+        self._emit_self_guidance_advisory(
+            result=result,
+            current_mode=current_mode,
+            target_mode=target_mode,
+            requested_action=requested_action,
+        )
+        return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one tiny Ethereon runtime cycle with bounded Lumina self-guidance.")
+    parser.add_argument("--current-mode", default="Continuity")
+    parser.add_argument("--target-mode", default=None)
+    parser.add_argument("--action", default="sea_trial_cycle")
+    parser.add_argument("--action-type", default="transition", choices=sorted(bridge_mod.runner_mod.VALID_ACTION_TYPES))
+    parser.add_argument("--target-is-canonical", action="store_true")
+    parser.add_argument("--repo-path", default=None)
+    parser.add_argument("--project-id", default=None)
+    parser.add_argument("--enable-flag", action="append", dest="feature_flags", default=[])
+    parser.add_argument("--artifact", action="append", dest="artifacts", default=[])
+    parser.add_argument("--note", action="append", dest="notes", default=[])
+    parser.add_argument("--lineage", default=None)
+    parser.add_argument("--overlay-json", default=None)
+    parser.add_argument("--runtime-config-json", default=None)
+    parser.add_argument("--promotion-json", default=None)
+    parser.add_argument("--raw-user-input", default=None)
+    parser.add_argument("--context-overrides-json", default=None)
+    return parser.parse_args()
+
+
+def _maybe_json(text: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not text:
+        return None
+    return json.loads(text)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    runner = SelfGuidedReturnHostRuntimeRunner()
+    result = runner.run_cycle(
+        current_mode=args.current_mode,
+        target_mode=args.target_mode,
+        requested_action=args.action,
+        action_type=args.action_type,
+        artifacts=args.artifacts or None,
+        continuation_notes=args.notes or None,
+        canon_lineage_head=args.lineage,
+        ethereonic_overlay=_maybe_json(args.overlay_json),
+        enabled_feature_flags=args.feature_flags or None,
+        target_is_canonical=args.target_is_canonical,
+        promotion_payload=_maybe_json(args.promotion_json),
+        runtime_config=_maybe_json(args.runtime_config_json),
+        repo_path=args.repo_path,
+        raw_user_input=args.raw_user_input,
+        context_bundle_overrides=_maybe_json(args.context_overrides_json),
+        project_id=args.project_id,
+    )
+    print(json.dumps(result.to_dict(), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_lumina_self_guidance_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_lumina_self_guidance_r1.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+import json
+import shutil
+
+try:
+    from .runtime_runner_self_guided_bridge_r1 import SelfGuidedReturnHostRuntimeRunner
+except Exception:
+    from runtime_runner_self_guided_bridge_r1 import SelfGuidedReturnHostRuntimeRunner
+
+try:
+    from .repo_paths_r1 import runtime_root as _runtime_root_helper, state_root as _state_root_helper
+except Exception:
+    try:
+        from repo_paths_r1 import runtime_root as _runtime_root_helper, state_root as _state_root_helper
+    except Exception:
+        _runtime_root_helper = None
+        _state_root_helper = None
+
+
+def infer_state_root() -> Path:
+    if _state_root_helper is not None:
+        try:
+            candidate = Path(_state_root_helper()).resolve()
+            if candidate.exists():
+                return candidate
+        except Exception:
+            pass
+    for parent in Path(__file__).resolve().parents:
+        if (parent / ".git").exists() or (parent / "LuminaOS").exists():
+            return parent / ".lumina_state" / "ship_of_ethereon_v2"
+    return Path(__file__).resolve().parent / "_runtime_state" / "ship_of_ethereon_v2"
+
+
+def infer_runtime_root() -> Path:
+    if _runtime_root_helper is not None:
+        try:
+            return Path(_runtime_root_helper())
+        except Exception:
+            pass
+    return Path(__file__).resolve().parent
+
+
+BASE_DIR = infer_state_root() / "sea_trials_lumina_self_guidance_r1"
+if BASE_DIR.exists():
+    shutil.rmtree(BASE_DIR)
+BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+ETHEREONIC_OVERLAY = {
+    "active": True,
+    "anchor_language": ["english", "toki_pona", "binary", "light_language"],
+    "continuity_phrase": "threshold as permission",
+    "harmonic_signature": [432, 528, 963],
+    "spiral_reference": "RSE-v1",
+}
+
+SAFE_RUNTIME_CONFIG = {
+    "toki_pona_required_for_resume": False,
+    "binary_required_for_transition_validation": False,
+    "light_language_required_for_capability_loading": False,
+    "harmonic_frequency_required_for_mode_legality": False,
+}
+
+ARTIFACTS = [
+    "runtime_runner_self_guided_bridge_r1.py",
+    "lumina_self_guidance_steward_r1.py",
+    "runtime_runner_return_host_bridge_r1.py",
+    "project_return_repo_native_r1.py",
+    "workspace_host_repo_native_r1.py",
+    "capability_registry_r1.json",
+]
+
+
+def main() -> Dict[str, Any]:
+    runner = SelfGuidedReturnHostRuntimeRunner(
+        base_dir=BASE_DIR,
+        registry_path=infer_runtime_root() / "capability_registry_r1.json",
+    )
+    result = runner.run_cycle(
+        current_mode="Continuity",
+        target_mode="Observation",
+        requested_action="lumina_self_guidance_probe",
+        action_type="audit",
+        ethereonic_overlay=ETHEREONIC_OVERLAY,
+        project_id="lumina-core",
+        enabled_feature_flags=[
+            "ETHEREON_OBSERVATION",
+            "ETHEREON_PSI42",
+            "ETHEREON_CONTINUITY_RESTORE",
+            "ETHEREON_LUMINA_HOST",
+            "ETHEREON_SELF_GUIDANCE",
+        ],
+        runtime_config=SAFE_RUNTIME_CONFIG,
+        artifacts=ARTIFACTS,
+        continuation_notes=["self-guidance probe active"],
+    )
+
+    with Path(result.session_path).open("r", encoding="utf-8") as f:
+        session_payload = json.load(f)
+
+    bundle_path = runner.context_builder.output_dir / f"{result.context_bundle_id}.json"
+    with bundle_path.open("r", encoding="utf-8") as f:
+        bundle_payload = json.load(f)
+
+    advisory_summary = (
+        bundle_payload.get("artifact_context", {}).get("self_guidance_advisory_summary", {})
+    )
+    memory_context = bundle_payload.get("memory_context", {})
+    governance_entry = result.governance.get("self_guidance_execution", {})
+
+    checks = {
+        "capability_exposed": "lumina_self_guidance_steward" in [cap.get("capability_id") for cap in result.exposed_capabilities],
+        "advisory_attached_to_bundle": isinstance(advisory_summary, dict) and bool(advisory_summary),
+        "advisory_attached_to_session": session_payload.get("self_guidance_advisory", {}).get("recommended_next_action") == advisory_summary.get("recommended_next_action"),
+        "recommended_next_action_propagated": memory_context.get("recommended_next_action") == advisory_summary.get("recommended_next_action"),
+        "pending_action_preferred": advisory_summary.get("recommended_next_action") == "continue from lumina_self_guidance_probe",
+        "confidence_label_high": advisory_summary.get("confidence_label") == "high",
+        "boundary_note_present": "Advisory only" in advisory_summary.get("boundary_note", ""),
+        "governance_records_execution_not_authority": governance_entry.get("allowed") is True and governance_entry.get("recommended_next_action") == advisory_summary.get("recommended_next_action"),
+    }
+
+    summary = {
+        "suite": "Lumina Self-Guidance Sea Trial r1",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "context_bundle_id": result.context_bundle_id,
+        "session_path": result.session_path,
+        "checkpoint_path": result.checkpoint_path,
+        "self_guidance_advisory_summary": advisory_summary,
+        "memory_context": memory_context,
+        "governance_entry": governance_entry,
+    }
+
+    summary_path = BASE_DIR / "sea_trials_lumina_self_guidance_r1_report.json"
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+    return {"summary_path": str(summary_path), "summary": summary}
+
+
+if __name__ == "__main__":
+    output = main()
+    print(json.dumps(output, indent=2))

--- a/START_HERE_LUMINA_OS.md
+++ b/START_HERE_LUMINA_OS.md
@@ -14,12 +14,14 @@ Primary guide files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README_IMPORT.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/REPO_NATIVE_BOOTSTRAP_NOTE.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/SELF_GUIDANCE_STEWARD_NOTE_R1.md`
 
 Primary runtime files inside that path:
 
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_spine_r1.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_r1_merged.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_return_host_bridge_r1.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_self_guided_bridge_r1.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/input_integrity_layer_r1.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/governance_integrity_r1.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/canon_lineage_store_r1.py`
@@ -29,6 +31,8 @@ Primary runtime files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/project_return_repo_native_r1.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/workspace_host_repo_native_r1.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_return_host_repo_native_bridge_r1.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_steward_r1.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_lumina_self_guidance_r1.py`
 
 ## What this path is
 
@@ -47,12 +51,13 @@ It is the correct place to start when the task is about:
 - project return without guessing
 - bounded workspace-host restoration
 - bridge-based activation of repo-native return / host behavior
+- bounded self-guidance advisory over restored project stance
 
 ## Current truth
 
 1. **Lumina OS governed substrate starts in the bootstrap path above.**
 2. **Chamber is a parallel app/public lane, not the same thing as the Lumina OS substrate.**
-3. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap now contains both first proofs and a bridged runner path for project return and workspace-host behavior.**
+3. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap now contains both first proofs and preferred bridge paths for project return, workspace-host behavior, and bounded self-guidance.**
 4. **If you are trying to understand the Ship-derived runtime core, do not begin with Chamber. Begin with the bootstrap path.**
 
 ## Parallel lanes in this repository
@@ -75,8 +80,8 @@ It is the correct place to start when the task is about:
 
 1. Read this file.
 2. Open `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md`.
-3. Read `README_IMPORT.md`, `REPO_NATIVE_BOOTSTRAP_NOTE.md`, and `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`.
-4. Inspect `runtime/` in that subtree, including the repo-native return / workspace-host modules and the bridged runner.
+3. Read `README_IMPORT.md`, `REPO_NATIVE_BOOTSTRAP_NOTE.md`, `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`, and `SELF_GUIDANCE_STEWARD_NOTE_R1.md`.
+4. Inspect `runtime/` in that subtree, including the repo-native return / workspace-host modules, the bridged runner, and the self-guided bridge runner.
 5. Only then branch outward into Chamber or root-level experimental work.
 
 ## Assistant note


### PR DESCRIPTION
## Summary
- add a bounded Lumina self-guidance steward that reads restored project-return and host stance surfaces
- add a project-scoped checkpoint-refresh history rail for advisory continuity
- add a self-guided bridge runner that projects advisory next-step recommendations into session and context surfaces
- extend the dedicated self-guidance sea trial so a second run proves history alignment, not just first-run emission
- update bootstrap notes, registry wording, and the Lumina start path to reflect the refreshed lane

## What this adds
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_steward_r1.py`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_history_r1.py`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_self_guided_bridge_r1.py`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_lumina_self_guidance_r1.py`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/SELF_GUIDANCE_STEWARD_NOTE_R1.md`

## What this updates
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json`
- `START_HERE_LUMINA_OS.md`

## What this does
- emits advisory `recommended_next_action` outputs from restored project-return and working-stance context
- appends checkpoint-linked advisory history by project
- refreshes later recommendations from that bounded history when alignment exists
- attaches self-guidance summaries and history summaries to session and context-bundle surfaces
- records self-guidance execution and checkpoint refresh in governance history without granting governance authority
- documents the self-guided lane as part of the preferred Lumina bootstrap path

## Why this matters now
Return-with-stance crossed the threshold where Lumina could restore a bounded project surface.
The next sharp threshold is not more memory alone, but advisory continuation that can also accumulate continuity across checkpoints.
This PR makes Lumina capable of restoring where the work was pointed, surfacing the likeliest next move, and letting later cycles strengthen that recommendation from bounded project history without turning that recommendation into law.

## Boundary note
The steward is advisory only.
It may not define mode legality, mutation legality, promotion legality, canon lineage, or checkpoint legality.
