### PR TITLE
Persist Chamber advisory queue and add Lumina advisory bridge

### DIFF
--- a/chamber-app/docker-compose.postgres.advisory.yml
+++ b/chamber-app/docker-compose.postgres.advisory.yml
@@ -1,0 +1,24 @@
+services:
+  chamber-postgres:
+    image: postgres:16
+    container_name: chamber-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: chamber
+      POSTGRES_USER: chamber
+      POSTGRES_PASSWORD: chamber
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U chamber -d chamber"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - chamber_postgres_data:/var/lib/postgresql/data
+      - ../chamber_data_model_r1.sql:/docker-entrypoint-initdb.d/001_chamber_data_model.sql:ro
+      - ../chamber_sessions_extension_r1.sql:/docker-entrypoint-initdb.d/002_chamber_sessions_extension.sql:ro
+      - ../chamber_advisory_queue_extension_r1.sql:/docker-entrypoint-initdb.d/003_chamber_advisory_queue_extension.sql:ro
+
+volumes:
+  chamber_postgres_data:

--- a/chamber-app/src/advisory_queue_memory_store_v0_2.ts
+++ b/chamber-app/src/advisory_queue_memory_store_v0_2.ts
@@ -1,0 +1,145 @@
+import { v4 as uuidv4 } from 'uuid';
+import type { ChamberActionQueueItem, ChamberAdvisory, AdvisoryDecision } from './advisory_queue_types.js';
+import type {
+  ChamberAdvisoryQueueStore,
+  ClaimQueueItemInput,
+  CompleteQueueItemInput,
+  CreateAdvisoryInput,
+  DecideAdvisoryInput
+} from './advisory_queue_store_contract.js';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export class ChamberAdvisoryQueueMemoryStoreV02 implements ChamberAdvisoryQueueStore {
+  private readonly advisoriesById = new Map<string, ChamberAdvisory>();
+  private readonly roomAdvisoryIds = new Map<string, string[]>();
+  private readonly queueItemsById = new Map<string, ChamberActionQueueItem>();
+  private readonly roomQueueIds = new Map<string, string[]>();
+
+  async init(): Promise<void> {
+    return;
+  }
+
+  async listAdvisories(roomSlug: string): Promise<ChamberAdvisory[]> {
+    const ids = this.roomAdvisoryIds.get(roomSlug) ?? [];
+    return ids
+      .map((id) => this.advisoriesById.get(id))
+      .filter((value): value is ChamberAdvisory => Boolean(value));
+  }
+
+  async listQueue(roomSlug: string): Promise<ChamberActionQueueItem[]> {
+    const ids = this.roomQueueIds.get(roomSlug) ?? [];
+    return ids
+      .map((id) => this.queueItemsById.get(id))
+      .filter((value): value is ChamberActionQueueItem => Boolean(value));
+  }
+
+  async createAdvisory(input: CreateAdvisoryInput): Promise<ChamberAdvisory> {
+    const advisory: ChamberAdvisory = {
+      advisoryId: uuidv4(),
+      roomSlug: input.roomSlug,
+      createdAt: nowIso(),
+      createdByUserId: input.createdByUserId,
+      createdByLabel: input.createdByLabel,
+      recommendationSource: input.recommendationSource,
+      guidanceStrategy: input.guidanceStrategy,
+      confidenceLabel: input.confidenceLabel,
+      reasoningBrief: input.reasoningBrief,
+      recommendedAction: input.recommendedAction,
+      actionType: input.actionType,
+      targetMode: input.targetMode,
+      decision: 'pending',
+      decisionAt: null,
+      decisionByUserId: null,
+      decisionReason: null,
+      queueItemId: null
+    };
+
+    this.advisoriesById.set(advisory.advisoryId, advisory);
+    const ids = this.roomAdvisoryIds.get(input.roomSlug) ?? [];
+    ids.push(advisory.advisoryId);
+    this.roomAdvisoryIds.set(input.roomSlug, ids);
+    return advisory;
+  }
+
+  async decideAdvisory(input: DecideAdvisoryInput): Promise<{ advisory: ChamberAdvisory; queueItem: ChamberActionQueueItem | null }> {
+    const advisory = this.advisoriesById.get(input.advisoryId);
+    if (!advisory) {
+      throw new Error('Advisory not found');
+    }
+    if (advisory.decision !== 'pending') {
+      throw new Error('Advisory has already been decided');
+    }
+
+    advisory.decision = input.decision as Exclude<AdvisoryDecision, 'pending'>;
+    advisory.decisionAt = nowIso();
+    advisory.decisionByUserId = input.decisionByUserId;
+    advisory.decisionReason = input.decisionReason;
+
+    if (input.decision === 'accepted') {
+      const queueItem: ChamberActionQueueItem = {
+        queueItemId: uuidv4(),
+        roomSlug: advisory.roomSlug,
+        advisoryId: advisory.advisoryId,
+        createdAt: nowIso(),
+        createdByUserId: input.decisionByUserId,
+        createdByLabel: input.decisionByLabel,
+        requestedAction: advisory.recommendedAction,
+        actionType: advisory.actionType,
+        targetMode: advisory.targetMode,
+        queueStatus: 'pending',
+        claimedAt: null,
+        claimedByUserId: null,
+        claimedByLabel: null,
+        completedAt: null,
+        completedByUserId: null,
+        completedByLabel: null,
+        outcomeSummary: null
+      };
+
+      advisory.queueItemId = queueItem.queueItemId;
+      this.queueItemsById.set(queueItem.queueItemId, queueItem);
+      const queueIds = this.roomQueueIds.get(advisory.roomSlug) ?? [];
+      queueIds.push(queueItem.queueItemId);
+      this.roomQueueIds.set(advisory.roomSlug, queueIds);
+      return { advisory, queueItem };
+    }
+
+    return { advisory, queueItem: null };
+  }
+
+  async claimQueueItem(input: ClaimQueueItemInput): Promise<ChamberActionQueueItem> {
+    const queueItem = this.queueItemsById.get(input.queueItemId);
+    if (!queueItem) {
+      throw new Error('Queue item not found');
+    }
+    if (queueItem.queueStatus !== 'pending') {
+      throw new Error('Queue item is not pending');
+    }
+
+    queueItem.queueStatus = 'claimed';
+    queueItem.claimedAt = nowIso();
+    queueItem.claimedByUserId = input.claimedByUserId;
+    queueItem.claimedByLabel = input.claimedByLabel;
+    return queueItem;
+  }
+
+  async completeQueueItem(input: CompleteQueueItemInput): Promise<ChamberActionQueueItem> {
+    const queueItem = this.queueItemsById.get(input.queueItemId);
+    if (!queueItem) {
+      throw new Error('Queue item not found');
+    }
+    if (queueItem.queueStatus !== 'claimed') {
+      throw new Error('Queue item must be claimed before completion');
+    }
+
+    queueItem.queueStatus = 'completed';
+    queueItem.completedAt = nowIso();
+    queueItem.completedByUserId = input.completedByUserId;
+    queueItem.completedByLabel = input.completedByLabel;
+    queueItem.outcomeSummary = input.outcomeSummary;
+    return queueItem;
+  }
+}

