### PR TITLE
Harden Ubuntu appliance scaffold with preflight checks

### DIFF
--- a/chamber-app/package.json
+++ b/chamber-app/package.json
@@ -10,6 +10,7 @@
     "dev:advisory": "tsx watch src/advisory_queue_server_v0_2.ts",
     "dev:advisory:postgres": "CHAMBER_STORE_MODE=postgres tsx watch src/advisory_queue_server_v0_2.ts",
     "start": "node dist/server.js",
+    "start:advisory": "node dist/advisory_queue_server_v0_2.js",
     "build": "tsc -p tsconfig.json",
     "check": "tsc -p tsconfig.json --noEmit",
     "db:up": "docker compose -f docker-compose.postgres.yml up -d",

--- a/deploy/ubuntu_server_lts/environment_reference_r1.md
+++ b/deploy/ubuntu_server_lts/environment_reference_r1.md
@@ -1,0 +1,43 @@
+# Lumina Appliance Environment Reference r1
+
+This note documents the host-local environment values expected by the current Ubuntu Server appliance scaffold.
+
+## Expected file path
+
+Suggested host path:
+
+- `/etc/lumina/lumina-appliance.env`
+
+## Current variables
+
+### Chamber consent surface
+- `CHAMBER_PUBLIC_ROOM_SLUG`
+  - default public room slug for Chamber endpoints
+- `SESSION_TTL_HOURS`
+  - session lifetime for Chamber auth
+- `CHAMBER_ALLOWED_ORIGINS`
+  - comma-separated origin allowlist
+- `CHAMBER_STORE_MODE`
+  - `memory` or `postgres`
+- `CHAMBER_ADVISORY_PORT`
+  - advisory queue service port
+- `DATABASE_URL`
+  - Postgres connection string for Chamber durable mode
+
+### Appliance runtime
+- `PYTHONUNBUFFERED`
+  - keeps Python logs flushed promptly in service mode
+
+## Recommended host-local additions
+
+These are not all consumed directly by the current code yet, but they are useful for standardizing appliance layout:
+
+- `LUMINA_ROOT`
+- `LUMINA_STATE_ROOT`
+- `LUMINA_LOG_ROOT`
+- `LUMINA_REPO_USER`
+
+## Operator note
+
+Do not commit real host secrets into the repository.
+This file exists so the scaffold has a human-readable contract for what belongs in the host-local environment file.

--- a/deploy/ubuntu_server_lts/preflight_validate_appliance_r1.sh
+++ b/deploy/ubuntu_server_lts/preflight_validate_appliance_r1.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-/opt/lumina/EthereonLabs}"
+ENV_FILE="${ENV_FILE:-/etc/lumina/lumina-appliance.env}"
+LOG_ROOT="${LOG_ROOT:-/var/log/lumina}"
+STATE_ROOT="${STATE_ROOT:-/var/lib/lumina}"
+
+pass() {
+  echo "[PASS] $1"
+}
+
+fail() {
+  echo "[FAIL] $1"
+  exit 1
+}
+
+check_command() {
+  local cmd="$1"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    pass "command available: $cmd"
+  else
+    fail "missing command: $cmd"
+  fi
+}
+
+check_file() {
+  local path="$1"
+  [[ -f "$path" ]] && pass "file exists: $path" || fail "missing file: $path"
+}
+
+check_dir() {
+  local path="$1"
+  [[ -d "$path" ]] && pass "directory exists: $path" || fail "missing directory: $path"
+}
+
+check_systemd_unit() {
+  local unit="$1"
+  if systemctl list-unit-files "$unit" >/dev/null 2>&1; then
+    pass "systemd unit visible: $unit"
+  else
+    fail "systemd unit not found: $unit"
+  fi
+}
+
+main() {
+  check_command python3
+  check_command node
+  check_command npm
+  check_command psql
+  check_command systemctl
+
+  check_dir "$REPO_ROOT"
+  check_dir "$REPO_ROOT/deploy/ubuntu_server_lts"
+  check_dir "$REPO_ROOT/chamber-app"
+  check_file "$REPO_ROOT/chamber_data_model_r1.sql"
+  check_file "$REPO_ROOT/chamber_sessions_extension_r1.sql"
+  check_file "$REPO_ROOT/chamber_advisory_queue_extension_r1.sql"
+  check_file "$ENV_FILE"
+
+  check_dir "$LOG_ROOT"
+  check_dir "$STATE_ROOT"
+
+  check_systemd_unit lumina-orchestrator.service
+  check_systemd_unit lumina-orchestrator.timer
+  check_systemd_unit chamber-advisory.service
+
+  pass "Lumina appliance preflight completed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a production advisory start script to `chamber-app/package.json`
- add a preflight validation script for the Ubuntu appliance host
- add an environment reference note for the host-local Lumina appliance config

## Files added
- `deploy/ubuntu_server_lts/preflight_validate_appliance_r1.sh`
- `deploy/ubuntu_server_lts/environment_reference_r1.md`

## Files updated
- `chamber-app/package.json`

## Why this helps
This makes the Ubuntu appliance path easier to operate and validate on a VM or local host.

## Improvements
- explicit `npm run start:advisory` for service use
- host-side preflight check for commands, paths, SQL files, env file, and systemd units
- small operator-facing reference for the host-local environment contract
