### PR TITLE
Add Ubuntu Server appliance scaffold for Lumina OS beta host

### DIFF
--- a/deploy/ubuntu_server_lts/README.md
+++ b/deploy/ubuntu_server_lts/README.md
@@ -1,0 +1,3 @@
+# Ubuntu appliance scaffold
+
+Placeholder scaffold for Lumina Ubuntu Server deployment.

--- a/deploy/ubuntu_server_lts/README.md
+++ b/deploy/ubuntu_server_lts/README.md
@@ -1,3 +1,84 @@
-# Ubuntu appliance scaffold
+# Lumina Ubuntu Server Appliance Scaffold r1
 
-Placeholder scaffold for Lumina Ubuntu Server deployment.
+This directory starts the process of binding **Lumina OS** to **Ubuntu Server LTS** as its first host substrate.
+
+It does **not** claim that Lumina is already a kernel-level operating system.
+It establishes the first believable beta path:
+
+- Ubuntu Server LTS as the host substrate
+- Lumina as a governed service stack installed on top of that substrate
+- Chamber as an adjacent consent surface for advisory handling and supervised queue state
+
+## What is included
+
+- `bootstrap_lumina_appliance_r1.sh`
+  - first-pass installer scaffold for Ubuntu Server
+- `lumina-orchestrator.service`
+  - systemd one-shot unit for bounded orchestration cycles
+- `lumina-orchestrator.timer`
+  - systemd timer for recurring bounded orchestration
+- `chamber-advisory.service`
+  - systemd service for the Chamber advisory consent surface
+
+## Current deployment shape
+
+This scaffold assumes a host with:
+
+- Ubuntu Server LTS
+- Python 3
+- Node.js + npm
+- PostgreSQL
+- systemd
+
+The target machine can be:
+
+- a VM
+- a dedicated mini PC
+- a spare laptop repurposed as an appliance
+- a small server/NUC-style box
+
+## Appliance model
+
+The current beta intent is:
+
+1. governed Lumina substrate resides in the repo
+2. bounded orchestration runs as supervised scheduled work
+3. Chamber advisory handling runs as a persistent service
+4. PostgreSQL persists Chamber consent and queue state
+
+This is a **Linux-resident Lumina appliance**, not yet a custom distro or custom kernel.
+
+## Important truth
+
+The orchestrator currently runs as a **bounded scheduled cycle**, not an always-on sovereign process.
+That is intentional.
+It preserves the repo's present law:
+
+- advisory output remains subordinate to runtime governance
+- consent remains visible in Chamber
+- accepted queue items do not yet automatically become governed execution records
+
+## First-use sequence
+
+On a fresh Ubuntu Server host:
+
+1. clone the repo or run the bootstrap script
+2. review and edit `/etc/lumina/lumina-appliance.env`
+3. build the Chamber app
+4. initialize PostgreSQL with the three Chamber SQL files
+5. install and enable the systemd units
+6. validate logs, queue persistence, and orchestration checkpoints across reboot
+
+## What this scaffold is for
+
+This directory exists to move Lumina from:
+
+- architecture in GitHub
+
+into:
+
+- a machine-resident governed runtime stack on Ubuntu Server LTS
+
+## Next likely hardening move
+
+After this scaffold, the next threshold is to validate the appliance end-to-end on a real Ubuntu Server VM and then decide whether accepted Chamber queue items should emit governed runtime execution records under explicit policy.

