### PR TITLE
Harden Lumina orchestration lane with repo-native runner path and stack sea trial

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/LUMINA_ORCHESTRATION_STACK_NOTE_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/LUMINA_ORCHESTRATION_STACK_NOTE_R1.md
@@ -1,0 +1,67 @@
+# Lumina Orchestration Stack Note r1
+
+This note records the current bounded orchestration lane that sits above the governed bootstrap runtime.
+
+## Stack shape
+
+The current stack now has four distinct layers:
+
+1. `runtime/runtime_runner_r1_merged.py`
+   - lawful execution substrate
+   - mode validation
+   - mutation / promotion gating
+   - capability exposure
+   - governance logging
+
+2. `lumina_context_loader_v0_1.py`
+   - recovers minimal usable context from the latest checkpoint
+   - restores `current_mode` and `last_action` without guessing beyond the available state
+
+3. `lumina_decision_engine_v0_1.py`
+   - emits an advisory next-step recommendation from restored context
+   - remains non-authoritative
+
+4. `lumina_orchestrator_v0_4.py`
+   - binds the runner, loader, and decision engine into one bounded orchestration loop
+   - attaches the loader to the runner's actual runtime state directory
+   - routes the recommended action into runtime execution without granting the recommendation governance authority
+
+## Why this matters
+
+This lane is the first compact proof that Lumina can:
+
+- restore a minimal project surface
+- orient from that surface
+- recommend a likely next move
+- execute through the governed runtime rather than bypass it
+
+That is not the positronic brain.
+But it is aligned with the compass that points toward durable, lawful cognition.
+
+## Current truth
+
+The orchestration layer is still intentionally narrow.
+It does not yet provide:
+
+- rich multi-project context fusion
+- user-visible advisory acceptance / rejection loops
+- supervised action queues
+- durable external process continuity
+- independent tool arbitration beyond the governed runtime boundary
+
+## Boundary note
+
+The decision engine and orchestrator are still subordinate to runtime law.
+They may recommend.
+They may not silently redefine legality, canon lineage, mutation authority, or user intent.
+
+They are steering surfaces, not sovereignty surfaces.
+
+## Likely next hardening move
+
+The next sharp threshold after this stack is a dedicated validation lane proving that:
+
+- restored context actually influences recommendation selection
+- recommendations remain advisory under governance
+- checkpoint recovery and coarse continuity state agree when both are present
+- orientation changes alter recommendations without bypassing runtime law

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_orchestrator_v0_4.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_orchestrator_v0_4.py
@@ -1,0 +1,85 @@
+# Lumina OS Orchestrator v0.4
+# Hardens the decision-engine lane against real repo/runtime paths
+
+import json
+import sys
+from pathlib import Path
+
+RUNTIME_DIR = Path(__file__).parent / "runtime"
+if str(RUNTIME_DIR) not in sys.path:
+    sys.path.append(str(RUNTIME_DIR))
+
+from runtime_runner_r1_merged import RuntimeRunner
+from lumina_context_loader_v0_1 import LuminaContextLoader
+from lumina_decision_engine_v0_1 import LuminaDecisionEngine
+
+STATE_FILE = Path(__file__).parent / "_lumina_state.json"
+
+
+class LuminaOrchestrator:
+    """
+    Bounded orchestration layer.
+    - Restores minimal context from runtime checkpoints
+    - Routes next-step selection through LuminaDecisionEngine
+    - Persists coarse continuity state across cycles
+    - Remains subordinate to RuntimeRunner governance at execution time
+    """
+
+    def __init__(self, base_dir=None, orientation_vector=None):
+        self.runner = RuntimeRunner(base_dir=base_dir) if base_dir else RuntimeRunner()
+        self.loader = LuminaContextLoader(runtime_state_dir=self.runner.base_dir)
+        self.decision_engine = LuminaDecisionEngine(orientation_vector=orientation_vector)
+        self.state = self._load_state()
+
+    def _load_state(self):
+        if STATE_FILE.exists():
+            try:
+                return json.loads(STATE_FILE.read_text())
+            except Exception:
+                pass
+        return {"last_action": None, "last_mode": "Continuity"}
+
+    def _save_state(self):
+        STATE_FILE.write_text(json.dumps(self.state, indent=2))
+
+    def _restore_context(self) -> dict:
+        context_bundle = self.loader.load_context()
+        if not context_bundle.get("last_action") and self.state.get("last_action"):
+            context_bundle["last_action"] = self.state["last_action"]
+        if not context_bundle.get("current_mode") and self.state.get("last_mode"):
+            context_bundle["current_mode"] = self.state["last_mode"]
+        return context_bundle
+
+    def run_cycle(self):
+        context_bundle = self._restore_context()
+        current_mode = context_bundle.get("current_mode", "Continuity")
+
+        next_action = self.decision_engine.select_next_action(context_bundle)
+
+        result = self.runner.run_cycle(
+            current_mode=current_mode,
+            target_mode=next_action["target_mode"],
+            requested_action=next_action["action"],
+            action_type=next_action["action_type"],
+        )
+
+        self.state["last_action"] = next_action["action"]
+        self.state["last_mode"] = next_action["target_mode"]
+        self._save_state()
+
+        return {
+            "restored_context": context_bundle,
+            "next_action": next_action,
+            "runner_result": result.to_dict(),
+        }
+
+    def run(self, cycles=3):
+        outputs = []
+        for _ in range(cycles):
+            outputs.append(self.run_cycle())
+        return outputs
+
+
+if __name__ == "__main__":
+    orchestrator = LuminaOrchestrator()
+    print(json.dumps(orchestrator.run(), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_orchestration_stack_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_orchestration_stack_r1.py
@@ -1,0 +1,89 @@
+import json
+import shutil
+from pathlib import Path
+
+from lumina_context_loader_v0_1 import LuminaContextLoader
+from lumina_decision_engine_v0_1 import LuminaDecisionEngine
+from lumina_orchestrator_v0_4 import LuminaOrchestrator
+
+BASE_DIR = Path(__file__).resolve().parent / "_sea_trials_lumina_orchestration_stack_r1"
+if BASE_DIR.exists():
+    shutil.rmtree(BASE_DIR)
+BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _write_checkpoint(root: Path, *, current_mode: str, last_action: str | None) -> Path:
+    checkpoint_dir = root / "sessions" / "trial_session"
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint_path = checkpoint_dir / "trial_checkpoint.json"
+    payload = {
+        "session_state": {
+            "current_mode": current_mode,
+            "last_completed_action": last_action,
+        }
+    }
+    checkpoint_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return checkpoint_path
+
+
+def main() -> dict:
+    checkpoint_root = BASE_DIR / "runtime_state"
+    checkpoint_path = _write_checkpoint(
+        checkpoint_root,
+        current_mode="Observation",
+        last_action="lumina_self_guidance_probe",
+    )
+
+    loader = LuminaContextLoader(runtime_state_dir=checkpoint_root)
+    restored_context = loader.load_context()
+
+    default_engine = LuminaDecisionEngine()
+    progression_engine = LuminaDecisionEngine({"priority": "progression"})
+    stability_engine = LuminaDecisionEngine({"priority": "stability"})
+
+    default_recommendation = default_engine.select_next_action(restored_context)
+    progression_recommendation = progression_engine.select_next_action(restored_context)
+    stability_recommendation = stability_engine.select_next_action(restored_context)
+
+    orchestrator = LuminaOrchestrator(
+        base_dir=checkpoint_root,
+        orientation_vector={"priority": "progression"},
+    )
+    orchestrator_context = orchestrator._restore_context()
+
+    fallback_orchestrator = LuminaOrchestrator(orientation_vector={"priority": "stability"})
+    fallback_context = fallback_orchestrator._restore_context()
+
+    checks = {
+        "checkpoint_written": checkpoint_path.exists(),
+        "loader_restored_mode": restored_context.get("current_mode") == "Observation",
+        "loader_restored_last_action": restored_context.get("last_action") == "lumina_self_guidance_probe",
+        "default_engine_continues_observation": default_recommendation.get("action") == "continue_observation",
+        "progression_engine_enters_drydock": progression_recommendation.get("action") == "enter_drydock",
+        "stability_engine_holds_observation": stability_recommendation.get("action") == "continue_observation",
+        "orchestrator_attaches_loader_to_runner_state": Path(orchestrator.loader.runtime_state_dir) == Path(orchestrator.runner.base_dir),
+        "orchestrator_restores_checkpoint_context": orchestrator_context.get("current_mode") == "Observation"
+        and orchestrator_context.get("last_action") == "lumina_self_guidance_probe",
+        "fallback_orchestrator_exposes_minimal_continuity_context": fallback_context.get("current_mode") == "Continuity",
+    }
+
+    summary = {
+        "suite": "Lumina Orchestration Stack Sea Trial r1",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "restored_context": restored_context,
+        "default_recommendation": default_recommendation,
+        "progression_recommendation": progression_recommendation,
+        "stability_recommendation": stability_recommendation,
+        "orchestrator_context": orchestrator_context,
+        "fallback_context": fallback_context,
+    }
+
+    summary_path = BASE_DIR / "sea_trials_lumina_orchestration_stack_r1_report.json"
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    return {"summary_path": str(summary_path), "summary": summary}
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))


### PR DESCRIPTION
## Summary
- add `lumina_orchestrator_v0_4.py` as a hardened orchestration file
- add `LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`
- add `sea_trials_lumina_orchestration_stack_r1.py`

## Why this was the sharp next move
The newly landed `lumina_orchestrator_v0_3.py` established the decision-engine lane, but it still pointed at a non-repo-native runner import and did not attach the context loader to the runner's actual state directory.

This follow-up keeps the same bounded architectural intent while making the lane more truthful to the repository's real runtime layout.

## What v0.4 changes
- uses the repo's actual runtime runner path via the `runtime/` subtree
- attaches `LuminaContextLoader` to `self.runner.base_dir`
- restores coarse state when checkpoints are absent
- keeps the decision engine advisory and subordinate to runtime governance

## What the note adds
The new orchestration stack note explains how the runner, context loader, decision engine, and orchestrator relate without implying hidden sovereignty.

## What the sea trial adds
The new sea trial validates that:
- checkpoint context is recoverable
- decision recommendations change with orientation
- the orchestrator is actually bound to the runner state directory
- minimal continuity context still exists when checkpoints are absent
