### PR TITLE
Add Chamber advisory acceptance loop and supervised action queue scaffold

### DIFF
--- a/chamber-app/src/advisory_queue_memory_store.ts
+++ b/chamber-app/src/advisory_queue_memory_store.ts
@@ -1,0 +1,168 @@
+import { v4 as uuidv4 } from 'uuid';
+import type { ChamberActionQueueItem, ChamberAdvisory, AdvisoryDecision } from './advisory_queue_types.js';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+interface CreateAdvisoryInput {
+  roomSlug: string;
+  createdByUserId: string;
+  createdByLabel: string;
+  recommendationSource: 'human' | 'system';
+  guidanceStrategy: string;
+  confidenceLabel: 'low' | 'medium' | 'high';
+  reasoningBrief: string;
+  recommendedAction: string;
+  actionType: 'transition' | 'mutation' | 'promotion' | 'audit';
+  targetMode: string | null;
+}
+
+interface DecideAdvisoryInput {
+  advisoryId: string;
+  decision: Exclude<AdvisoryDecision, 'pending'>;
+  decisionByUserId: string;
+  decisionByLabel: string;
+  decisionReason: string | null;
+}
+
+interface ClaimQueueItemInput {
+  queueItemId: string;
+  claimedByUserId: string;
+  claimedByLabel: string;
+}
+
+interface CompleteQueueItemInput {
+  queueItemId: string;
+  completedByUserId: string;
+  completedByLabel: string;
+  outcomeSummary: string | null;
+}
+
+export class ChamberAdvisoryQueueMemoryStore {
+  private readonly advisoriesById = new Map<string, ChamberAdvisory>();
+  private readonly roomAdvisoryIds = new Map<string, string[]>();
+  private readonly queueItemsById = new Map<string, ChamberActionQueueItem>();
+  private readonly roomQueueIds = new Map<string, string[]>();
+
+  listAdvisories(roomSlug: string): ChamberAdvisory[] {
+    const ids = this.roomAdvisoryIds.get(roomSlug) ?? [];
+    return ids
+      .map((id) => this.advisoriesById.get(id))
+      .filter((value): value is ChamberAdvisory => Boolean(value));
+  }
+
+  listQueue(roomSlug: string): ChamberActionQueueItem[] {
+    const ids = this.roomQueueIds.get(roomSlug) ?? [];
+    return ids
+      .map((id) => this.queueItemsById.get(id))
+      .filter((value): value is ChamberActionQueueItem => Boolean(value));
+  }
+
+  createAdvisory(input: CreateAdvisoryInput): ChamberAdvisory {
+    const advisory: ChamberAdvisory = {
+      advisoryId: uuidv4(),
+      roomSlug: input.roomSlug,
+      createdAt: nowIso(),
+      createdByUserId: input.createdByUserId,
+      createdByLabel: input.createdByLabel,
+      recommendationSource: input.recommendationSource,
+      guidanceStrategy: input.guidanceStrategy,
+      confidenceLabel: input.confidenceLabel,
+      reasoningBrief: input.reasoningBrief,
+      recommendedAction: input.recommendedAction,
+      actionType: input.actionType,
+      targetMode: input.targetMode,
+      decision: 'pending',
+      decisionAt: null,
+      decisionByUserId: null,
+      decisionReason: null,
+      queueItemId: null
+    };
+
+    this.advisoriesById.set(advisory.advisoryId, advisory);
+    const ids = this.roomAdvisoryIds.get(input.roomSlug) ?? [];
+    ids.push(advisory.advisoryId);
+    this.roomAdvisoryIds.set(input.roomSlug, ids);
+    return advisory;
+  }
+
+  decideAdvisory(input: DecideAdvisoryInput): { advisory: ChamberAdvisory; queueItem: ChamberActionQueueItem | null } {
+    const advisory = this.advisoriesById.get(input.advisoryId);
+    if (!advisory) {
+      throw new Error('Advisory not found');
+    }
+    if (advisory.decision !== 'pending') {
+      throw new Error('Advisory has already been decided');
+    }
+
+    advisory.decision = input.decision;
+    advisory.decisionAt = nowIso();
+    advisory.decisionByUserId = input.decisionByUserId;
+    advisory.decisionReason = input.decisionReason;
+
+    if (input.decision === 'accepted') {
+      const queueItem: ChamberActionQueueItem = {
+        queueItemId: uuidv4(),
+        roomSlug: advisory.roomSlug,
+        advisoryId: advisory.advisoryId,
+        createdAt: nowIso(),
+        createdByUserId: input.decisionByUserId,
+        createdByLabel: input.decisionByLabel,
+        requestedAction: advisory.recommendedAction,
+        actionType: advisory.actionType,
+        targetMode: advisory.targetMode,
+        queueStatus: 'pending',
+        claimedAt: null,
+        claimedByUserId: null,
+        claimedByLabel: null,
+        completedAt: null,
+        completedByUserId: null,
+        completedByLabel: null,
+        outcomeSummary: null
+      };
+
+      advisory.queueItemId = queueItem.queueItemId;
+      this.queueItemsById.set(queueItem.queueItemId, queueItem);
+      const queueIds = this.roomQueueIds.get(advisory.roomSlug) ?? [];
+      queueIds.push(queueItem.queueItemId);
+      this.roomQueueIds.set(advisory.roomSlug, queueIds);
+      return { advisory, queueItem };
+    }
+
+    return { advisory, queueItem: null };
+  }
+
+  claimQueueItem(input: ClaimQueueItemInput): ChamberActionQueueItem {
+    const queueItem = this.queueItemsById.get(input.queueItemId);
+    if (!queueItem) {
+      throw new Error('Queue item not found');
+    }
+    if (queueItem.queueStatus !== 'pending') {
+      throw new Error('Queue item is not pending');
+    }
+
+    queueItem.queueStatus = 'claimed';
+    queueItem.claimedAt = nowIso();
+    queueItem.claimedByUserId = input.claimedByUserId;
+    queueItem.claimedByLabel = input.claimedByLabel;
+    return queueItem;
+  }
+
+  completeQueueItem(input: CompleteQueueItemInput): ChamberActionQueueItem {
+    const queueItem = this.queueItemsById.get(input.queueItemId);
+    if (!queueItem) {
+      throw new Error('Queue item not found');
+    }
+    if (queueItem.queueStatus !== 'claimed') {
+      throw new Error('Queue item must be claimed before completion');
+    }
+
+    queueItem.queueStatus = 'completed';
+    queueItem.completedAt = nowIso();
+    queueItem.completedByUserId = input.completedByUserId;
+    queueItem.completedByLabel = input.completedByLabel;
+    queueItem.outcomeSummary = input.outcomeSummary;
+    return queueItem;
+  }
+}