--- a/chamber-app/src/advisory_queue_postgres_store_r1.ts
+++ b/chamber-app/src/advisory_queue_postgres_store_r1.ts
@@ -1,0 +1,283 @@
+import { Pool } from 'pg';
+import { v4 as uuidv4 } from 'uuid';
+import type { ChamberActionQueueItem, ChamberAdvisory } from './advisory_queue_types.js';
+import type {
+  ChamberAdvisoryQueueStore,
+  ClaimQueueItemInput,
+  CompleteQueueItemInput,
+  CreateAdvisoryInput,
+  DecideAdvisoryInput
+} from './advisory_queue_store_contract.js';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function mapAdvisory(row: Record<string, unknown>): ChamberAdvisory {
+  return {
+    advisoryId: String(row.advisory_id),
+    roomSlug: String(row.room_slug),
+    createdAt: new Date(String(row.created_at)).toISOString(),
+    createdByUserId: String(row.created_by_user_id),
+    createdByLabel: String(row.created_by_label),
+    recommendationSource: row.recommendation_source as ChamberAdvisory['recommendationSource'],
+    guidanceStrategy: String(row.guidance_strategy),
+    confidenceLabel: row.confidence_label as ChamberAdvisory['confidenceLabel'],
+    reasoningBrief: String(row.reasoning_brief),
+    recommendedAction: String(row.recommended_action),
+    actionType: row.action_type as ChamberAdvisory['actionType'],
+    targetMode: row.target_mode ? String(row.target_mode) : null,
+    decision: row.decision as ChamberAdvisory['decision'],
+    decisionAt: row.decision_at ? new Date(String(row.decision_at)).toISOString() : null,
+    decisionByUserId: row.decision_by_user_id ? String(row.decision_by_user_id) : null,
+    decisionReason: row.decision_reason ? String(row.decision_reason) : null,
+    queueItemId: row.queue_item_id ? String(row.queue_item_id) : null
+  };
+}
+
+function mapQueueItem(row: Record<string, unknown>): ChamberActionQueueItem {
+  return {
+    queueItemId: String(row.queue_item_id),
+    roomSlug: String(row.room_slug),
+    advisoryId: String(row.advisory_id),
+    createdAt: new Date(String(row.created_at)).toISOString(),
+    createdByUserId: String(row.created_by_user_id),
+    createdByLabel: String(row.created_by_label),
+    requestedAction: String(row.requested_action),
+    actionType: row.action_type as ChamberActionQueueItem['actionType'],
+    targetMode: row.target_mode ? String(row.target_mode) : null,
+    queueStatus: row.queue_status as ChamberActionQueueItem['queueStatus'],
+    claimedAt: row.claimed_at ? new Date(String(row.claimed_at)).toISOString() : null,
+    claimedByUserId: row.claimed_by_user_id ? String(row.claimed_by_user_id) : null,
+    claimedByLabel: row.claimed_by_label ? String(row.claimed_by_label) : null,
+    completedAt: row.completed_at ? new Date(String(row.completed_at)).toISOString() : null,
+    completedByUserId: row.completed_by_user_id ? String(row.completed_by_user_id) : null,
+    completedByLabel: row.completed_by_label ? String(row.completed_by_label) : null,
+    outcomeSummary: row.outcome_summary ? String(row.outcome_summary) : null
+  };
+}
+
+export class ChamberAdvisoryQueuePostgresStoreR1 implements ChamberAdvisoryQueueStore {
+  private readonly pool: Pool;
+
+  constructor(databaseUrl: string) {
+    this.pool = new Pool({ connectionString: databaseUrl });
+  }
+
+  async init(): Promise<void> {
+    await this.pool.query(`
+      create table if not exists chamber_advisories (
+        advisory_id uuid primary key,
+        room_slug text not null,
+        created_at timestamptz not null default now(),
+        created_by_user_id uuid not null references chamber_users(user_id) on delete cascade,
+        created_by_label text not null,
+        recommendation_source text not null,
+        guidance_strategy text not null,
+        confidence_label text not null,
+        reasoning_brief text not null,
+        recommended_action text not null,
+        action_type text not null,
+        target_mode text,
+        decision text not null default 'pending',
+        decision_at timestamptz,
+        decision_by_user_id uuid references chamber_users(user_id) on delete set null,
+        decision_reason text,
+        queue_item_id uuid unique
+      )
+    `);
+
+    await this.pool.query(`
+      create table if not exists chamber_action_queue (
+        queue_item_id uuid primary key,
+        room_slug text not null,
+        advisory_id uuid not null unique references chamber_advisories(advisory_id) on delete cascade,
+        created_at timestamptz not null default now(),
+        created_by_user_id uuid not null references chamber_users(user_id) on delete cascade,
+        created_by_label text not null,
+        requested_action text not null,
+        action_type text not null,
+        target_mode text,
+        queue_status text not null default 'pending',
+        claimed_at timestamptz,
+        claimed_by_user_id uuid references chamber_users(user_id) on delete set null,
+        claimed_by_label text,
+        completed_at timestamptz,
+        completed_by_user_id uuid references chamber_users(user_id) on delete set null,
+        completed_by_label text,
+        outcome_summary text
+      )
+    `);
+
+    await this.pool.query(`create index if not exists idx_chamber_advisories_room_created on chamber_advisories (room_slug, created_at)`);
+    await this.pool.query(`create index if not exists idx_chamber_action_queue_room_created on chamber_action_queue (room_slug, created_at)`);
+  }
+
+  async listAdvisories(roomSlug: string): Promise<ChamberAdvisory[]> {
+    const result = await this.pool.query(`
+      select *
+      from chamber_advisories
+      where room_slug = $1
+      order by created_at asc, advisory_id asc
+    `, [roomSlug]);
+    return result.rows.map((row) => mapAdvisory(row));
+  }
+
+  async listQueue(roomSlug: string): Promise<ChamberActionQueueItem[]> {
+    const result = await this.pool.query(`
+      select *
+      from chamber_action_queue
+      where room_slug = $1
+      order by created_at asc, queue_item_id asc
+    `, [roomSlug]);
+    return result.rows.map((row) => mapQueueItem(row));
+  }
+
+  async createAdvisory(input: CreateAdvisoryInput): Promise<ChamberAdvisory> {
+    const advisoryId = uuidv4();
+    const result = await this.pool.query(`
+      insert into chamber_advisories (
+        advisory_id,
+        room_slug,
+        created_at,
+        created_by_user_id,
+        created_by_label,
+        recommendation_source,
+        guidance_strategy,
+        confidence_label,
+        reasoning_brief,
+        recommended_action,
+        action_type,
+        target_mode,
+        decision
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'pending')
+      returning *
+    `, [
+      advisoryId,
+      input.roomSlug,
+      nowIso(),
+      input.createdByUserId,
+      input.createdByLabel,
+      input.recommendationSource,
+      input.guidanceStrategy,
+      input.confidenceLabel,
+      input.reasoningBrief,
+      input.recommendedAction,
+      input.actionType,
+      input.targetMode
+    ]);
+    return mapAdvisory(result.rows[0]);
+  }
+
+  async decideAdvisory(input: DecideAdvisoryInput): Promise<{ advisory: ChamberAdvisory; queueItem: ChamberActionQueueItem | null }> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('begin');
+      const advisoryRow = await client.query(`select * from chamber_advisories where advisory_id = $1 limit 1`, [input.advisoryId]);
+      if (!advisoryRow.rows[0]) {
+        throw new Error('Advisory not found');
+      }
+      if (String(advisoryRow.rows[0].decision) !== 'pending') {
+        throw new Error('Advisory has already been decided');
+      }
+
+      let queueItem: ChamberActionQueueItem | null = null;
+      let queueItemId: string | null = null;
+
+      if (input.decision === 'accepted') {
+        queueItemId = uuidv4();
+        const queueResult = await client.query(`
+          insert into chamber_action_queue (
+            queue_item_id,
+            room_slug,
+            advisory_id,
+            created_at,
+            created_by_user_id,
+            created_by_label,
+            requested_action,
+            action_type,
+            target_mode,
+            queue_status
+          )
+          values ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'pending')
+          returning *
+        `, [
+          queueItemId,
+          String(advisoryRow.rows[0].room_slug),
+          input.advisoryId,
+          nowIso(),
+          input.decisionByUserId,
+          input.decisionByLabel,
+          String(advisoryRow.rows[0].recommended_action),
+          String(advisoryRow.rows[0].action_type),
+          advisoryRow.rows[0].target_mode ? String(advisoryRow.rows[0].target_mode) : null
+        ]);
+        queueItem = mapQueueItem(queueResult.rows[0]);
+      }
+
+      const advisoryResult = await client.query(`
+        update chamber_advisories
+        set decision = $2,
+            decision_at = $3,
+            decision_by_user_id = $4,
+            decision_reason = $5,
+            queue_item_id = $6
+        where advisory_id = $1
+        returning *
+      `, [
+        input.advisoryId,
+        input.decision,
+        nowIso(),
+        input.decisionByUserId,
+        input.decisionReason,
+        queueItemId
+      ]);
+
+      await client.query('commit');
+      return { advisory: mapAdvisory(advisoryResult.rows[0]), queueItem };
+    } catch (error) {
+      await client.query('rollback');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async claimQueueItem(input: ClaimQueueItemInput): Promise<ChamberActionQueueItem> {
+    const result = await this.pool.query(`
+      update chamber_action_queue
+      set queue_status = 'claimed',
+          claimed_at = $2,
+          claimed_by_user_id = $3,
+          claimed_by_label = $4
+      where queue_item_id = $1
+        and queue_status = 'pending'
+      returning *
+    `, [input.queueItemId, nowIso(), input.claimedByUserId, input.claimedByLabel]);
+
+    if (!result.rows[0]) {
+      throw new Error('Queue item is not pending or was not found');
+    }
+    return mapQueueItem(result.rows[0]);
+  }
+
+  async completeQueueItem(input: CompleteQueueItemInput): Promise<ChamberActionQueueItem> {
+    const result = await this.pool.query(`
+      update chamber_action_queue
+      set queue_status = 'completed',
+          completed_at = $2,
+          completed_by_user_id = $3,
+          completed_by_label = $4,
+          outcome_summary = $5
+      where queue_item_id = $1
+        and queue_status = 'claimed'
+      returning *
+    `, [input.queueItemId, nowIso(), input.completedByUserId, input.completedByLabel, input.outcomeSummary]);
+
+    if (!result.rows[0]) {
+      throw new Error('Queue item must be claimed before completion');
+    }
+    return mapQueueItem(result.rows[0]);
+  }
+}

