### PR TITLE
Add Lumina human interface north-star doc

### DIFF
--- a/docs/lumina_human_interface_north_star_r1.md
+++ b/docs/lumina_human_interface_north_star_r1.md
@@ -1,0 +1,238 @@
+# Lumina Human Interface North Star r1
+
+**Status:** active design direction  
+**Scope:** product-surface guidance for the finished Lumina OS experience  
+**Audience:** Spencer, Minerva, future collaborators, and any contributor building the human-facing shell above the governed substrate
+
+---
+
+## 1. Purpose
+
+This document exists to keep Lumina pointed toward the correct end-state.
+
+The governed runtime, orchestration stack, bridge layers, and continuity substrate may remain sophisticated.
+The **human-facing surface must not feel sophisticated in a burdensome way**.
+
+The target is not:
+- "usable for technical operators"
+- "impressive once explained"
+- "understandable after reading five notes"
+
+The target is:
+
+> **10/10 intuitive usability for the average human.**
+
+A finished Lumina OS should feel obvious without instruction.
+
+---
+
+## 2. Core design truth
+
+The user should never need to think about:
+- mode legality
+- governance rails
+- canon lineage
+- checkpoint hashing
+- capability exposure rules
+- symbolic boundary enforcement
+- orchestration contracts
+
+Those things are real and important.
+They are also **beneath the surface**.
+
+The average human should experience Lumina as:
+- clear
+- calm
+- helpful
+- continuous
+- forgiving
+- context-aware
+
+---
+
+## 3. What success feels like
+
+A person sits down and Lumina:
+1. understands what project they are returning to
+2. restores the relevant context without clutter
+3. surfaces the next likely step
+4. opens the needed tool or workspace naturally
+5. lets them continue without feeling like they are reassembling the machine first
+
+The user should feel:
+- "It already knows where I was."
+- "I do not need to hunt for everything."
+- "I can just begin."
+- "This feels easy."
+
+If the interface feels technically impressive but still makes people orient themselves before they can work, it has missed the mark.
+
+---
+
+## 4. Finished-product promises
+
+Lumina should eventually make these promises true at the interaction level:
+
+### A. Return, not restart
+Opening Lumina should feel like coming back, not booting into chaos.
+
+### B. Natural language first
+Users should be able to speak or type naturally.
+The machine should adapt to the human more than the human adapts to the machine.
+
+### C. Context stays attached
+Projects, artifacts, recent decisions, and active tools should remain meaningfully connected.
+
+### D. Tools open in context
+If a user wants Photoshop, Lumina should open Photoshop **as part of the active project flow**, not as an isolated detached app event.
+
+### E. Guidance without domination
+Lumina may recommend, restore, suggest, and organize.
+It should not feel bossy, coercive, or over-automated.
+
+### F. Errors are survivable
+Mistakes, typos, ambiguous commands, and wrong turns should be recoverable without dread.
+
+### G. Depth hides gracefully
+Advanced capabilities may exist in abundance.
+They should reveal themselves progressively rather than intimidating the user at first contact.
+
+---
+
+## 5. Surface design principles
+
+### 5.1 Calm before clever
+Do not sacrifice clarity for futurism.
+Do not sacrifice usability for atmosphere.
+The interface may feel luminous and premium, but it must remain legible.
+
+### 5.2 Show the next move
+The system should reduce cognitive load by making the next useful action visible.
+
+### 5.3 Do not make the user translate
+Internal architectural vocabulary may be valid for builders.
+It should not be required for ordinary users.
+
+### 5.4 Progressive disclosure
+The beginner should feel safe.
+The expert should feel powerful.
+Both should be true in the same system.
+
+### 5.5 Preserve momentum
+Every major surface decision should be judged by a simple question:
+
+> Does this help the user continue naturally?
+
+If not, it is likely decorative, premature, or misplaced.
+
+---
+
+## 6. Representative finished-use scenario
+
+A user returns to Lumina to continue visual work.
+
+Lumina says, in effect:
+- you were refining the interface blueprint
+- these artifacts are in scope
+- your last checkpoint is available
+- Photoshop is ready to open
+- your references are attached
+- here is the most likely next step
+
+The user does **not** need to:
+- remember exact filenames
+- reopen every reference manually
+- reconstruct prior intent from fragments
+- navigate internal system law
+- understand runtime terminology
+
+This is the level of continuity the surface should strive to make normal.
+
+---
+
+## 7. Relationship to Chamber
+
+Chamber and Lumina are related but not identical.
+
+### Chamber
+- threshold space
+- social / consent / advisory surface
+- public or semi-public interaction layer
+
+### Lumina Studio / workroom
+- deeper project environment
+- active workspace shell
+- artifact, tool, and continuity host surface
+
+The finished journey should feel natural:
+
+**threshold -> studio -> tool use -> continued work**
+
+The human should sense one coherent habitat rather than several disconnected systems.
+
+---
+
+## 8. Relationship to runtime law
+
+The runtime may remain mode-governed, checkpoint-aware, and boundary-enforced.
+That is good.
+
+But the human-facing shell should translate all of that into simple experiential truths such as:
+- safe to proceed
+- restore available
+- action needs confirmation
+- project context loaded
+- recommendation available
+- this action is advisory
+- this action will change something real
+
+The human should receive the meaning of the law, not the machinery of the law.
+
+---
+
+## 9. Advertising truth
+
+If Lumina is ever advertised honestly at its strongest, the public message should lead with:
+- continuity
+- ease
+- clarity
+- momentum
+- context-aware tool use
+
+Not with:
+- recursion
+- governance terminology
+- symbolic frameworks
+- internal runtime architecture
+
+The product should feel like:
+
+> **A workspace that stays with you.**
+
+---
+
+## 10. Practical pass/fail questions
+
+A finished Lumina surface is moving in the right direction if the average person can:
+- understand what Lumina is within seconds
+- know what to do next without instruction
+- recover from mistakes easily
+- open tools naturally
+- continue work without rebuilding context manually
+- feel assisted rather than overwhelmed
+
+A finished Lumina surface is failing if people regularly say:
+- "Wait, what am I looking at?"
+- "Where do I start?"
+- "Why is this so complicated?"
+- "I feel like I need training first."
+
+---
+
+## 11. North-star sentence
+
+> **Lumina should provide maximum depth with minimum intimidation.**
+
+That is the standard.
+That is the bar.
+That is the shape the surface should keep growing toward.


### PR DESCRIPTION
## Summary
- add a repo-native north-star document for the finished Lumina human interface
- translate recent product-direction discussion into a practical design target
- make "10/10 intuitive usability for the average human" an explicit reference point for future surface work

## File added
- `docs/lumina_human_interface_north_star_r1.md`

## Why this was the right move
The governed substrate, runtime law, orchestration lane, and bridge layers are becoming increasingly real.
What the repo still needed was a clean design artifact that protects the product surface from drifting into operator-native complexity.

This doc records the agreed direction:
- the average human should not need to understand internal machinery
- Lumina should feel obvious without instruction
- the surface should prioritize continuity, ease, clarity, and momentum
- advanced depth should remain available without becoming intimidating

## What this gives us
- a human-facing design bar for future Lumina UI work
- a practical bridge between Chamber/front-hall discussion and deeper Lumina Studio/workroom intent
- a shared artifact contributors can reference when evaluating whether a surface decision helps users continue naturally

## Boundary note
This is a product-surface guidance artifact, not a change to runtime law, governance boundaries, canon lineage, or the current Ubuntu appliance path.
It helps ensure the eventual shell remains genuinely human-first while the deeper substrate continues to mature.