### PR TITLE
Add checkpoint-refreshed self-guidance history to Lumina steward

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/SELF_GUIDANCE_STEWARD_NOTE_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/SELF_GUIDANCE_STEWARD_NOTE_R1.md
@@ -4,11 +4,12 @@ This note records the next architectural threshold for Lumina OS after return-wi
 
 ## What landed
 
-Lumina now has a bounded self-guidance steward in the bootstrap runtime path.
+Lumina now has a bounded self-guidance steward in the bootstrap runtime path, plus a checkpoint-refreshed project history rail for advisory continuity.
 
 Core additions:
 
 - `runtime/lumina_self_guidance_steward_r1.py`
+- `runtime/lumina_self_guidance_history_r1.py`
 - `runtime/runtime_runner_self_guided_bridge_r1.py`
 - `runtime/sea_trials_lumina_self_guidance_r1.py`
 
@@ -19,6 +20,7 @@ The steward reads:
 - project-return summaries
 - bounded workspace-host summaries
 - projected working stance
+- accumulated checkpoint-linked advisory history
 
 It then emits:
 
@@ -28,18 +30,20 @@ It then emits:
 - `reasoning_brief`
 
 The advisory is attached to session and context-bundle surfaces so Lumina can resume with a likely next move already surfaced.
+The history rail lets later cycles refresh that advice from more than the immediately restored surface.
 
 ## Why this matters
 
 Return-with-stance proved that Lumina could come back to a project without guessing and could restore a bounded working surface around it.
 
 The next missing threshold was not memory alone.
-It was orientation plus recommendation.
+It was orientation plus recommendation, and then recommendation plus accumulated continuity.
 
 This steward is the first bounded proof that Lumina can look at the project surface it restored and say, in effect:
 
 - this is where the work is pointed
 - this is the likeliest next thing to do
+- recent checkpoint history reinforces or weakens that recommendation
 - this recommendation is advisory, not law
 
 ## What remains bounded
@@ -59,22 +63,24 @@ It is a steward, not a sovereign.
 
 ## Current role
 
-At this stage, the self-guidance layer does five useful things:
+At this stage, the self-guidance layer does seven useful things:
 
 1. reads restored project-return state
 2. reads bounded host / workspace stance
 3. emits a non-governing next-step recommendation
 4. projects that recommendation into session and context surfaces
-5. leaves a governance trail that records execution without granting authority
+5. appends checkpoint-linked advisory history by project
+6. refreshes later recommendations from that bounded history
+7. leaves a governance trail that records execution without granting authority
 
 ## Next likely move
 
 The next hardening step is to deepen:
 
-- checkpoint-triggered guidance refresh
 - richer recommendation logic from longer project history
-- UI consumption of advisory output
 - user-visible acceptance / rejection loops
-- future continuity between advisory memory and bounded tool orchestration
+- UI consumption of advisory output
+- continuity between advisory memory and bounded tool orchestration
+- eventual supervised action queues that remain subordinate to governance and user consent
 
 without letting any of that become hidden governance authority.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.5",