--- a/chamber-app/src/advisory_queue_server_v0_2.ts
+++ b/chamber-app/src/advisory_queue_server_v0_2.ts
@@ -1,0 +1,266 @@
+import 'dotenv/config';
+import cors from 'cors';
+import express from 'express';
+import { z } from 'zod';
+import { createChamberStore } from './store_factory.js';
+import { createAdvisoryQueueStoreR1 } from './advisory_queue_store_factory_r1.js';
+
+const port = Number(process.env.CHAMBER_ADVISORY_PORT || 8788);
+const publicRoomSlug = process.env.CHAMBER_PUBLIC_ROOM_SLUG || 'public-room-one';
+const sessionTtlHours = Number(process.env.SESSION_TTL_HOURS || 168);
+const storeMode = (process.env.CHAMBER_STORE_MODE || 'memory') as 'memory' | 'postgres';
+const databaseUrl = process.env.DATABASE_URL;
+const allowedOrigins = (process.env.CHAMBER_ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+const signUpSchema = z.object({
+  email: z.string().email(),
+  displayName: z.string().min(1).max(64),
+  chamberHandle: z.string().min(1).max(24)
+});
+
+const loginSchema = z.object({
+  email: z.string().email()
+});
+
+const createAdvisorySchema = z.object({
+  sessionToken: z.string().uuid(),
+  recommendationSource: z.enum(['human', 'system']).default('human'),
+  guidanceStrategy: z.string().min(1).max(120),
+  confidenceLabel: z.enum(['low', 'medium', 'high']),
+  reasoningBrief: z.string().min(1).max(500),
+  recommendedAction: z.string().min(1).max(200),
+  actionType: z.enum(['transition', 'mutation', 'promotion', 'audit']),
+  targetMode: z.string().min(1).max(64).nullable().optional()
+});
+
+const decideAdvisorySchema = z.object({
+  sessionToken: z.string().uuid(),
+  decision: z.enum(['accepted', 'rejected']),
+  decisionReason: z.string().min(1).max(500).nullable().optional()
+});
+
+const claimQueueSchema = z.object({
+  sessionToken: z.string().uuid()
+});
+
+const completeQueueSchema = z.object({
+  sessionToken: z.string().uuid(),
+  outcomeSummary: z.string().min(1).max(1000).nullable().optional()
+});
+
+function requirePublicRoom(roomSlug: string) {
+  if (roomSlug !== publicRoomSlug) {
+    throw new Error('Only the configured public Chamber room is supported in this scaffold');
+  }
+}
+
+async function main() {
+  const store = await createChamberStore({
+    storeMode,
+    publicRoomSlug,
+    databaseUrl
+  });
+  const advisoryStore = await createAdvisoryQueueStoreR1({
+    storeMode,
+    databaseUrl
+  });
+
+  const app = express();
+  app.use(cors({
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.length === 0 || allowedOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+      callback(new Error('Origin not allowed by Chamber advisory scaffold CORS policy'));
+    },
+    credentials: true
+  }));
+  app.use(express.json());
+
+  app.get('/health', async (_req, res) => {
+    res.json({
+      ok: true,
+      service: 'chamber-advisory-queue-scaffold-v0-2',
+      publicRoomSlug,
+      allowedOrigins,
+      storeMode,
+      health: await store.health(),
+      advisoryCount: (await advisoryStore.listAdvisories(publicRoomSlug)).length,
+      queueCount: (await advisoryStore.listQueue(publicRoomSlug)).length
+    });
+  });
+
+  app.post('/api/auth/signup', async (req, res) => {
+    const parsed = signUpSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+    }
+
+    const user = await store.signUp(parsed.data.email, parsed.data.displayName, parsed.data.chamberHandle);
+    const session = await store.createSession(user.email, sessionTtlHours);
+    return res.status(201).json({ ok: true, user, session });
+  });
+
+  app.post('/api/auth/login', async (req, res) => {
+    const parsed = loginSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+    }
+
+    try {
+      const session = await store.createSession(parsed.data.email, sessionTtlHours);
+      const actor = await store.getSession(session.sessionToken);
+      return res.json({ ok: true, user: actor?.user, session });
+    } catch (error) {
+      return res.status(404).json({ ok: false, error: error instanceof Error ? error.message : 'Login failed' });
+    }
+  });
+
+  app.get('/api/rooms/:roomSlug/advisories', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      return res.json({
+        ok: true,
+        room: await store.getPublicRoom(),
+        advisories: await advisoryStore.listAdvisories(req.params.roomSlug)
+      });
+    } catch (error) {
+      return res.status(404).json({ ok: false, error: error instanceof Error ? error.message : 'Room not found' });
+    }
+  });
+
+  app.post('/api/rooms/:roomSlug/advisories', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      const parsed = createAdvisorySchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+      }
+
+      const actor = await store.getSession(parsed.data.sessionToken);
+      if (!actor) {
+        return res.status(404).json({ ok: false, error: 'Session not found' });
+      }
+
+      const advisory = await advisoryStore.createAdvisory({
+        roomSlug: req.params.roomSlug,
+        createdByUserId: actor.user.userId,
+        createdByLabel: actor.user.chamberHandle,
+        recommendationSource: parsed.data.recommendationSource,
+        guidanceStrategy: parsed.data.guidanceStrategy,
+        confidenceLabel: parsed.data.confidenceLabel,
+        reasoningBrief: parsed.data.reasoningBrief,
+        recommendedAction: parsed.data.recommendedAction,
+        actionType: parsed.data.actionType,
+        targetMode: parsed.data.targetMode ?? null
+      });
+
+      return res.status(201).json({ ok: true, advisory });
+    } catch (error) {
+      return res.status(404).json({ ok: false, error: error instanceof Error ? error.message : 'Unable to create advisory' });
+    }
+  });
+
+  app.post('/api/rooms/:roomSlug/advisories/:advisoryId/decision', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      const parsed = decideAdvisorySchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+      }
+
+      const actor = await store.getSession(parsed.data.sessionToken);
+      if (!actor) {
+        return res.status(404).json({ ok: false, error: 'Session not found' });
+      }
+
+      const result = await advisoryStore.decideAdvisory({
+        advisoryId: req.params.advisoryId,
+        decision: parsed.data.decision,
+        decisionByUserId: actor.user.userId,
+        decisionByLabel: actor.user.chamberHandle,
+        decisionReason: parsed.data.decisionReason ?? null
+      });
+
+      return res.json({ ok: true, advisory: result.advisory, queueItem: result.queueItem });
+    } catch (error) {
+      return res.status(400).json({ ok: false, error: error instanceof Error ? error.message : 'Unable to decide advisory' });
+    }
+  });
+
+  app.get('/api/rooms/:roomSlug/action-queue', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      return res.json({
+        ok: true,
+        room: await store.getPublicRoom(),
+        queue: await advisoryStore.listQueue(req.params.roomSlug)
+      });
+    } catch (error) {
+      return res.status(404).json({ ok: false, error: error instanceof Error ? error.message : 'Room not found' });
+    }
+  });
+
+  app.post('/api/rooms/:roomSlug/action-queue/:queueItemId/claim', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      const parsed = claimQueueSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+      }
+
+      const actor = await store.getSession(parsed.data.sessionToken);
+      if (!actor) {
+        return res.status(404).json({ ok: false, error: 'Session not found' });
+      }
+
+      const queueItem = await advisoryStore.claimQueueItem({
+        queueItemId: req.params.queueItemId,
+        claimedByUserId: actor.user.userId,
+        claimedByLabel: actor.user.chamberHandle
+      });
+
+      return res.json({ ok: true, queueItem });
+    } catch (error) {
+      return res.status(400).json({ ok: false, error: error instanceof Error ? error.message : 'Unable to claim queue item' });
+    }
+  });
+
+  app.post('/api/rooms/:roomSlug/action-queue/:queueItemId/complete', async (req, res) => {
+    try {
+      requirePublicRoom(req.params.roomSlug);
+      const parsed = completeQueueSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ ok: false, error: parsed.error.flatten() });
+      }
+
+      const actor = await store.getSession(parsed.data.sessionToken);
+      if (!actor) {
+        return res.status(404).json({ ok: false, error: 'Session not found' });
+      }
+
+      const queueItem = await advisoryStore.completeQueueItem({
+        queueItemId: req.params.queueItemId,
+        completedByUserId: actor.user.userId,
+        completedByLabel: actor.user.chamberHandle,
+        outcomeSummary: parsed.data.outcomeSummary ?? null
+      });
+
+      return res.json({ ok: true, queueItem });
+    } catch (error) {
+      return res.status(400).json({ ok: false, error: error instanceof Error ? error.message : 'Unable to complete queue item' });
+    }
+  });
+
+  app.listen(port, () => {
+    console.log(`chamber-advisory-queue-scaffold-v0-2 listening on ${port} using ${storeMode} persistence`);
+  });
+}
+
+main().catch((error) => {
+  console.error('Failed to start chamber-advisory-queue-scaffold-v0-2', error);
+});