--- a/chamber-app/src/advisory_queue_server_v0_1.ts
+++ b/chamber-app/src/advisory_queue_server_v0_1.ts
@@ -1,0 +1,262 @@
+import 'dotenv/config';
+import cors from 'cors';
+import express from 'express';
+import { z } from 'zod';
+import { createChamberStore } from './store_factory.js';
+import { ChamberAdvisoryQueueMemoryStore } from './advisory_queue_memory_store.js';
+
+const port = Number(process.env.CHAMBER_ADVISORY_PORT || 8788);
+const publicRoomSlug = process.env.CHAMBER_PUBLIC_ROOM_SLUG || 'public-room-one';
+const sessionTtlHours = Number(process.env.SESSION_TTL_HOURS || 168);
+const storeMode = (process.env.CHAMBER_STORE_MODE || 'memory') as 'memory' | 'postgres';
+const databaseUrl = process.env.DATABASE_URL;
+const allowedOrigins = (process.env.CHAMBER_ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+const signUpSchema = z.object({
+  email: z.string().email(),
+  displayName: z.string().min(1).max(64),
+  chamberHandle: z.string().min(1).max(24)
+});
+
+const loginSchema = z.object({
+  email: z.string().email()
+});
+
+const createAdvisorySchema = z.object({
+  sessionToken: z.string().uuid(),
+  recommendationSource: z.enum(['human', 'system']).default('human'),
+  guidanceStrategy: z.string().min(1).max(120),
+  confidenceLabel: z.enum(['low', 'medium', 'high']),
+  reasoningBrief: z.string().min(1).max(500),
+  recommendedAction: z.string().min(1).max(200),
+  actionType: z.enum(['transition', 'mutation', 'promotion', 'audit']),
+  targetMode: z.string().min(1).max(64).nullable().optional()
+});
+
+const decideAdvisorySchema = z.object({
+  sessionToken: z.string().uuid(),
+  decision: z.enum(['accepted', 'rejected']),
+  decisionReason: z.string().min(1).max(500).nullable().optional()
+});
+
+const claimQueueSchema = z.object({
+  sessionToken: z.string().uuid()
+});
+
+const completeQueueSchema = z.object({
+  sessionToken: z.string().uuid(),
+  outcomeSummary: z.string().min(1).max(1000).nullable().optional()
+});
+
+function requirePublicRoom(roomSlug: string) {
+  if (roomSlug !== publicRoomSlug) {
+    throw new Error('Only the configured public Chamber room is supported in this scaffold');
+  }
+}
+
+async function main() {
+  const store = await createChamberStore({
+    storeMode,
+    publicRoomSlug,
+    databaseUrl
+  });
+  const advisoryStore = new ChamberAdvisoryQueueMemoryStore();
+
+  const app = express();
+  app.use(cors({
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.length === 0 || allowedOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+      callback(new Error('Origin not allowed by Chamber advisory scaffold CORS policy'));
+    },
+    credentials: true
+  }));
+  app.use(express.json());
+
+  app.get('/health', async (_req, res) => {
+    res.json({
+      ok: true,
+      service: 'chamber-advisory-queue-scaffold',
+      publicRoomSlug,
+      allowedOrigins,
+      health: await store.health(),
+      advisoryCount: advisoryStore.listAdvisories(publicRoomSlug).length,
+      queueCount: advisoryStore.listQueue(publicRoomSlug).length
+    });
+  });
+
+  app.post('/api/auth/signup', async (req, res) => {
+    const parsed = signUpSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+    }
+
+    const user = await store.signUp(parsed.data.email, parsed.data.displayName, parsed.data.chamberHandle);
+    const session = await store.createSession(user.email, sessionTtlHours);
+    return res.status(201).json({ ok: true, user, session });
+  });
+
+  app.post('/api/auth/login', async (req, res) => {
+    const parsed = loginSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+    }
+
+    try {
+      const session = await store.createSession(parsed.data.email, sessionTtlHours);
+      const actor = await store.getSession(session.sessionToken);
+      return res.json({ ok: true, user: actor?.user, session });
+    } catch (error) {
+      return res.status(404).json({ ok: false, error: error instanceof Error ? error.message : 'Login failed' });
+    }
+  });
+
+  app.get('/api/rooms/:roomSlug/advisories', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      return res.json({
+        ok: true,
+        room: await store.getPublicRoom(),
+        advisories: advisoryStore.listAdvisories(req.params.roomSlug)
+      });
+    } catch (error) {
+      return res.status(404).json({ ok: false, error: error instanceof Error ? error.message : 'Room not found' });
+    }
+  });
+
+  app.post('/api/rooms/:roomSlug/advisories', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      const parsed = createAdvisorySchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+      }
+
+      const actor = await store.getSession(parsed.data.sessionToken);
+      if (!actor) {
+        return res.status(404).json({ ok: false, error: 'Session not found' });
+      }
+
+      const advisory = advisoryStore.createAdvisory({
+        roomSlug: req.params.roomSlug,
+        createdByUserId: actor.user.userId,
+        createdByLabel: actor.user.chamberHandle,
+        recommendationSource: parsed.data.recommendationSource,
+        guidanceStrategy: parsed.data.guidanceStrategy,
+        confidenceLabel: parsed.data.confidenceLabel,
+        reasoningBrief: parsed.data.reasoningBrief,
+        recommendedAction: parsed.data.recommendedAction,
+        actionType: parsed.data.actionType,
+        targetMode: parsed.data.targetMode ?? null
+      });
+
+      return res.status(201).json({ ok: true, advisory });
+    } catch (error) {
+      return res.status(404).json({ ok: false, error: error instanceof Error ? error.message : 'Unable to create advisory' });
+    }
+  });
+
+  app.post('/api/rooms/:roomSlug/advisories/:advisoryId/decision', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      const parsed = decideAdvisorySchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+      }
+
+      const actor = await store.getSession(parsed.data.sessionToken);
+      if (!actor) {
+        return res.status(404).json({ ok: false, error: 'Session not found' });
+      }
+
+      const result = advisoryStore.decideAdvisory({
+        advisoryId: req.params.advisoryId,
+        decision: parsed.data.decision,
+        decisionByUserId: actor.user.userId,
+        decisionByLabel: actor.user.chamberHandle,
+        decisionReason: parsed.data.decisionReason ?? null
+      });
+
+      return res.json({ ok: true, advisory: result.advisory, queueItem: result.queueItem });
+    } catch (error) {
+      return res.status(400).json({ ok: false, error: error instanceof Error ? error.message : 'Unable to decide advisory' });
+    }
+  });
+
+  app.get('/api/rooms/:roomSlug/action-queue', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      return res.json({
+        ok: true,
+        room: await store.getPublicRoom(),
+        queue: advisoryStore.listQueue(req.params.roomSlug)
+      });
+    } catch (error) {
+      return res.status(404).json({ ok: false, error: error instanceof Error ? error.message : 'Room not found' });
+    }
+  });
+
+  app.post('/api/rooms/:roomSlug/action-queue/:queueItemId/claim', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      const parsed = claimQueueSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+      }
+
+      const actor = await store.getSession(parsed.data.sessionToken);
+      if (!actor) {
+        return res.status(404).json({ ok: false, error: 'Session not found' });
+      }
+
+      const queueItem = advisoryStore.claimQueueItem({
+        queueItemId: req.params.queueItemId,
+        claimedByUserId: actor.user.userId,
+        claimedByLabel: actor.user.chamberHandle
+      });
+
+      return res.json({ ok: true, queueItem });
+    } catch (error) {
+      return res.status(400).json({ ok: false, error: error instanceof Error ? error.message : 'Unable to claim queue item' });
+    }
+  });
+
+  app.post('/api/rooms/:roomSlug/action-queue/:queueItemId/complete', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      const parsed = completeQueueSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+      }
+
+      const actor = await store.getSession(parsed.data.sessionToken);
+      if (!actor) {
+        return res.status(404).json({ ok: false, error: 'Session not found' });
+      }
+
+      const queueItem = advisoryStore.completeQueueItem({
+        queueItemId: req.params.queueItemId,
+        completedByUserId: actor.user.userId,
+        completedByLabel: actor.user.chamberHandle,
+        outcomeSummary: parsed.data.outcomeSummary ?? null
+      });
+
+      return res.json({ ok: true, queueItem });
+    } catch (error) {
+      return res.status(400).json({ ok: false, error: error instanceof Error ? error.message : 'Unable to complete queue item' });
+    }
+  });
+
+  app.listen(port, () => {
+    console.log(`chamber-advisory-queue-scaffold listening on ${port} using ${storeMode} chamber identity store`);
+  });
+}
+
+main().catch((error) => {
+  console.error('Failed to start chamber-advisory-queue-scaffold', error);
+});