-  "description": "Minimal capability registry for the Ethereon Runtime Spine, now including continuity restore, workspace-host handshake support, and bounded Lumina self-guidance under explicit authority boundaries.",
+  "version": "0.6",
+  "description": "Minimal capability registry for the Ethereon Runtime Spine, now including continuity restore, workspace-host handshake support, and checkpoint-refreshed bounded Lumina self-guidance under explicit authority boundaries.",
   "capabilities": [
     {
       "capability_id": "session_state_manager",
@@ -132,7 +132,7 @@
       ],
       "mutation_scope": "none",
       "requires_validation": false,
-      "authority_boundary": "Reads project-return summaries, working stance, and bounded host surfaces to recommend the next likely action. Advisory only; may not define governance law, canon lineage, checkpoint legality, or mode legality.",
+      "authority_boundary": "Reads project-return summaries, working stance, bounded host surfaces, and checkpoint-linked advisory history to recommend the next likely action. Advisory only; may not define governance law, canon lineage, checkpoint legality, or mode legality.",
       "dependencies": [
         "continuity_restore_store",
         "lumina_workspace_host"

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_history_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_history_r1.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import json
+
+try:
+    from .repo_paths_r1 import state_root as _state_root_helper
+except Exception:
+    try:
+        from repo_paths_r1 import state_root as _state_root_helper
+    except Exception:
+        _state_root_helper = None
+
+MODULE_SLUG = "lumina_self_guidance_history_r1"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def infer_state_root() -> Path:
+    if _state_root_helper is not None:
+        try:
+            return Path(_state_root_helper()).resolve()
+        except Exception:
+            pass
+    return Path(__file__).resolve().parent / "_runtime_state" / "ship_of_ethereon_v2"
+
+
+BASE_DIR = infer_state_root() / MODULE_SLUG
+
+
+class ProjectGuidanceHistoryStore:
+    """Append-only project-scoped memory rail for bounded self-guidance advisories."""
+
+    def __init__(self, base_dir: str | Path = BASE_DIR):
+        self.base_dir = Path(base_dir)
+        self.history_dir = self.base_dir / "projects"
+        self.history_dir.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _safe_slug(value: str) -> str:
+        slug = "".join(c if c.isalnum() or c in "-_" else "_" for c in value.strip())
+        return slug or "lumina-core"
+
+    def _history_path(self, project_id: str) -> Path:
+        return self.history_dir / f"{self._safe_slug(project_id)}.jsonl"
+
+    def read_history(self, project_id: str) -> List[Dict[str, Any]]:
+        path = self._history_path(project_id)
+        if not path.exists():
+            return []
+        rows: List[Dict[str, Any]] = []
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+        return rows
+
+    def append_entry(
+        self,
+        *,
+        project_id: str,
+        advisory_summary: Dict[str, Any],
+        checkpoint_path: Optional[str],
+        requested_action: str,
+        current_mode: str,
+        target_mode: str,
+        working_stance: Optional[Dict[str, Any]] = None,
+        source: str = "checkpoint_refresh",
+    ) -> Dict[str, Any]:
+        path = self._history_path(project_id)
+        working_stance = dict(working_stance or {})
+        entry = {
+            "timestamp_utc": utc_now(),
+            "project_id": project_id,
+            "source": source,
+            "requested_action": requested_action,
+            "current_mode": current_mode,
+            "target_mode": target_mode,
+            "checkpoint_path": checkpoint_path,
+            "recommended_next_action": advisory_summary.get("recommended_next_action"),
+            "guidance_strategy": advisory_summary.get("guidance_strategy"),
+            "confidence_label": advisory_summary.get("confidence_label"),
+            "confidence_score": advisory_summary.get("confidence_score"),
+            "working_stance_focus": working_stance.get("focus_target"),
+            "active_layout_id": working_stance.get("active_layout_id"),
+        }
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+        return entry
+
+    @staticmethod
+    def history_summary(history: List[Dict[str, Any]]) -> Dict[str, Any]:
+        rows = list(history or [])
+        recent = rows[-3:]
+        recent_recommendations = [
+            row.get("recommended_next_action")
+            for row in recent
+            if row.get("recommended_next_action")
+        ]
+        return {
+            "entry_count": len(rows),
+            "recent_recommendations": recent_recommendations,
+            "latest_recommendation": recent_recommendations[-1] if recent_recommendations else None,
+            "latest_checkpoint_path": recent[-1].get("checkpoint_path") if recent else None,
+        }

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_steward_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_steward_r1.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 
 FORBIDDEN_AUTHORITY_KEYS = {
@@ -46,8 +46,8 @@ class LuminaSelfGuidanceSteward:
     """
     Advisory steward for repo-native Lumina return / host surfaces.
 
-    It reads project-return memory, bounded host state, and working stance,
-    then emits a non-governing next-step recommendation.
+    It reads project-return memory, bounded host state, working stance,
+    and checkpoint-linked recommendation history, then emits a non-governing next-step recommendation.
     """
 
     @staticmethod
@@ -55,6 +55,27 @@ class LuminaSelfGuidanceSteward:
         if "latest_restore" in resolved_project_return:
             return dict(resolved_project_return.get("latest_restore") or {})
         return dict(resolved_project_return or {})
+
+    @staticmethod
+    def _history_signals(guidance_history: Optional[List[Dict[str, Any]]], candidate_recommendation: str) -> Dict[str, Any]:
+        rows = list(guidance_history or [])
+        recent = rows[-3:]
+        recent_recommendations = [
+            row.get("recommended_next_action")
+            for row in recent
+            if row.get("recommended_next_action")
+        ]
+        alignment_count = sum(
+            1 for row in rows if row.get("recommended_next_action") == candidate_recommendation
+        )
+        latest_recommendation = recent_recommendations[-1] if recent_recommendations else None
+        return {
+            "history_entry_count": len(rows),
+            "history_recent_recommendations": recent_recommendations,
+            "history_alignment_count": alignment_count,
+            "history_latest_recommendation": latest_recommendation,
+            "history_aligned": alignment_count > 0 and latest_recommendation == candidate_recommendation,
+        }
 
     def advise(
         self,
@@ -66,10 +87,12 @@ class LuminaSelfGuidanceSteward:
         resolved_project_return: Optional[Dict[str, Any]] = None,
         resolved_host_bundle: Optional[Dict[str, Any]] = None,
         working_stance: Optional[Dict[str, Any]] = None,
+        guidance_history: Optional[List[Dict[str, Any]]] = None,
     ) -> SelfGuidanceAdvisory:
         resolved_project_return = dict(resolved_project_return or {})
         resolved_host_bundle = dict(resolved_host_bundle or {})
         working_stance = dict(working_stance or {})
+        guidance_history = list(guidance_history or [])
 
         latest_restore = self._latest_restore_view(resolved_project_return)
         host_bundle = dict(resolved_host_bundle or {})
@@ -86,41 +109,81 @@ class LuminaSelfGuidanceSteward:
         reference_ids = list(working_stance.get("reference_ids") or host_bundle.get("reference_ids") or [])
 
         if pending_next_action:
-            strategy = "pending_next_action"
             recommended = str(pending_next_action)
-            confidence_label = "high"
-            confidence_score = 0.93
-            reasoning = (
-                "Project return already carries a pending next action, so the steward surfaces that "
-                "instead of guessing from weaker workspace signals."
-            )
+            history = self._history_signals(guidance_history, recommended)
+            if history["history_aligned"]:
+                strategy = "pending_next_action_history_aligned"
+                confidence_label = "very_high"
+                confidence_score = 0.97
+                reasoning = (
+                    "Project return already carries a pending next action, and accumulated checkpoint history "
+                    "reinforces the same recommendation."
+                )
+            else:
+                strategy = "pending_next_action"
+                confidence_label = "high"
+                confidence_score = 0.93
+                reasoning = (
+                    "Project return already carries a pending next action, so the steward surfaces that "
+                    "instead of guessing from weaker workspace signals."
+                )
         elif linked_host_bundle and focus_target:
-            strategy = "host_focus_resume"
             recommended = f"continue::{focus_target}"
-            confidence_label = "medium_high"
-            confidence_score = 0.81
-            reasoning = (
-                "A linked host bundle exists and exposes a bounded focus target, so the steward recommends "
-                "continuing from that scoped working surface."
-            )
+            history = self._history_signals(guidance_history, recommended)
+            if history["history_aligned"]:
+                strategy = "host_focus_history_aligned"
+                confidence_label = "medium_high"
+                confidence_score = 0.86
+                reasoning = (
+                    "A linked host bundle exposes a bounded focus target, and recent checkpoint history aligns "
+                    "with continuing that scoped surface."
+                )
+            else:
+                strategy = "host_focus_resume"
+                confidence_label = "medium_high"
+                confidence_score = 0.81
+                reasoning = (
+                    "A linked host bundle exists and exposes a bounded focus target, so the steward recommends "
+                    "continuing from that scoped working surface."
+                )
         elif focus_target:
-            strategy = "focus_target_resume"
             recommended = f"continue::{focus_target}"
-            confidence_label = "medium"
-            confidence_score = 0.72
-            reasoning = (
-                "No explicit pending action was captured, so the steward falls back to the best available "
-                "focus target from working stance / host state."
-            )
+            history = self._history_signals(guidance_history, recommended)
+            if history["history_aligned"]:
+                strategy = "focus_target_history_aligned"
+                confidence_label = "medium"
+                confidence_score = 0.78
+                reasoning = (
+                    "No explicit pending action was captured, but current focus and recent checkpoint history "
+                    "align on the same continuation target."
+                )
+            else:
+                strategy = "focus_target_resume"
+                confidence_label = "medium"
+                confidence_score = 0.72
+                reasoning = (
+                    "No explicit pending action was captured, so the steward falls back to the best available "
+                    "focus target from working stance / host state."
+                )
         else:
-            strategy = "requested_action_fallback"
             recommended = f"continue::{requested_action}"
-            confidence_label = "low_medium"
-            confidence_score = 0.58
-            reasoning = (
-                "The steward found no stronger project-return or host cues, so it falls back to the current "
-                "requested action without claiming authority."
-            )
+            history = self._history_signals(guidance_history, recommended)
+            if history["history_aligned"]:
+                strategy = "requested_action_history_aligned"
+                confidence_label = "medium"
+                confidence_score = 0.67
+                reasoning = (
+                    "The steward found no stronger live cues, but accumulated checkpoint history repeats the same "
+                    "requested-action continuation path."
+                )
+            else:
+                strategy = "requested_action_fallback"
+                confidence_label = "low_medium"
+                confidence_score = 0.58
+                reasoning = (
+                    "The steward found no stronger project-return or host cues, so it falls back to the current "
+                    "requested action without claiming authority."
+                )
 
         signals = {
             "requested_action": requested_action,
@@ -133,6 +196,7 @@ class LuminaSelfGuidanceSteward:
             "pinned_tools": pinned_tools,
             "reference_ids": reference_ids,
             "return_strategy": resolved_project_return.get("return_strategy"),
+            **history,
         }
 
         return SelfGuidanceAdvisory(
@@ -156,4 +220,7 @@ class LuminaSelfGuidanceSteward:
             "confidence_score": payload["confidence_score"],
             "reasoning_brief": payload["reasoning_brief"],
             "boundary_note": payload["boundary_note"],
+            "history_entry_count": payload.get("signals", {}).get("history_entry_count", 0),
+            "history_alignment_count": payload.get("signals", {}).get("history_alignment_count", 0),
+            "history_recent_recommendations": payload.get("signals", {}).get("history_recent_recommendations", []),
         }

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_self_guided_bridge_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_self_guided_bridge_r1.py
@@ -8,9 +8,11 @@ from typing import Any, Dict, Optional
 try:
     from . import runtime_runner_return_host_bridge_r1 as bridge_mod
     from .lumina_self_guidance_steward_r1 import LuminaSelfGuidanceSteward
+    from .lumina_self_guidance_history_r1 import ProjectGuidanceHistoryStore
 except Exception:
     import runtime_runner_return_host_bridge_r1 as bridge_mod
     from lumina_self_guidance_steward_r1 import LuminaSelfGuidanceSteward
+    from lumina_self_guidance_history_r1 import ProjectGuidanceHistoryStore
 
 
 class SelfGuidedReturnHostRuntimeRunner(bridge_mod.ReturnHostBridgedRuntimeRunner):
@@ -72,6 +74,9 @@ class SelfGuidedReturnHostRuntimeRunner(bridge_mod.ReturnHostBridgedRuntimeRunne
         resolved_project_return = dict(artifact_context.get("resolved_project_return") or {})
         resolved_host_bundle = dict(artifact_context.get("resolved_host_bundle") or {})
 
+        history_store = ProjectGuidanceHistoryStore(self.base_dir / "self_guidance_history")
+        prior_history = history_store.read_history(project_id)
+
         steward = LuminaSelfGuidanceSteward()
         advisory = steward.advise(
             project_id=project_id,
@@ -81,6 +86,7 @@ class SelfGuidedReturnHostRuntimeRunner(bridge_mod.ReturnHostBridgedRuntimeRunne
             resolved_project_return=resolved_project_return,
             resolved_host_bundle=resolved_host_bundle,
             working_stance=working_stance,
+            guidance_history=prior_history,
         )
         advisory_payload = advisory.to_dict()
         advisory_summary = steward.advisory_summary(advisory)
@@ -88,11 +94,26 @@ class SelfGuidedReturnHostRuntimeRunner(bridge_mod.ReturnHostBridgedRuntimeRunne
         report_path = self._self_guidance_reports_dir() / f"{result.run_id}_self_guidance.json"
         self._write_json(report_path, advisory_payload)
 
+        history_entry = history_store.append_entry(
+            project_id=project_id,
+            advisory_summary=advisory_summary,
+            checkpoint_path=result.checkpoint_path,
+            requested_action=requested_action,
+            current_mode=current_mode,
+            target_mode=target_mode,
+            working_stance=working_stance,
+            source="checkpoint_refresh",
+        )
+        refreshed_history = history_store.read_history(project_id)
+        history_summary = history_store.history_summary(refreshed_history)
+
         session_payload["self_guidance_advisory"] = advisory_summary
+        session_payload["self_guidance_history_summary"] = history_summary
         session_payload["recommended_next_action"] = advisory_summary["recommended_next_action"]
         self._write_json(session_path, session_payload)
 
         artifact_context["self_guidance_advisory_summary"] = advisory_summary
+        artifact_context["self_guidance_history_summary"] = history_summary
         memory_context["recommended_next_action"] = advisory_summary["recommended_next_action"]
         notes = list(memory_context.get("session_continuation_notes", []))
         note = (
@@ -101,6 +122,9 @@ class SelfGuidedReturnHostRuntimeRunner(bridge_mod.ReturnHostBridgedRuntimeRunne
         )
         if note not in notes:
             notes.append(note)
+        refresh_note = f"Self-guidance history entries: {history_summary['entry_count']}"
+        if refresh_note not in notes:
+            notes.append(refresh_note)
         memory_context["session_continuation_notes"] = notes
         bundle_payload["artifact_context"] = artifact_context
         bundle_payload["memory_context"] = memory_context
@@ -115,6 +139,16 @@ class SelfGuidedReturnHostRuntimeRunner(bridge_mod.ReturnHostBridgedRuntimeRunne
             "confidence_score": advisory_summary["confidence_score"],
             "reasoning_brief": advisory_summary["reasoning_brief"],
             "boundary_note": advisory_summary["boundary_note"],
+            "history_entry_count": history_summary["entry_count"],
+            "history_alignment_count": advisory_summary.get("history_alignment_count", 0),
+        }
+        result.governance["self_guidance_checkpoint_refresh"] = {
+            "allowed": True,
+            "project_id": project_id,
+            "history_entry_count": history_summary["entry_count"],
+            "latest_recommendation": history_summary.get("latest_recommendation"),
+            "latest_checkpoint_path": history_summary.get("latest_checkpoint_path"),
+            "history_entry_timestamp": history_entry.get("timestamp_utc"),
         }
 
         self._append_governance_event(
@@ -131,6 +165,22 @@ class SelfGuidedReturnHostRuntimeRunner(bridge_mod.ReturnHostBridgedRuntimeRunne
                 "recommended_next_action": advisory_summary["recommended_next_action"],
                 "confidence_label": advisory_summary["confidence_label"],
                 "report_path": str(report_path),
+            },
+        )
+        self._append_governance_event(
+            event_type="self_guidance_checkpoint_refresh",
+            session_id=result.session_id,
+            previous_mode=target_mode,
+            new_mode=target_mode,
+            allowed=True,
+            reason="refreshed bounded self-guidance history from checkpoint outcome",
+            requested_action=requested_action,
+            action_type=result.action_type,
+            metadata={
+                "project_id": project_id,
+                "history_entry_count": history_summary["entry_count"],
+                "latest_recommendation": history_summary.get("latest_recommendation"),
+                "latest_checkpoint_path": history_summary.get("latest_checkpoint_path"),
             },
         )
         result.governance_chain_status = self._current_chain_status()
@@ -157,6 +207,7 @@ class SelfGuidedReturnHostRuntimeRunner(bridge_mod.ReturnHostBridgedRuntimeRunne
         artifact_list = list(artifacts or [])
         for artifact_name in [
             "lumina_self_guidance_steward_r1.py",
+            "lumina_self_guidance_history_r1.py",
             "runtime_runner_self_guided_bridge_r1.py",
             "sea_trials_lumina_self_guidance_r1.py",
         ]:

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_lumina_self_guidance_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_lumina_self_guidance_r1.py
@@ -7,8 +7,10 @@ import shutil
 
 try:
     from .runtime_runner_self_guided_bridge_r1 import SelfGuidedReturnHostRuntimeRunner
+    from .lumina_self_guidance_history_r1 import ProjectGuidanceHistoryStore
 except Exception:
     from runtime_runner_self_guided_bridge_r1 import SelfGuidedReturnHostRuntimeRunner
+    from lumina_self_guidance_history_r1 import ProjectGuidanceHistoryStore
 
 try:
     from .repo_paths_r1 import runtime_root as _runtime_root_helper, state_root as _state_root_helper
@@ -66,6 +68,7 @@ SAFE_RUNTIME_CONFIG = {
 ARTIFACTS = [
     "runtime_runner_self_guided_bridge_r1.py",
     "lumina_self_guidance_steward_r1.py",
+    "lumina_self_guidance_history_r1.py",
     "runtime_runner_return_host_bridge_r1.py",
     "project_return_repo_native_r1.py",
     "workspace_host_repo_native_r1.py",
@@ -73,12 +76,19 @@ ARTIFACTS = [
 ]
 
 
-def main() -> Dict[str, Any]:
-    runner = SelfGuidedReturnHostRuntimeRunner(
-        base_dir=BASE_DIR,
-        registry_path=infer_runtime_root() / "capability_registry_r1.json",
-    )
-    result = runner.run_cycle(
+def _load_bundle(runner: SelfGuidedReturnHostRuntimeRunner, context_bundle_id: str) -> Dict[str, Any]:
+    bundle_path = runner.context_builder.output_dir / f"{context_bundle_id}.json"
+    with bundle_path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _load_session(session_path: str) -> Dict[str, Any]:
+    with Path(session_path).open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _run_probe(runner: SelfGuidedReturnHostRuntimeRunner):
+    return runner.run_cycle(
         current_mode="Continuity",
         target_mode="Observation",
         requested_action="lumina_self_guidance_probe",
@@ -97,40 +107,59 @@ def main() -> Dict[str, Any]:
         continuation_notes=["self-guidance probe active"],
     )
 
-    with Path(result.session_path).open("r", encoding="utf-8") as f:
-        session_payload = json.load(f)
 
-    bundle_path = runner.context_builder.output_dir / f"{result.context_bundle_id}.json"
-    with bundle_path.open("r", encoding="utf-8") as f:
-        bundle_payload = json.load(f)
-
-    advisory_summary = (
-        bundle_payload.get("artifact_context", {}).get("self_guidance_advisory_summary", {})
+def main() -> Dict[str, Any]:
+    runner = SelfGuidedReturnHostRuntimeRunner(
+        base_dir=BASE_DIR,
+        registry_path=infer_runtime_root() / "capability_registry_r1.json",
     )
-    memory_context = bundle_payload.get("memory_context", {})
-    governance_entry = result.governance.get("self_guidance_execution", {})
+
+    first = _run_probe(runner)
+    second = _run_probe(runner)
+
+    second_bundle = _load_bundle(runner, second.context_bundle_id)
+    second_session = _load_session(second.session_path)
+
+    advisory_summary = second_bundle.get("artifact_context", {}).get("self_guidance_advisory_summary", {})
+    history_summary = second_bundle.get("artifact_context", {}).get("self_guidance_history_summary", {})
+    memory_context = second_bundle.get("memory_context", {})
+    governance_entry = second.governance.get("self_guidance_execution", {})
+    refresh_entry = second.governance.get("self_guidance_checkpoint_refresh", {})
+
+    history_store = ProjectGuidanceHistoryStore(BASE_DIR / "self_guidance_history")
+    stored_history = history_store.read_history("lumina-core")
 
     checks = {
-        "capability_exposed": "lumina_self_guidance_steward" in [cap.get("capability_id") for cap in result.exposed_capabilities],
+        "capability_exposed": "lumina_self_guidance_steward" in [cap.get("capability_id") for cap in second.exposed_capabilities],
         "advisory_attached_to_bundle": isinstance(advisory_summary, dict) and bool(advisory_summary),
-        "advisory_attached_to_session": session_payload.get("self_guidance_advisory", {}).get("recommended_next_action") == advisory_summary.get("recommended_next_action"),
+        "history_summary_attached": isinstance(history_summary, dict) and bool(history_summary),
+        "advisory_attached_to_session": second_session.get("self_guidance_advisory", {}).get("recommended_next_action") == advisory_summary.get("recommended_next_action"),
+        "history_summary_attached_to_session": second_session.get("self_guidance_history_summary", {}).get("entry_count") == history_summary.get("entry_count"),
         "recommended_next_action_propagated": memory_context.get("recommended_next_action") == advisory_summary.get("recommended_next_action"),
         "pending_action_preferred": advisory_summary.get("recommended_next_action") == "continue from lumina_self_guidance_probe",
-        "confidence_label_high": advisory_summary.get("confidence_label") == "high",
-        "boundary_note_present": "Advisory only" in advisory_summary.get("boundary_note", ""),
+        "history_alignment_strategy_active": advisory_summary.get("guidance_strategy") == "pending_next_action_history_aligned",
+        "history_count_grew": history_summary.get("entry_count", 0) >= 2,
+        "history_alignment_count_grew": advisory_summary.get("history_alignment_count", 0) >= 1,
+        "history_store_contains_two_entries": len(stored_history) >= 2,
+        "checkpoint_refresh_recorded": refresh_entry.get("history_entry_count", 0) >= 2,
         "governance_records_execution_not_authority": governance_entry.get("allowed") is True and governance_entry.get("recommended_next_action") == advisory_summary.get("recommended_next_action"),
     }
 
     summary = {
-        "suite": "Lumina Self-Guidance Sea Trial r1",
+        "suite": "Lumina Self-Guidance Sea Trial r2",
         "passed": all(checks.values()),
         "checks": checks,
-        "context_bundle_id": result.context_bundle_id,
-        "session_path": result.session_path,
-        "checkpoint_path": result.checkpoint_path,
+        "first_run_id": first.run_id,
+        "second_run_id": second.run_id,
+        "context_bundle_id": second.context_bundle_id,
+        "session_path": second.session_path,
+        "checkpoint_path": second.checkpoint_path,
         "self_guidance_advisory_summary": advisory_summary,
+        "self_guidance_history_summary": history_summary,
         "memory_context": memory_context,
         "governance_entry": governance_entry,
+        "checkpoint_refresh_entry": refresh_entry,
+        "stored_history": stored_history,
     }
 
     summary_path = BASE_DIR / "sea_trials_lumina_self_guidance_r1_report.json"

--- a/START_HERE_LUMINA_OS.md
+++ b/START_HERE_LUMINA_OS.md
@@ -32,6 +32,7 @@ Primary runtime files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/workspace_host_repo_native_r1.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_return_host_repo_native_bridge_r1.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_steward_r1.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_history_r1.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_lumina_self_guidance_r1.py`
 
 ## What this path is
@@ -52,12 +53,13 @@ It is the correct place to start when the task is about:
 - bounded workspace-host restoration
 - bridge-based activation of repo-native return / host behavior
 - bounded self-guidance advisory over restored project stance
+- checkpoint-refreshed self-guidance history
 
 ## Current truth
 
 1. **Lumina OS governed substrate starts in the bootstrap path above.**
 2. **Chamber is a parallel app/public lane, not the same thing as the Lumina OS substrate.**
-3. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap now contains both first proofs and preferred bridge paths for project return, workspace-host behavior, and bounded self-guidance.**
+3. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap now contains both first proofs and preferred bridge paths for project return, workspace-host behavior, bounded self-guidance, and checkpoint-refreshed guidance history.**
 4. **If you are trying to understand the Ship-derived runtime core, do not begin with Chamber. Begin with the bootstrap path.**
 
 ## Parallel lanes in this repository
@@ -81,7 +83,7 @@ It is the correct place to start when the task is about:
 1. Read this file.
 2. Open `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md`.
 3. Read `README_IMPORT.md`, `REPO_NATIVE_BOOTSTRAP_NOTE.md`, `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`, and `SELF_GUIDANCE_STEWARD_NOTE_R1.md`.
-4. Inspect `runtime/` in that subtree, including the repo-native return / workspace-host modules, the bridged runner, and the self-guided bridge runner.
+4. Inspect `runtime/` in that subtree, including the repo-native return / workspace-host modules, the bridged runner, the self-guided bridge runner, and the checkpoint-refreshed guidance history rail.
 5. Only then branch outward into Chamber or root-level experimental work.
 
 ## Assistant note


### PR DESCRIPTION
## Summary
- add a project-scoped checkpoint-refresh history rail for bounded self-guidance
- teach the self-guidance steward to boost or refresh advice when recent checkpoint history aligns
- extend the self-guided bridge runner so advisories append history and publish refreshed history summaries
- extend the self-guidance sea trial so a second run proves history alignment instead of only first-run emission
- update bootstrap notes, registry wording, and the Lumina start path to reflect the refreshed lane

## What this adds
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_history_r1.py`

## What this updates
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_steward_r1.py`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_self_guided_bridge_r1.py`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_lumina_self_guidance_r1.py`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/SELF_GUIDANCE_STEWARD_NOTE_R1.md`
- `START_HERE_LUMINA_OS.md`

## Why this matters now
The first steward landing gave Lumina advisory continuation.
This follow-up makes that advice capable of accumulating continuity across checkpoints so later cycles can detect alignment instead of behaving like every run begins from zero.

## Boundary note
The history rail remains advisory only.
It may not define governance law, canon lineage, checkpoint legality, or mode legality.