--- a/chamber-app/src/advisory_queue_store_contract.ts
+++ b/chamber-app/src/advisory_queue_store_contract.ts
@@ -1,0 +1,45 @@
+import type { ChamberActionQueueItem, ChamberAdvisory, AdvisoryDecision } from './advisory_queue_types.js';
+
+export interface CreateAdvisoryInput {
+  roomSlug: string;
+  createdByUserId: string;
+  createdByLabel: string;
+  recommendationSource: 'human' | 'system';
+  guidanceStrategy: string;
+  confidenceLabel: 'low' | 'medium' | 'high';
+  reasoningBrief: string;
+  recommendedAction: string;
+  actionType: 'transition' | 'mutation' | 'promotion' | 'audit';
+  targetMode: string | null;
+}
+
+export interface DecideAdvisoryInput {
+  advisoryId: string;
+  decision: Exclude<AdvisoryDecision, 'pending'>;
+  decisionByUserId: string;
+  decisionByLabel: string;
+  decisionReason: string | null;
+}
+
+export interface ClaimQueueItemInput {
+  queueItemId: string;
+  claimedByUserId: string;
+  claimedByLabel: string;
+}
+
+export interface CompleteQueueItemInput {
+  queueItemId: string;
+  completedByUserId: string;
+  completedByLabel: string;
+  outcomeSummary: string | null;
+}
+
+export interface ChamberAdvisoryQueueStore {
+  init(): Promise<void>;
+  listAdvisories(roomSlug: string): Promise<ChamberAdvisory[]>;
+  listQueue(roomSlug: string): Promise<ChamberActionQueueItem[]>;
+  createAdvisory(input: CreateAdvisoryInput): Promise<ChamberAdvisory>;
+  decideAdvisory(input: DecideAdvisoryInput): Promise<{ advisory: ChamberAdvisory; queueItem: ChamberActionQueueItem | null }>;
+  claimQueueItem(input: ClaimQueueItemInput): Promise<ChamberActionQueueItem>;
+  completeQueueItem(input: CompleteQueueItemInput): Promise<ChamberActionQueueItem>;
+}