--- a/chamber-app/src/advisory_queue_types.ts
+++ b/chamber-app/src/advisory_queue_types.ts
@@ -1,0 +1,42 @@
+export type AdvisoryDecision = 'pending' | 'accepted' | 'rejected';
+export type ActionQueueStatus = 'pending' | 'claimed' | 'completed' | 'cancelled';
+
+export interface ChamberAdvisory {
+  advisoryId: string;
+  roomSlug: string;
+  createdAt: string;
+  createdByUserId: string;
+  createdByLabel: string;
+  recommendationSource: 'human' | 'system';
+  guidanceStrategy: string;
+  confidenceLabel: 'low' | 'medium' | 'high';
+  reasoningBrief: string;
+  recommendedAction: string;
+  actionType: 'transition' | 'mutation' | 'promotion' | 'audit';
+  targetMode: string | null;
+  decision: AdvisoryDecision;
+  decisionAt: string | null;
+  decisionByUserId: string | null;
+  decisionReason: string | null;
+  queueItemId: string | null;
+}
+
+export interface ChamberActionQueueItem {
+  queueItemId: string;
+  roomSlug: string;
+  advisoryId: string;
+  createdAt: string;
+  createdByUserId: string;
+  createdByLabel: string;
+  requestedAction: string;
+  actionType: 'transition' | 'mutation' | 'promotion' | 'audit';
+  targetMode: string | null;
+  queueStatus: ActionQueueStatus;
+  claimedAt: string | null;
+  claimedByUserId: string | null;
+  claimedByLabel: string | null;
+  completedAt: string | null;
+  completedByUserId: string | null;
+  completedByLabel: string | null;
+  outcomeSummary: string | null;
+}

