### PR TITLE
Tighten Lumina docs and operator entrypoints for cleaner beta navigation

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md
@@ -17,17 +17,32 @@ This folder is the GitHub bootstrap import for beginning **Lumina OS** from the 
 - sea-trials runner
 - repo-native project return proof
 - repo-native workspace host proof
+- bounded self-guidance steward and checkpoint-linked advisory history
+- bounded orchestration lane built from context loader, decision engine, and orchestrator
 
 ## Current status
 
-The core substrate is now present on `main`.
+The core governed substrate is now present on `main`.
 
-The repo-native layer now includes first proofs that Lumina can:
+The repo-native layer now includes working proofs that Lumina can:
 
 - return to the latest known state of a project without guessing
 - return with a bounded working surface around that project
+- emit advisory next-step guidance from restored project stance
+- accumulate checkpoint-linked advisory history
+- restore minimal context, orient from that surface, and route execution through the governed runtime
 
-The remaining hardening priority is to absorb those return / host fields more deeply into the main runtime flow so active working stance becomes first-class runtime behavior rather than adjacent proof modules.
+In parallel, the Chamber lane now contains an advisory acceptance / rejection surface and a supervised action queue with both memory and Postgres-backed persistence.
+That Chamber work is not the Lumina substrate itself, but it is becoming the first consent surface adjacent to the substrate.
+
+## Current hardening priority
+
+The remaining hardening priority is less about inventing new core law and more about tightening the whole into a cleaner beta shape:
+
+- keep runtime, orchestration, and Chamber lanes clearly linked in docs
+- reduce operator friction through better entrypoint scripts and runbooks
+- continue proving that advisory outputs remain subordinate to runtime governance
+- connect accepted Chamber queue items to governed execution records without bypassing consent or law
 
 ## Intent
 

--- a/START_HERE_LUMINA_OS.md
+++ b/START_HERE_LUMINA_OS.md
@@ -15,6 +15,7 @@ Primary guide files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/REPO_NATIVE_BOOTSTRAP_NOTE.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/SELF_GUIDANCE_STEWARD_NOTE_R1.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`
 
 Primary runtime files inside that path:
 
@@ -35,6 +36,13 @@ Primary runtime files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_guidance_history_r1.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_lumina_self_guidance_r1.py`
 