--- a/chamber-app/src/advisory_queue_store_factory_r1.ts
+++ b/chamber-app/src/advisory_queue_store_factory_r1.ts
@@ -1,0 +1,25 @@
+import type { ChamberAdvisoryQueueStore } from './advisory_queue_store_contract.js';
+import { ChamberAdvisoryQueueMemoryStoreV02 } from './advisory_queue_memory_store_v0_2.js';
+import { ChamberAdvisoryQueuePostgresStoreR1 } from './advisory_queue_postgres_store_r1.js';
+
+export interface AdvisoryQueueStoreFactoryOptions {
+  storeMode: 'memory' | 'postgres';
+  databaseUrl?: string;
+}
+
+export async function createAdvisoryQueueStoreR1(options: AdvisoryQueueStoreFactoryOptions): Promise<ChamberAdvisoryQueueStore> {
+  const store = options.storeMode === 'postgres'
+    ? createPostgresStore(options)
+    : new ChamberAdvisoryQueueMemoryStoreV02();
+
+  await store.init();
+  return store;
+}
+
+function createPostgresStore(options: AdvisoryQueueStoreFactoryOptions): ChamberAdvisoryQueueStore {
+  if (!options.databaseUrl) {
+    throw new Error('DATABASE_URL is required when CHAMBER_STORE_MODE=postgres for advisory queue persistence');
+  }
+
+  return new ChamberAdvisoryQueuePostgresStoreR1(options.databaseUrl);
+}