--- a/chamber-app/src/sea_trials_advisory_queue_r1.ts
+++ b/chamber-app/src/sea_trials_advisory_queue_r1.ts
@@ -1,0 +1,83 @@
+import { ChamberAdvisoryQueueMemoryStore } from './advisory_queue_memory_store.js';
+
+function main() {
+  const store = new ChamberAdvisoryQueueMemoryStore();
+  const roomSlug = 'public-room-one';
+
+  const accepted = store.createAdvisory({
+    roomSlug,
+    createdByUserId: 'user-1',
+    createdByLabel: 'architect',
+    recommendationSource: 'system',
+    guidanceStrategy: 'pending_next_action_history_aligned',
+    confidenceLabel: 'high',
+    reasoningBrief: 'Recent continuity signals align on the same next move.',
+    recommendedAction: 'continue::lumina_orchestration_stack',
+    actionType: 'audit',
+    targetMode: 'Observation'
+  });
+
+  const rejected = store.createAdvisory({
+    roomSlug,
+    createdByUserId: 'user-2',
+    createdByLabel: 'keeper',
+    recommendationSource: 'human',
+    guidanceStrategy: 'manual_override',
+    confidenceLabel: 'medium',
+    reasoningBrief: 'This recommendation should be refused for now.',
+    recommendedAction: 'enter_drydock',
+    actionType: 'transition',
+    targetMode: 'DryDock'
+  });
+
+  const acceptedDecision = store.decideAdvisory({
+    advisoryId: accepted.advisoryId,
+    decision: 'accepted',
+    decisionByUserId: 'user-1',
+    decisionByLabel: 'architect',
+    decisionReason: 'Recommendation matches the present heading.'
+  });
+
+  const rejectedDecision = store.decideAdvisory({
+    advisoryId: rejected.advisoryId,
+    decision: 'rejected',
+    decisionByUserId: 'user-2',
+    decisionByLabel: 'keeper',
+    decisionReason: 'Hold this move outside the current lane.'
+  });
+
+  const claimed = store.claimQueueItem({
+    queueItemId: acceptedDecision.queueItem!.queueItemId,
+    claimedByUserId: 'user-3',
+    claimedByLabel: 'operator'
+  });
+
+  const completed = store.completeQueueItem({
+    queueItemId: claimed.queueItemId,
+    completedByUserId: 'user-3',
+    completedByLabel: 'operator',
+    outcomeSummary: 'Advisory was reviewed and marked complete under supervision.'
+  });
+
+  const queue = store.listQueue(roomSlug);
+  const advisories = store.listAdvisories(roomSlug);
+
+  const checks = {
+    accepted_advisory_creates_queue_item: acceptedDecision.queueItem !== null,
+    rejected_advisory_does_not_create_queue_item: rejectedDecision.queueItem === null,
+    queue_item_can_be_claimed: claimed.queueStatus === 'claimed',
+    queue_item_can_be_completed_after_claim: completed.queueStatus === 'completed',
+    room_retains_two_advisories: advisories.length === 2,
+    room_retains_one_queue_item: queue.length === 1
+  };
+
+  return {
+    suite: 'Chamber Advisory Queue Sea Trial r1',
+    passed: Object.values(checks).every(Boolean),
+    checks,
+    advisories,
+    queue
+  };
+}
+
+console.log(JSON.stringify(main(), null, 2));