--- a/deploy/ubuntu_server_lts/bootstrap_lumina_appliance_r1.sh
+++ b/deploy/ubuntu_server_lts/bootstrap_lumina_appliance_r1.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/ethereoninitiative/EthereonLabs.git}"
+REPO_ROOT="${REPO_ROOT:-/opt/lumina/EthereonLabs}"
+SERVICE_USER="${SERVICE_USER:-lumina}"
+STATE_ROOT="${STATE_ROOT:-/var/lib/lumina}"
+LOG_ROOT="${LOG_ROOT:-/var/log/lumina}"
+ENV_DIR="/etc/lumina"
+ENV_FILE="${ENV_DIR}/lumina-appliance.env"
+
+require_root() {
+  if [[ "$(id -u)" -ne 0 ]]; then
+    echo "Run as root or through sudo."
+    exit 1
+  fi
+}
+
+install_packages() {
+  apt-get update
+  apt-get install -y \
+    git \
+    curl \
+    python3 \
+    python3-venv \
+    python3-pip \
+    nodejs \
+    npm \
+    postgresql \
+    postgresql-contrib
+}
+
+ensure_service_user() {
+  if ! id -u "${SERVICE_USER}" >/dev/null 2>&1; then
+    useradd --system --create-home --shell /bin/bash "${SERVICE_USER}"
+  fi
+}
+
+prepare_directories() {
+  install -d -o "${SERVICE_USER}" -g "${SERVICE_USER}" "${STATE_ROOT}"
+  install -d -o "${SERVICE_USER}" -g "${SERVICE_USER}" "${LOG_ROOT}"
+  install -d -o root -g root "${ENV_DIR}"
+  install -d -o "${SERVICE_USER}" -g "${SERVICE_USER}" "$(dirname "${REPO_ROOT}")"
+}
+
+checkout_repo() {
+  if [[ ! -d "${REPO_ROOT}/.git" ]]; then
+    sudo -u "${SERVICE_USER}" git clone "${REPO_URL}" "${REPO_ROOT}"
+  else
+    sudo -u "${SERVICE_USER}" git -C "${REPO_ROOT}" pull --ff-only
+  fi
+}
+
+install_node_dependencies() {
+  sudo -u "${SERVICE_USER}" npm --prefix "${REPO_ROOT}/chamber-app" install
+  sudo -u "${SERVICE_USER}" npm --prefix "${REPO_ROOT}/chamber-app" run build
+}
+
+write_env_template() {
+  if [[ ! -f "${ENV_FILE}" ]]; then
+    cat > "${ENV_FILE}" <<'EOF'
+PYTHONUNBUFFERED=1
+CHAMBER_PUBLIC_ROOM_SLUG=public-room-one
+SESSION_TTL_HOURS=168
+CHAMBER_ALLOWED_ORIGINS=http://localhost:3000,https://example.com
+CHAMBER_STORE_MODE=postgres
+CHAMBER_ADVISORY_PORT=8788
+DATABASE_URL=postgres://SET_USER:SET_PASSWORD@localhost:5432/SET_DBNAME
+EOF
+    chmod 600 "${ENV_FILE}"
+  fi
+}
+
+initialize_database() {
+  sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='chamber'" | grep -q 1 || \
+    sudo -u postgres psql -c "CREATE ROLE chamber LOGIN PASSWORD 'change-me';"
+  sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='chamber'" | grep -q 1 || \
+    sudo -u postgres createdb -O chamber chamber
+  sudo -u postgres psql -d chamber -f "${REPO_ROOT}/chamber_data_model_r1.sql"
+  sudo -u postgres psql -d chamber -f "${REPO_ROOT}/chamber_sessions_extension_r1.sql"
+  sudo -u postgres psql -d chamber -f "${REPO_ROOT}/chamber_advisory_queue_extension_r1.sql"
+}
+
+install_systemd_units() {
+  cp "${REPO_ROOT}/deploy/ubuntu_server_lts/lumina-orchestrator.service" /etc/systemd/system/
+  cp "${REPO_ROOT}/deploy/ubuntu_server_lts/lumina-orchestrator.timer" /etc/systemd/system/
+  cp "${REPO_ROOT}/deploy/ubuntu_server_lts/chamber-advisory.service" /etc/systemd/system/
+  systemctl daemon-reload
+  systemctl enable chamber-advisory.service
+  systemctl enable lumina-orchestrator.timer
+}
+
+start_services() {
+  systemctl restart chamber-advisory.service
+  systemctl restart lumina-orchestrator.timer
+}
+
+main() {
+  require_root
+  install_packages
+  ensure_service_user
+  prepare_directories
+  checkout_repo
+  install_node_dependencies
+  write_env_template
+  initialize_database
+  install_systemd_units
+  start_services
+  echo "Lumina Appliance bootstrap scaffold complete. Review ${ENV_FILE} and change placeholder database credentials."
+}
+
+main "$@"