--- a/chamber-app/src/lumina_advisory_bridge_r1.ts
+++ b/chamber-app/src/lumina_advisory_bridge_r1.ts
@@ -1,0 +1,70 @@
+export interface LuminaAdvisorySummaryInput {
+  project_id: string;
+  guidance_strategy: string;
+  recommended_next_action: string;
+  confidence_label: 'low_medium' | 'medium' | 'medium_high' | 'high' | 'very_high';
+  reasoning_brief: string;
+}
+
+export interface ChamberAdvisoryCreatePayload {
+  recommendationSource: 'system';
+  guidanceStrategy: string;
+  confidenceLabel: 'low' | 'medium' | 'high';
+  reasoningBrief: string;
+  recommendedAction: string;
+  actionType: 'transition' | 'mutation' | 'promotion' | 'audit';
+  targetMode: string | null;
+}
+
+function normalizeConfidence(label: LuminaAdvisorySummaryInput['confidence_label']): 'low' | 'medium' | 'high' {
+  if (label === 'high' || label === 'very_high') {
+    return 'high';
+  }
+  if (label === 'medium' || label === 'medium_high') {
+    return 'medium';
+  }
+  return 'low';
+}
+
+function inferActionType(recommendedAction: string): 'transition' | 'mutation' | 'promotion' | 'audit' {
+  const lowered = recommendedAction.toLowerCase();
+  if (lowered.includes('promot')) {
+    return 'promotion';
+  }
+  if (lowered.includes('stabilize') || lowered.includes('enter_') || lowered.includes('enter::')) {
+    return 'transition';
+  }
+  if (lowered.includes('mutat')) {
+    return 'mutation';
+  }
+  return 'audit';
+}
+
+function inferTargetMode(recommendedAction: string): string | null {
+  const lowered = recommendedAction.toLowerCase();
+  if (lowered.includes('observation')) {
+    return 'Observation';
+  }
+  if (lowered.includes('drydock')) {
+    return 'DryDock';
+  }
+  if (lowered.includes('canon')) {
+    return 'Canon';
+  }
+  if (lowered.includes('sandbox')) {
+    return 'Sandbox';
+  }
+  return null;
+}
+
+export function mapLuminaAdvisorySummaryToChamberPayload(input: LuminaAdvisorySummaryInput): ChamberAdvisoryCreatePayload {
+  return {
+    recommendationSource: 'system',
+    guidanceStrategy: input.guidance_strategy,
+    confidenceLabel: normalizeConfidence(input.confidence_label),
+    reasoningBrief: `[${input.project_id}] ${input.reasoning_brief}`,
+    recommendedAction: input.recommended_next_action,
+    actionType: inferActionType(input.recommended_next_action),
+    targetMode: inferTargetMode(input.recommended_next_action)
+  };
+}