--- a/docs/chamber_advisory_queue_note_r1.md
+++ b/docs/chamber_advisory_queue_note_r1.md
@@ -1,0 +1,69 @@
+# Chamber advisory acceptance and supervised action queue note r1
+
+This note records the next bridge between bounded Lumina self-guidance and user-visible Chamber interaction.
+
+## What this scaffold adds
+
+New files:
+
+- `chamber-app/src/advisory_queue_types.ts`
+- `chamber-app/src/advisory_queue_memory_store.ts`
+- `chamber-app/src/advisory_queue_server_v0_1.ts`
+
+## What it does
+
+This scaffold introduces a minimal public-room flow where a human can:
+
+1. create an advisory recommendation
+2. accept or reject that recommendation explicitly
+3. place accepted recommendations into a supervised action queue
+4. claim and complete queued actions as visible, bounded steps
+
+## Why this matters
+
+The current Lumina bootstrap path already supports bounded self-guidance advisory output.
+What it did not yet have was a simple user-visible acceptance / rejection loop and a supervised queue surface that makes consent legible.
+
+This Chamber scaffold is not hidden autonomy.
+It is the opposite.
+It makes recommendation, decision, and queued action separable and inspectable.
+
+## Current boundary
+
+This first scaffold is intentionally narrow:
+
+- queue persistence is in-memory only for now
+- it runs as a parallel server entrypoint rather than replacing the main Chamber server
+- it does not execute tools itself
+- queue completion is a human-marked supervision event, not autonomous tool execution
+
+## Why this shape
+
+That narrowness is on purpose.
+The goal is to prove the behavioral pattern first:
+
+- recommendation
+- explicit user decision
+- supervised queue placement
+- visible claim / completion state
+
+before deeper integration with Postgres, Chamber UI, or governed runtime execution.
+
+## Likely next hardening move
+
+After this, the sharp next step is to connect the same advisory / queue pattern to:
+
+- persisted Postgres storage
+- Chamber UI surfaces
+- Lumina-produced advisory objects
+- governed runtime execution records
+
+without allowing queued actions to bypass governance or user intent.
+
+## Manual run note
+
+This server is designed to be run directly with `tsx`, for example:
+
+`tsx watch src/advisory_queue_server_v0_1.ts`
+
+from inside `chamber-app/`.


