### PR TITLE
Add Lumina toki pona semantic layer

### DIFF
--- a/docs/lumina_toki_pona_semantic_layer_r1.md
+++ b/docs/lumina_toki_pona_semantic_layer_r1.md
@@ -1,0 +1,129 @@
+# Lumina Toki Pona Semantic Layer r1
+
+**Status:** design / translation guidance  
+**Scope:** human-interface language, onboarding compression, conceptual alignment  
+**Authority:** non-governing; not runtime law; not canon lineage; not mode legality  
+**Related:** `docs/lumina_human_interface_north_star_r1.md`
+
+---
+
+## 1. Purpose
+
+This document records a compact toki pona-inspired semantic layer for Lumina OS.
+
+The purpose is not to require users to learn toki pona.
+The purpose is to preserve a small, stable set of meanings beneath the human-facing interface so Lumina can remain simple even while its governed substrate becomes powerful.
+
+Lumina should be able to translate complex internal machinery into clear experiential truths.
+This layer helps maintain that translation discipline.
+
+---
+
+## 2. Core compression set
+
+| Term | Lumina meaning | Interface translation |
+|---|---|---|
+| **awen sona** | continuity / preserved context | return, remember, restore, keep the thread |
+| **lawa** | governance / system law | safe to proceed, needs confirmation, action boundary |
+| **nasin** | guidance / path | next step, direction, recommended path |
+| **pali** | action / work | do, create, continue, execute |
+| **jan** | human consent / human presence | user choice, acceptance, rejection, agency |
+| **ilo** | tool substrate / machine capability | app, instrument, service, capability |
+| **tomo** | Chamber / Studio / workspace habitat | room, workspace, project environment, threshold |
+
+These are not command tokens.
+They are semantic anchors.
+
+---
+
+## 3. Compressed Lumina sentence
+
+In toki pona-shaped form, Lumina's surface promise can be compressed as:
+
+> **jan li kama. ilo li awen e sona. ilo li lukin e nasin. jan li wile la pali li tawa kepeken lawa.**
+
+Meaning:
+
+> The human arrives. The system preserves context. The system sees a path. If the human chooses, the work proceeds through governance.
+
+This sentence should act as a product-surface compass.
+
+---
+
+## 4. Relationship to Lumina interface design
+
+The human-facing interface should translate the seven anchors into ordinary user experience:
+
+- **awen sona** becomes: "Your project is restored."
+- **lawa** becomes: "This action is safe / needs confirmation / changes something real."
+- **nasin** becomes: "Here is the likely next step."
+- **pali** becomes: "Continue the work."
+- **jan** becomes: "You choose."
+- **ilo** becomes: "The needed tool is ready."
+- **tomo** becomes: "You are in the right workspace."
+
+The user should receive the meaning, not the machinery.
+
+---
+
+## 5. Boundary rule
+
+This layer may influence:
+
+- onboarding language
+- interface labels
+- explanatory diagrams
+- Chamber / Studio metaphors
+- product copy
+- semantic compression for contributors
+- future translation of runtime events into human-readable states
+
+This layer may not:
+
+- define mode legality
+- define mutation legality
+- define promotion legality
+- define canon lineage
+- define checkpoint legality
+- bypass human consent
+- replace explicit user intent
+- become required for runtime operation
+
+In short:
+
+> **toki li ken pana e sona. toki li lawa ala.**
+
+Language may give understanding. Language is not law.
+
+---
+
+## 6. Practical design test
+
+When building any Lumina surface, ask:
+
+1. Does this help the human return rather than restart? (**awen sona**)
+2. Does the system make boundaries clear without exposing machinery? (**lawa**)
+3. Is the next useful path visible? (**nasin**)
+4. Can work continue naturally? (**pali**)
+5. Does the human clearly choose or decline? (**jan**)
+6. Are tools presented in context rather than as detached apps? (**ilo**)
+7. Does the workspace feel like a coherent habitat? (**tomo**)
+
+If a surface cannot answer those questions simply, it is probably too operator-facing or too ornamental.
+
+---
+
+## 7. Why this belongs in Lumina OS
+
+Lumina's substrate is intentionally governed, layered, and technical.
+Its finished surface must remain calm, obvious, and human-first.
+
+This semantic layer provides a small internal compass for translating depth into ease.
+It helps the project remember that the average human should not need to understand the machinery in order to continue their work.
+
+The deeper system may be complex.
+The user experience should feel simple:
+
+> **pali li kama pona.**
+
+Work becomes easy.


### PR DESCRIPTION
## Summary
- add `docs/lumina_toki_pona_semantic_layer_r1.md`
- record the seven-anchor compression set for Lumina interface language
- position toki pona as a semantic / translation layer rather than runtime law

## Core anchors
- `awen sona` — continuity / preserved context
- `lawa` — governance / system law
- `nasin` — guidance / path
- `pali` — action / work
- `jan` — human consent / human presence
- `ilo` — tool substrate / machine capability
- `tomo` — Chamber / Studio / workspace habitat

## Why this belongs
The governed substrate is becoming powerful and layered. The finished Lumina surface needs a small internal compass that keeps the user experience simple, calm, and human-first.

This document gives contributors a compression layer for translating runtime depth into ordinary interface meaning: restore, boundary, next step, work, consent, tool, workspace.

## Boundary note
This is not runtime law, canon lineage, mode legality, checkpoint legality, or governance authority. It may guide language, onboarding, interface labels, and product-surface translation only.