--- a/deploy/ubuntu_server_lts/chamber-advisory.service
+++ b/deploy/ubuntu_server_lts/chamber-advisory.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Chamber Advisory Consent Surface
+After=network.target postgresql.service
+Requires=postgresql.service
+
+[Service]
+Type=simple
+User=lumina
+Group=lumina
+WorkingDirectory=/opt/lumina/EthereonLabs/chamber-app
+EnvironmentFile=/etc/lumina/lumina-appliance.env
+ExecStart=/usr/bin/node /opt/lumina/EthereonLabs/chamber-app/dist/advisory_queue_server_v0_2.js
+Restart=always
+RestartSec=5
+StandardOutput=append:/var/log/lumina/chamber-advisory.log
+StandardError=append:/var/log/lumina/chamber-advisory.log
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ubuntu_server_lts/lumina-orchestrator.service
+++ b/deploy/ubuntu_server_lts/lumina-orchestrator.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Lumina Orchestrator One-Shot Cycle
+After=network.target
+
+[Service]
+Type=oneshot
+User=lumina
+Group=lumina
+WorkingDirectory=/opt/lumina/EthereonLabs
+EnvironmentFile=/etc/lumina/lumina-appliance.env
+ExecStart=/usr/bin/python3 /opt/lumina/EthereonLabs/LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_orchestrator_v0_4.py
+StandardOutput=append:/var/log/lumina/orchestrator.log
+StandardError=append:/var/log/lumina/orchestrator.log
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ubuntu_server_lts/lumina-orchestrator.timer
+++ b/deploy/ubuntu_server_lts/lumina-orchestrator.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Lumina Orchestrator on a bounded schedule
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=15min
+Persistent=true
+Unit=lumina-orchestrator.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/ubuntu_server_lts/lumina_appliance_layout_r1.md
+++ b/deploy/ubuntu_server_lts/lumina_appliance_layout_r1.md
@@ -1,0 +1,49 @@
+# Lumina Appliance Layout r1
+
+This note defines the first suggested filesystem layout for a Lumina OS beta appliance hosted on Ubuntu Server LTS.
+
+## Proposed layout
+
+### Repository checkout
+- `/opt/lumina/EthereonLabs`
+
+This keeps the repo in a stable system location owned by the service user.
+
+### Environment and service configuration
+- `/etc/lumina/lumina-appliance.env`
+
+This file should hold host-local environment values for Chamber and service configuration.
+
+### Persistent state root
+- `/var/lib/lumina`
+
+Suggested child paths:
+- `/var/lib/lumina/runtime`
+- `/var/lib/lumina/checkpoints`
+- `/var/lib/lumina/governance`
+- `/var/lib/lumina/advisory-history`
+- `/var/lib/lumina/chamber`
+
+### Log root
+- `/var/log/lumina`
+
+Suggested log files:
+- `/var/log/lumina/orchestrator.log`
+- `/var/log/lumina/chamber-advisory.log`
+
+## Why this shape
+
+This separates:
+
+- mutable host config in `/etc`
+- persistent operational state in `/var/lib`
+- service logs in `/var/log`
+- repo code in `/opt`
+
+That is a conventional Linux service layout and makes the Lumina appliance easier to reason about, back up, and restore.
+
+## Current truth
+
+The repo itself still contains internal runtime state conventions of its own.
+This layout note does not override runtime law.
+It gives the Ubuntu appliance a cleaner outer operating envelope.