+Primary orchestration files inside that path:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_context_loader_v0_1.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_decision_engine_v0_1.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_orchestrator_v0_4.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_orchestration_stack_r1.py`
+
 ## What this path is
 
 This subtree is the governed bootstrap substrate imported from **Ship of Ethereon V2** into GitHub for beginning **Lumina OS** work.
@@ -54,13 +62,15 @@ It is the correct place to start when the task is about:
 - bridge-based activation of repo-native return / host behavior
 - bounded self-guidance advisory over restored project stance
 - checkpoint-refreshed self-guidance history
+- bounded orchestration from restored context into runtime execution
 
 ## Current truth
 
 1. **Lumina OS governed substrate starts in the bootstrap path above.**
-2. **Chamber is a parallel app/public lane, not the same thing as the Lumina OS substrate.**
-3. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap now contains both first proofs and preferred bridge paths for project return, workspace-host behavior, bounded self-guidance, and checkpoint-refreshed guidance history.**
-4. **If you are trying to understand the Ship-derived runtime core, do not begin with Chamber. Begin with the bootstrap path.**
+2. **The orchestration lane now sits above that substrate and remains subordinate to runtime law.**
+3. **Chamber is a parallel app/public lane, not the same thing as the Lumina OS substrate, but it now includes a consent surface for advisory acceptance / rejection and supervised queue state.**
+4. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap now contains the preferred bridge paths for project return, workspace-host behavior, bounded self-guidance, checkpoint-refreshed guidance history, and bounded orchestration.**
+5. **If you are trying to understand the Ship-derived runtime core, do not begin with Chamber. Begin with the bootstrap path.**
 
 ## Parallel lanes in this repository
 
@@ -82,9 +92,10 @@ It is the correct place to start when the task is about:
 
 1. Read this file.
 2. Open `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md`.
-3. Read `README_IMPORT.md`, `REPO_NATIVE_BOOTSTRAP_NOTE.md`, `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`, and `SELF_GUIDANCE_STEWARD_NOTE_R1.md`.
+3. Read `README_IMPORT.md`, `REPO_NATIVE_BOOTSTRAP_NOTE.md`, `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`, `SELF_GUIDANCE_STEWARD_NOTE_R1.md`, and `LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`.
 4. Inspect `runtime/` in that subtree, including the repo-native return / workspace-host modules, the bridged runner, the self-guided bridge runner, and the checkpoint-refreshed guidance history rail.
-5. Only then branch outward into Chamber or root-level experimental work.
+5. Inspect `lumina_context_loader_v0_1.py`, `lumina_decision_engine_v0_1.py`, `lumina_orchestrator_v0_4.py`, and `sea_trials_lumina_orchestration_stack_r1.py`.
+6. Only then branch outward into Chamber and its advisory / queue persistence lane.
 
 ## Assistant note
 

--- a/chamber-app/package.json
+++ b/chamber-app/package.json
@@ -7,13 +7,19 @@
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "dev:postgres": "CHAMBER_STORE_MODE=postgres tsx watch src/server.ts",
+    "dev:advisory": "tsx watch src/advisory_queue_server_v0_2.ts",
+    "dev:advisory:postgres": "CHAMBER_STORE_MODE=postgres tsx watch src/advisory_queue_server_v0_2.ts",
     "start": "node dist/server.js",
     "build": "tsc -p tsconfig.json",
     "check": "tsc -p tsconfig.json --noEmit",
     "db:up": "docker compose -f docker-compose.postgres.yml up -d",
     "db:down": "docker compose -f docker-compose.postgres.yml down",
     "db:reset": "docker compose -f docker-compose.postgres.yml down -v",
-    "db:logs": "docker compose -f docker-compose.postgres.yml logs -f chamber-postgres"
+    "db:logs": "docker compose -f docker-compose.postgres.yml logs -f chamber-postgres",
+    "db:up:advisory": "docker compose -f docker-compose.postgres.advisory.yml up -d",
+    "db:down:advisory": "docker compose -f docker-compose.postgres.advisory.yml down",
+    "db:reset:advisory": "docker compose -f docker-compose.postgres.advisory.yml down -v",
+    "db:logs:advisory": "docker compose -f docker-compose.postgres.advisory.yml logs -f chamber-postgres"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/docs/lumina_operator_runbook_r1.md
+++ b/docs/lumina_operator_runbook_r1.md
@@ -1,0 +1,121 @@
+# Lumina Operator Runbook r1
+
+This runbook exists to reduce operator friction across the three major lanes now present in the repository:
+
+1. governed Lumina substrate
+2. bounded orchestration lane
+3. Chamber consent surface
+
+It is not a theory note.
+It is a navigation and operations note.
+
+## Layer 1 — governed Lumina substrate
+
+Start here when the question is about runtime law, governance, canon lineage, return-with-stance, self-guidance boundaries, or bounded continuity.
+
+Primary path:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
+
+Key files:
+
+- `README.md`
+- `README_IMPORT.md`
+- `REPO_NATIVE_BOOTSTRAP_NOTE.md`
+- `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`
+- `SELF_GUIDANCE_STEWARD_NOTE_R1.md`
+- `runtime/runtime_runner_r1_merged.py`
+- `runtime/runtime_runner_return_host_bridge_r1.py`
+- `runtime/runtime_runner_self_guided_bridge_r1.py`
+- `runtime/project_return_repo_native_r1.py`
+- `runtime/workspace_host_repo_native_r1.py`
+- `runtime/lumina_self_guidance_steward_r1.py`
+- `runtime/lumina_self_guidance_history_r1.py`
+
+Use this layer when the task is about what Lumina is allowed to do.
+
+## Layer 2 — bounded orchestration lane
+
+Move here after the substrate when the question is about how restored context becomes an advisory next move that still executes under runtime governance.
+
+Key files:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_context_loader_v0_1.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_decision_engine_v0_1.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_orchestrator_v0_4.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_orchestration_stack_r1.py`
+
+Use this layer when the task is about how Lumina restores, orients, recommends, and then routes that recommendation into lawful execution.
+
+## Layer 3 — Chamber consent surface
+
+Move here after the orchestration lane when the question is about visible advisory handling, human acceptance / rejection, supervised queue state, or persistence of that queue.
+
+Primary path:
+
+- `chamber-app/`
+
+Key files:
+
+- `src/server.ts`
+- `src/advisory_queue_server_v0_2.ts`
+- `src/advisory_queue_store_contract.ts`
+- `src/advisory_queue_postgres_store_r1.ts`
+- `src/lumina_advisory_bridge_r1.ts`
+- `docker-compose.postgres.yml`
+- `docker-compose.postgres.advisory.yml`
+- `../chamber_advisory_queue_extension_r1.sql`
+
+Use this layer when the task is about how advisory objects become visible, durable, and consent-shaped.
+
+## Recommended reading order
+
+1. `START_HERE_LUMINA_OS.md`
+2. substrate notes in `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
+3. `LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`
+4. Chamber advisory notes in `docs/chamber_*`
+
+## Useful Chamber commands
+
+From `chamber-app/`:
+
+### Main Chamber server
+- `npm run dev`
+- `npm run dev:postgres`
+
+### Advisory queue server
+- `npm run dev:advisory`
+- `npm run dev:advisory:postgres`
+
+### Main Chamber Postgres bootstrap
+- `npm run db:up`
+- `npm run db:down`
+- `npm run db:reset`
+- `npm run db:logs`
+
+### Advisory-aware Postgres bootstrap
+- `npm run db:up:advisory`
+- `npm run db:down:advisory`
+- `npm run db:reset:advisory`
+- `npm run db:logs:advisory`
+
+## Beta truth
+
+As of this runbook:
+
+- Lumina substrate is real and governed
+- orchestration is real but still intentionally bounded
+- Chamber now provides a persisted consent surface for advisories and supervised queue state
+- accepted queue items do not yet become governed runtime execution records automatically
+
+## Boundary reminder
+
+The Chamber consent surface is adjacent to the substrate.
+It is not the substrate itself.
+
+The orchestration lane may recommend.
+The runtime layer decides legality.
+The Chamber lane makes consent and queue state visible.
+
+That separation should stay explicit until a later hardening step intentionally binds accepted queue items to governed execution records.


### PR DESCRIPTION
## Summary
- refresh `START_HERE_LUMINA_OS.md` so it reflects the orchestration lane and Chamber consent surface
- refresh the bootstrap `README.md` so the current status matches the repo's present shape
- add Chamber package scripts for the advisory queue server and advisory-aware Postgres compose lane
- add an operator runbook linking substrate, orchestration, and Chamber consent surface

## What this housekeeping fixes
The repository recently crossed several real thresholds, but the navigation and operator surfaces were lagging behind the new reality.

This PR reduces that friction by making the docs and entrypoints match what is actually on `main` now.

## Files updated
- `START_HERE_LUMINA_OS.md`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md`
- `chamber-app/package.json`

## File added
- `docs/lumina_operator_runbook_r1.md`

## What this improves
- new contributors can see the orchestration lane directly from the Lumina start file
- the bootstrap README now reflects bounded self-guidance, orchestration, and Chamber's consent surface accurately
- Chamber operators now have obvious scripts for the advisory queue server and advisory-aware Postgres bootstrap
- the repo now has one runbook that links the governed substrate, the bounded orchestration lane, and the Chamber consent surface in one place

## Why this matters
This is not a new architectural threshold.
It is the housekeeping pass that makes the current threshold legible and easier to operate as a cleaner beta whole.
