### PR TITLE
Add Lumina orchestrator v0.3 wired to decision engine

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_orchestrator_v0_3.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_orchestrator_v0_3.py
@@ -1,0 +1,69 @@
+# Lumina OS Orchestrator v0.3
+# Context-loader path wired into decision engine
+
+from runtime_runner_r2_merged import RuntimeRunner
+from lumina_context_loader_v0_1 import LuminaContextLoader
+from lumina_decision_engine_v0_1 import LuminaDecisionEngine
+import json
+from pathlib import Path
+
+STATE_FILE = Path(__file__).parent / "_lumina_state.json"
+
+class LuminaOrchestrator:
+    def __init__(self, base_dir=None):
+        self.runner = RuntimeRunner(base_dir=base_dir) if base_dir else RuntimeRunner()
+        self.loader = LuminaContextLoader()
+        self.decision_engine = LuminaDecisionEngine()
+        self.state = self._load_state()
+
+    def _load_state(self):
+        if STATE_FILE.exists():
+            try:
+                return json.loads(STATE_FILE.read_text())
+            except Exception:
+                pass
+        return {"last_action": None, "last_mode": "Continuity"}
+
+    def _save_state(self):
+        STATE_FILE.write_text(json.dumps(self.state, indent=2))
+
+    def select_next_action(self, context_bundle: dict) -> dict:
+        mode = context_bundle.get("current_mode")
+        last_action = context_bundle.get("last_action")
+
+        if not last_action:
+            return {"action": "initial_observation", "action_type": "audit", "target_mode": "Observation"}
+
+        if mode == "Observation":
+            return {"action": "continue_observation", "action_type": "audit", "target_mode": "Observation"}
+
+        return {"action": "stabilize_to_observation", "action_type": "transition", "target_mode": "Observation"}
+
+    def run_cycle(self):
+        context_bundle = self.loader.load_context()
+
+        next_action = self.decision_engine.select_next_action(context_bundle)
+
+        result = self.runner.run_cycle(
+            current_mode=context_bundle["current_mode"],
+            target_mode=next_action["target_mode"],
+            requested_action=next_action["action"],
+            action_type=next_action["action_type"]
+        )
+
+        self.state["last_action"] = next_action["action"]
+        self.state["last_mode"] = next_action["target_mode"]
+        self._save_state()
+
+        return result.to_dict()
+
+    def run(self, cycles=3):
+        outputs = []
+        for _ in range(cycles):
+            outputs.append(self.run_cycle())
+        return outputs
+
+
+if __name__ == "__main__":
+    orchestrator = LuminaOrchestrator()
+    print(json.dumps(orchestrator.run(), indent=2))


### PR DESCRIPTION
## Summary
- add `lumina_orchestrator_v0_3.py`
- wire the new orchestrator to `LuminaDecisionEngine`
- preserve the current v0.2 file unchanged

## What changed
- imports `LuminaDecisionEngine`
- initializes `self.decision_engine = LuminaDecisionEngine()` in `__init__`
- routes `run_cycle()` through `self.decision_engine.select_next_action(context_bundle)`

## Why this shape
I attempted the direct in-place replacement you requested for `lumina_orchestrator_v0_2.py`, but the connector blocked overwrite updates during this session. So this PR lands the exact behavior as a clean `v0_3` file instead of mutating `v0_2` in place.

## File added
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_orchestrator_v0_3.py`