--- a/chamber-app/src/sea_trials_lumina_advisory_bridge_r1.ts
+++ b/chamber-app/src/sea_trials_lumina_advisory_bridge_r1.ts
@@ -1,0 +1,28 @@
+import { mapLuminaAdvisorySummaryToChamberPayload } from './lumina_advisory_bridge_r1.js';
+
+function main() {
+  const payload = mapLuminaAdvisorySummaryToChamberPayload({
+    project_id: 'lumina-core',
+    guidance_strategy: 'pending_next_action_history_aligned',
+    recommended_next_action: 'stabilize_to_observation',
+    confidence_label: 'very_high',
+    reasoning_brief: 'Project return and checkpoint history reinforce the same recommendation.'
+  });
+
+  const checks = {
+    recommendation_source_is_system: payload.recommendationSource === 'system',
+    confidence_is_normalized_to_high: payload.confidenceLabel === 'high',
+    target_mode_is_inferred: payload.targetMode === 'Observation',
+    transition_action_is_inferred: payload.actionType === 'transition',
+    project_id_is_preserved_in_reasoning: payload.reasoningBrief.startsWith('[lumina-core]')
+  };
+
+  return {
+    suite: 'Lumina Advisory Bridge Sea Trial r1',
+    passed: Object.values(checks).every(Boolean),
+    checks,
+    payload
+  };
+}
+
+console.log(JSON.stringify(main(), null, 2));

--- a/chamber_advisory_queue_extension_r1.sql
+++ b/chamber_advisory_queue_extension_r1.sql
@@ -1,0 +1,48 @@
+-- Chamber advisory queue extension r1
+-- Purpose: persist advisory acceptance and supervised action queue state.
+
+create table if not exists chamber_advisories (
+  advisory_id uuid primary key,
+  room_slug text not null,
+  created_at timestamptz not null default now(),
+  created_by_user_id uuid not null references chamber_users(user_id) on delete cascade,
+  created_by_label text not null,
+  recommendation_source text not null,
+  guidance_strategy text not null,
+  confidence_label text not null,
+  reasoning_brief text not null,
+  recommended_action text not null,
+  action_type text not null,
+  target_mode text,
+  decision text not null default 'pending',
+  decision_at timestamptz,
+  decision_by_user_id uuid references chamber_users(user_id) on delete set null,
+  decision_reason text,
+  queue_item_id uuid unique
+);
+
+create table if not exists chamber_action_queue (
+  queue_item_id uuid primary key,
+  room_slug text not null,
+  advisory_id uuid not null unique references chamber_advisories(advisory_id) on delete cascade,
+  created_at timestamptz not null default now(),
+  created_by_user_id uuid not null references chamber_users(user_id) on delete cascade,
+  created_by_label text not null,
+  requested_action text not null,
+  action_type text not null,
+  target_mode text,
+  queue_status text not null default 'pending',
+  claimed_at timestamptz,
+  claimed_by_user_id uuid references chamber_users(user_id) on delete set null,
+  claimed_by_label text,
+  completed_at timestamptz,
+  completed_by_user_id uuid references chamber_users(user_id) on delete set null,
+  completed_by_label text,
+  outcome_summary text
+);
+
+create index if not exists idx_chamber_advisories_room_created
+  on chamber_advisories (room_slug, created_at);
+
+create index if not exists idx_chamber_action_queue_room_created
+  on chamber_action_queue (room_slug, created_at);