--- a/deploy/ubuntu_server_lts/ubuntu_vm_validation_checklist_r1.md
+++ b/deploy/ubuntu_server_lts/ubuntu_vm_validation_checklist_r1.md
@@ -1,0 +1,56 @@
+# Ubuntu VM Validation Checklist r1
+
+Use this checklist after installing the Lumina appliance scaffold on an Ubuntu Server LTS VM.
+
+## Host checks
+
+- Ubuntu Server LTS installed successfully
+- VM has network access
+- `python3`, `node`, `npm`, and `psql` are available
+- the repo exists at `/opt/lumina/EthereonLabs`
+- `/etc/lumina/lumina-appliance.env` exists and has been edited away from placeholders
+
+## Service checks
+
+- `systemctl status chamber-advisory.service` is healthy
+- `systemctl status lumina-orchestrator.timer` is healthy
+- `systemctl list-timers | grep lumina-orchestrator` shows the timer scheduled
+
+## Database checks
+
+- database `chamber` exists
+- Chamber tables exist
+- advisory queue tables exist
+- a signup/login flow works against Postgres mode
+
+## Chamber checks
+
+- `/health` responds on the advisory server port
+- an advisory can be created
+- an advisory can be accepted
+- an accepted advisory creates a queue item
+- a queue item can be claimed
+- a queue item can be completed
+- queue state survives service restart and VM reboot
+
+## Orchestration checks
+
+- the orchestrator service can be triggered manually with `systemctl start lumina-orchestrator.service`
+- `/var/log/lumina/orchestrator.log` receives output
+- checkpoints continue to exist after reboot
+- no service restart produces obvious path or permission errors
+
+## Boundary checks
+
+- Chamber queue state remains visible and durable
+- accepted queue items do not bypass runtime law unexpectedly
+- service behavior remains bounded and inspectable
+
+## Exit condition
+
+The VM passes this checklist when:
+
+- services start cleanly
+- persistence survives reboot
+- advisory queue flows work end-to-end
+- bounded orchestration still behaves like a governed substrate


### PR DESCRIPTION
## Summary
- add a first Ubuntu Server LTS appliance scaffold for Lumina OS beta hosting
- add systemd units for bounded orchestration and the Chamber advisory consent surface
- add a bootstrap installer scaffold for local VM or dedicated-machine setup
- add filesystem layout and VM validation notes

## What this adds
- `deploy/ubuntu_server_lts/README.md`
- `deploy/ubuntu_server_lts/bootstrap_lumina_appliance_r1.sh`
- `deploy/ubuntu_server_lts/lumina-orchestrator.service`
- `deploy/ubuntu_server_lts/lumina-orchestrator.timer`
- `deploy/ubuntu_server_lts/chamber-advisory.service`
- `deploy/ubuntu_server_lts/lumina_appliance_layout_r1.md`
- `deploy/ubuntu_server_lts/ubuntu_vm_validation_checklist_r1.md`

## Why this matters now
We agreed that Ubuntu Server LTS is the first realistic substrate choice for Lumina OS beta.
The repo already has the governed substrate, bounded orchestration lane, and Chamber consent surface.
What it did not yet have was the first machine-resident deployment scaffold that begins turning that architecture into a Linux-hosted appliance.

## What this scaffold does
- treats Ubuntu Server LTS as the host substrate
- treats Lumina as a governed service stack installed on top of that substrate
- schedules bounded orchestration via systemd timer
- runs the Chamber advisory consent surface as a persistent service
- initializes PostgreSQL with the Chamber data model, session extension, and advisory queue extension
- provides a VM checklist for first real appliance validation

## Boundary note
This does not claim Lumina is already a custom kernel-level OS.
It is the first believable bridge from repo architecture to an Ubuntu-resident Lumina appliance.

## Next likely move
After this scaffold lands, the sharp next step is to validate it on a real Ubuntu Server VM, then decide how and when accepted Chamber queue items should emit governed runtime execution records under explicit policy.