### PR DESCRIPTION
## Summary
- add Chamber advisory / queue types and memory store
- add a parallel advisory queue server entrypoint
- add a Chamber advisory queue sea trial
- document the scaffold and its current boundary

## What this adds
- `chamber-app/src/advisory_queue_types.ts`
- `chamber-app/src/advisory_queue_memory_store.ts`
- `chamber-app/src/advisory_queue_server_v0_1.ts`
- `chamber-app/src/sea_trials_advisory_queue_r1.ts`
- `docs/chamber_advisory_queue_note_r1.md`

## Why this was the next move
The Lumina substrate now has bounded self-guidance and a hardened orchestration lane. The next missing threshold was the user-visible loop where a recommendation can be accepted or rejected explicitly, and accepted recommendations can enter a supervised queue instead of disappearing into hidden autonomy.

## What this scaffold proves
- advisories can be created as visible objects
- advisories can be accepted or rejected explicitly
- accepted advisories create queue items
- rejected advisories do not create queue items
- queued actions can be claimed and completed under supervision

## Boundary note
This is intentionally narrow:
- queue persistence is memory-backed only for now
- it runs as a parallel Chamber server entrypoint
- it does not execute tools autonomously
- completion is a supervised human-marked state change, not hidden execution

## Why that boundary matters
This keeps the pattern honest. Recommendation, decision, and queued action remain separable and inspectable while we prove the loop before deeper integration with Postgres, UI surfaces, or governed runtime execution.
