### PR TITLE
Define Lumina beta hardware target and VM-first validation sequence

### DIFF
--- a/deploy/ubuntu_server_lts/lumina_beta_hardware_target_r1.md
+++ b/deploy/ubuntu_server_lts/lumina_beta_hardware_target_r1.md
@@ -1,0 +1,90 @@
+# Lumina Beta Hardware Target r1
+
+This note defines the first recommended **hardware target** for a Lumina OS beta appliance while the Ubuntu Server VM validation path proceeds in parallel.
+
+## Recommended class
+
+A **dedicated mini PC / NUC-style machine** is the preferred beta host.
+
+Why this class:
+
+- small always-on footprint
+- lower noise and power draw than a tower
+- cleaner appliance identity than a spare laptop
+- easier to dedicate fully to Lumina than a shared desktop
+
+## Recommended baseline spec
+
+### CPU
+- modern 64-bit x86 processor
+- 4 to 8 cores is a healthy beta target
+
+### Memory
+- minimum: 16 GB RAM
+- preferred: 32 GB RAM
+
+Reason:
+The host should have room for Ubuntu Server, PostgreSQL, Chamber services, bounded orchestration, logging, and future interface growth without feeling cramped.
+
+### Storage
+- minimum: 512 GB SSD
+- preferred: 1 TB SSD
+
+Reason:
+This gives room for repo growth, state, logs, checkpoints, database storage, snapshots, and future build artifacts.
+
+### Network
+- reliable Ethernet preferred
+- Wi-Fi acceptable as secondary convenience, not primary dependency
+
+### GPU
+- not required for the first beta appliance
+
+Reason:
+The current Lumina beta path is about governed substrate, orchestration, persistence, and consent surfaces rather than local model inference or graphics-heavy rendering.
+
+## Recommended posture
+
+The first dedicated beta machine should be:
+
+- boring
+- stable
+- easy to image
+- easy to re-install
+- easy to leave on continuously
+
+This is not the moment to optimize for maximum power or visual flair.
+It is the moment to optimize for **reliable presence**.
+
+## Machine-role recommendation
+
+Use the first dedicated machine for:
+
+- Ubuntu Server LTS host substrate
+- Lumina governed runtime stack
+- Chamber advisory consent surface
+- PostgreSQL persistence
+- reboot and continuity validation
+
+Do not overload the first beta box with unrelated creative software, general desktop clutter, or experimental local AI stacks unless they are intentionally part of the appliance test plan.
+
+## Sequencing note
+
+This hardware target note is paired with a VM-first validation path.
+
+The sequence is:
+
+1. define the ideal beta host now
+2. validate the Ubuntu appliance scaffold on a VM
+3. buy or dedicate the machine after the VM reveals practical friction
+4. image the dedicated host with what the VM taught us
+
+## Exit condition
+
+The hardware target is considered good enough when it supports:
+
+- Ubuntu Server LTS cleanly
+- PostgreSQL comfortably
+- Lumina services without thermal or memory pressure
+- repeated reboot / restart validation
+- continuous quiet operation as a machine-resident appliance

--- a/deploy/ubuntu_server_lts/vm_first_validation_sequence_r1.md
+++ b/deploy/ubuntu_server_lts/vm_first_validation_sequence_r1.md
@@ -1,0 +1,57 @@
+# VM-First Validation Sequence r1
+
+This note defines the recommended order for validating the Lumina Ubuntu appliance before moving onto a dedicated beta machine.
+
+## Principle
+
+Do not buy hardware first and hope the stack fits.
+Let the VM reveal the stack's real needs, then let the dedicated machine inherit those lessons.
+
+## Sequence
+
+### Phase 1 — host definition
+Choose the intended beta host class in advance.
+
+For the current path, that is:
+
+- dedicated mini PC / NUC-style machine
+
+### Phase 2 — Ubuntu VM proving ground
+Create an Ubuntu Server LTS VM and use it to validate:
+
+- bootstrap installer behavior
+- package installation assumptions
+- PostgreSQL initialization
+- Chamber advisory service startup
+- orchestrator timer behavior
+- filesystem layout assumptions
+- persistence across reboot
+- preflight validation output
+
+### Phase 3 — friction log
+Record every issue the VM reveals, especially:
+
+- missing packages
+- wrong service paths
+- environment-file assumptions
+- permissions problems
+- log path failures
+- database setup surprises
+- service ordering issues
+
+### Phase 4 — appliance hardening
+Fix the repo scaffold based on VM truth.
+Do not move to hardware until the appliance path stops feeling brittle.
+
+### Phase 5 — dedicated machine acquisition
+Only after the VM pass should the first dedicated Lumina beta box be bought or fully repurposed.
+
+### Phase 6 — dedicated host install
+Install Ubuntu Server LTS on the real box and follow the same appliance path with a better expectation of success.
+
+## Success condition
+
+This sequence succeeds when:
+
+- the VM proves the deployment path cleanly enough that the hardware install feels deliberate rather than improvised
+- the dedicated host inherits a scaffold that has already survived one real proving ground


### PR DESCRIPTION
## Summary
- add a hardware target note for the first dedicated Lumina beta host
- add a VM-first validation sequence note so hardware acquisition follows proven deployment truth

## Files added
- `deploy/ubuntu_server_lts/lumina_beta_hardware_target_r1.md`
- `deploy/ubuntu_server_lts/vm_first_validation_sequence_r1.md`

## Why this was the right move
We agreed on the sequence:
1. define the real beta box now
2. validate the appliance path on a VM first
3. buy or dedicate hardware after the VM reveals the truth

This PR records that sequence explicitly so the project does not drift into either rushed hardware buying or endless simulation.

## What this gives us
- a recommended beta host class: dedicated mini PC / NUC-style machine
- a baseline hardware envelope for CPU, RAM, storage, and posture
- a clear VM-first proving-ground sequence before dedicated hardware install

## Boundary note
This is a planning-and-deployment hardening pass, not a claim that Lumina is already a finished independent OS.
It helps the Ubuntu appliance path become deliberate and awesome rather than rushed.