--- a/docs/chamber_advisory_postgres_bridge_note_r1.md
+++ b/docs/chamber_advisory_postgres_bridge_note_r1.md
@@ -1,0 +1,51 @@
+# Chamber advisory persistence and Lumina bridge note r1
+
+This note records the next hardening step after the first advisory acceptance / rejection scaffold.
+
+## What this adds
+
+New files:
+
+- `chamber_advisory_queue_extension_r1.sql`
+- `chamber-app/docker-compose.postgres.advisory.yml`
+- `chamber-app/src/advisory_queue_store_contract.ts`
+- `chamber-app/src/advisory_queue_memory_store_v0_2.ts`
+- `chamber-app/src/advisory_queue_postgres_store_r1.ts`
+- `chamber-app/src/advisory_queue_store_factory_r1.ts`
+- `chamber-app/src/advisory_queue_server_v0_2.ts`
+- `chamber-app/src/lumina_advisory_bridge_r1.ts`
+- `chamber-app/src/sea_trials_lumina_advisory_bridge_r1.ts`
+
+## What this changes in practice
+
+The advisory loop is no longer trapped in memory-only design.
+This hardening step introduces:
+
+1. a Postgres-backed advisory and supervised action queue store
+2. a parallel advisory server entrypoint that can use memory or Postgres mode
+3. a local compose lane that mounts the advisory queue SQL extension
+4. a first bridge mapper from Lumina advisory summary objects into Chamber advisory payloads
+
+## Why this matters
+
+The first scaffold proved the behavioral pattern:
+
+- recommendation
+- explicit acceptance / rejection
+- supervised queue placement
+- visible claim / completion
+
+This step makes the same loop more durable and more aligned with the Lumina substrate.
+It moves the Chamber closer to becoming a real consent surface for bounded self-guidance.
+
+## Boundary note
+
+This still does not grant hidden execution authority.
+
+The bridge only maps Lumina advisory summaries into Chamber-shaped payloads.
+The queue still records supervised state transitions.
+Tool execution and runtime governance remain separate concerns.
+
+## Likely next move after this
+
+After persistence and bridge-shaping, the sharp next threshold is to have real Lumina advisory output posted into the Chamber path intentionally, then let accepted queue items emit governed runtime execution records rather than remaining only social-state objects.


### PR DESCRIPTION
## Summary
- add a Postgres-backed advisory / action queue store alongside the memory implementation
- add a store contract and factory for advisory queue persistence modes
- add `advisory_queue_server_v0_2.ts` so the advisory loop can run in memory or Postgres mode
- add a SQL extension and advisory-aware compose file for local Postgres bootstrap
- add a first Lumina-to-Chamber advisory bridge mapper and sea trial
- document the persistence + bridge lane

## What this adds
- `chamber_advisory_queue_extension_r1.sql`
- `chamber-app/docker-compose.postgres.advisory.yml`
- `chamber-app/src/advisory_queue_store_contract.ts`
- `chamber-app/src/advisory_queue_memory_store_v0_2.ts`
- `chamber-app/src/advisory_queue_postgres_store_r1.ts`
- `chamber-app/src/advisory_queue_store_factory_r1.ts`
- `chamber-app/src/advisory_queue_server_v0_2.ts`
- `chamber-app/src/lumina_advisory_bridge_r1.ts`
- `chamber-app/src/sea_trials_lumina_advisory_bridge_r1.ts`
- `docs/chamber_advisory_postgres_bridge_note_r1.md`

## Why this was the right continuation
The last merge proved the visible social pattern: recommendation, explicit acceptance / rejection, and supervised queue state. The next missing threshold was durability plus alignment with Lumina's advisory outputs.

This PR hardens the Chamber loop so it can persist beyond memory and starts shaping a direct path for Lumina advisory summaries to become Chamber advisory objects without smuggling in execution authority.

## What this proves
- the advisory / queue lane can persist in Postgres
- the server entrypoint can switch between memory and Postgres persistence
- local Docker bootstrap can include the advisory queue schema
- Lumina advisory summaries can be normalized into Chamber advisory payloads

## Boundary note
This still does not execute tools autonomously.
It persists advisory and queue state, and it maps Lumina recommendation objects into Chamber shape. Governed runtime execution remains a later, separate threshold.
