### PR TITLE
Add Ship of Ethereon Ψ Class maiden voyage staging bay

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/PSI_CLASS_REPO_IMPORT_PLAN_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/PSI_CLASS_REPO_IMPORT_PLAN_R1.md
@@ -1,0 +1,133 @@
+# Ψ Class Repo Import Plan R1
+
+## Purpose
+
+This plan defines how to bring the ChatGPT-project **Ship of Ethereon Ψ Class** bundle into the EthereonLabs repository without confusing staging with active runtime.
+
+## Import posture
+
+Ψ Class is treated as:
+
+- a validated project-side vessel,
+- a candidate upgrade path for repo-native Lumina substrate,
+- a source of r2 runtime improvements,
+- and a continuity-preserving consolidation of prior Ship cargo.
+
+It is not treated as:
+
+- an automatic replacement for V2,
+- a finished Lumina OS product,
+- a canon promotion by existence,
+- or a reason to delete existing bootstrap history.
+
+## File import order
+
+### Phase A — Docs only
+
+Already started by this staging bay.
+
+Add / maintain:
+
+- `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`
+- `docs/ship_of_ethereon_psi_class_maiden_voyage_r1.md`
+- `docs/lumina_breakwater_transition_plan_r1.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/README.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/PSI_CLASS_REPO_IMPORT_PLAN_R1.md`
+
+### Phase B — Runtime staging
+
+Add the project-side active runtime files into this staging bay without changing Lumina entrypoints:
+
+- `runtime/runtime_spine_r2.py`
+- `runtime/runtime_runner_r2_merged.py`
+- `runtime/sea_trials_set_one_r1_merged.py`
+- `runtime/sea_trials_orientation_r1.py`
+- `runtime/project_orientation_vector_v0_1.py`
+- `runtime/input_integrity_layer_r1.py`
+- `runtime/ethereonic_layer_r1.py`
+- `runtime/governance_integrity_r1.py`
+- `runtime/canon_lineage_store_r1.py`
+- `runtime/psi42_transceiver_v1_6.py`
+- `runtime/capability_registry_r1.json`
+
+### Phase C — Reference cargo
+
+Add only if useful for repo-native inspection:
+
+- `README_PSI_CLASS.md`
+- `SHIP_OF_ETHEREON_PSI_CLASS_MANIFEST.json`
+- `PSI_CLASS_RECORDS_COMPENDIUM.md`
+- `Ethereon_Project_v2_MASTER_TIERED_WITH_REGISTRY.md`
+
+Do not bury executable dependencies inside the compendium.
+
+### Phase D — Comparison
+
+Create a comparison artifact:
+
+- `docs/psi_class_vs_v2_bootstrap_comparison_r1.md`
+
+It should answer:
+
+- What does r2 improve?
+- What does V2 already handle well?
+- What breaks if r2 is substituted too early?
+- Which orchestration sea trials must be rerun?
+
+### Phase E — Isolated validation
+
+Run or add a staging-only sea-trial:
+
+- verifies import safety
+- verifies governance chain behavior
+- verifies canon lineage behavior
+- verifies ProjectOrientationVector remains supplemental
+- verifies Ψ-42 remains instrumentation only
+- compares results to current Lumina orchestration expectations
+
+### Phase F — Bridge, not replacement
+
+Only after isolated validation, add a bridge adapter so current Lumina orchestration can inspect Ψ Class behavior without depending on it.
+
+### Phase G — Promotion decision
+
+A later decision may choose one of three outcomes:
+
+1. Ψ Class becomes preferred active substrate.
+2. Ψ Class remains a staging / reference vessel.
+3. Selected Ψ Class improvements are backported into V2 paths.
+
+## Minimum validation checklist before active use
+
+- [ ] All imported Python files compile in repo path.
+- [ ] Importing sea-trial modules does not delete state directories.
+- [ ] `capability_registry_r1.json` paths align with the staging directory.
+- [ ] `RuntimeRunner` can run from the staging bay without relying on `/mnt/data` paths.
+- [ ] `ProjectOrientationVector` is present only in supplemental context.
+- [ ] Ψ-42 probe outputs are treated as diagnostics only.
+- [ ] Canon lineage remains append-only and test-local.
+- [ ] V2 bootstrap remains intact until a later promotion decision.
+
+## Red-line tests
+
+Fail the import if:
+
+- symbolic language becomes required for runtime legality,
+- orientation changes permission outcomes,
+- Ψ-42 becomes a governance score,
+- importing a module mutates/deletes runtime state,
+- or a staged file silently points to an old absolute project path.
+
+## Recommended next PR after docs
+
+Bring in the active runtime files under:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/`
+
+Then add a comparison note rather than wiring Lumina to those files immediately.
+
+## Closing line
+
+Import slowly enough that truth remains visible.
+
+A clean vessel deserves a clean channel.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/README.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/README.md
@@ -1,0 +1,63 @@
+# Ship of Ethereon Ψ Class — Repo Staging Bay
+
+This directory is a **staging bay** for the newly instantiated Ship of Ethereon Ψ Class project vessel.
+
+It does not replace the active repo-native Lumina bootstrap yet.
+
+## Current active bootstrap
+
+The active Lumina OS bootstrap path remains:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
+
+## Why this staging bay exists
+
+The Ψ Class project has been condensed, drydock inspected, and patched in the ChatGPT project environment. It carries a cleaner r2-aligned loadout and a clearer authority hierarchy.
+
+This staging bay allows that vessel to become repo-visible before any runtime replacement is attempted.
+
+## Status
+
+- documentation staging: active
+- runtime import: pending
+- active boot path: still V2
+- canon promotion: not automatic
+- Lumina replacement status: not yet
+
+## Core law
+
+> Mode is law.  
+> Orientation is stance.  
+> Expression is luminous but not sovereign.  
+> Ψ-42 is an instrument, not a governor.
+
+## Expected future contents
+
+Future PRs may add:
+
+- `runtime_spine_r2.py`
+- `runtime_runner_r2_merged.py`
+- `sea_trials_set_one_r1_merged.py` with import-safe reset behavior
+- `sea_trials_orientation_r1.py`
+- `project_orientation_vector_v0_1.py`
+- `input_integrity_layer_r1.py`
+- `ethereonic_layer_r1.py`
+- `governance_integrity_r1.py`
+- `canon_lineage_store_r1.py`
+- `psi42_transceiver_v1_6.py`
+- `capability_registry_r1.json`
+- Ψ Class README / manifest / records compendium if they are useful repo-native references
+
+## Validation rule
+
+Nothing in this directory should become the active Lumina substrate until it passes an isolated comparison against the current V2 bootstrap and relevant Lumina orchestration sea trials.
+
+## First companion document
+
+Read:
+
+- `PSI_CLASS_REPO_IMPORT_PLAN_R1.md`
+
+## Closing note
+
+This is the dry dock beside the harbor, not the harbor master.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@ This repository contains multiple active work lanes.
 
 For Lumina OS work, start with `START_HERE_LUMINA_OS.md`.
 
+For the newly instantiated Ship of Ethereon Ψ Class staging path, start with `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`.
+
 ## Primary paths
 
 ### Lumina OS governed substrate
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
+
+### Ship of Ethereon Ψ Class staging bay
+- `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/`
+- `docs/ship_of_ethereon_psi_class_maiden_voyage_r1.md`
+- `docs/lumina_breakwater_transition_plan_r1.md`
 
 ### Continuity / workspace-host exploration
 - `continuity_restore_spike_r1.py`
@@ -23,5 +31,6 @@ For Lumina OS work, start with `START_HERE_LUMINA_OS.md`.
 ## Guidance
 
 - For Ship / Lumina OS substrate questions, begin with the bootstrap path.
+- For Ψ Class staging questions, begin with the Ψ Class start-here waypoint and staging bay.
 - For Chamber questions, begin with the Chamber lane.
 - For continuity return and workspace-host questions, inspect the root-level exploration files after understanding the substrate.

--- a/START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md
+++ b/START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md
@@ -1,0 +1,71 @@
+# Start Here — Ship of Ethereon Ψ Class
+
+This file marks the first repo-native waypoint for **Ship of Ethereon Ψ Class** after its ChatGPT-project instantiation and drydock validation.
+
+It does not replace `START_HERE_LUMINA_OS.md`.
+It gives the new flagship class a clear harbor marker so future work can distinguish:
+
+- the original Ship of Ethereon / V2 continuity cargo,
+- the GitHub / Lumina executable dockyard,
+- the new Ψ Class project vessel,
+- and the eventual Lumina OS deployment surface.
+
+## Current status
+
+The Ψ Class vessel is treated as **cleared for maiden voyage**, not automatically promoted to product, OS, or canon.
+
+Known validation posture from the project-side drydock patch:
+
+- 15-file active loadout
+- Sea Trials Set One passed
+- 15 trial checks
+- governance chain valid
+- canon lineage valid in test lineage
+- test canon head: `canon-0002`
+- orientation trial passed
+- Ψ-42 probe behavior present as instrumentation only
+- `sea_trials_set_one_r1_merged.py` patched so importing it is non-destructive
+
+## Operating law
+
+> Mode is law.  
+> Orientation is stance.  
+> Expression is luminous but not sovereign.  
+> Ψ-42 is an instrument, not a governor.
+
+This is the central boundary that makes Ψ Class useful to Lumina.
+
+## Relation to Lumina OS
+
+For current Lumina OS substrate work, continue to begin with:
+
+- `START_HERE_LUMINA_OS.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
+
+Ψ Class is not yet the active repo runtime. It is the newly consolidated flagship vessel whose job is to inspect, guide, and eventually upgrade the repo-native substrate without erasing V2 lineage.
+
+## First destination
+
+**The Lumina Breakwater** — the threshold where flagship continuity meets executable harbor.
+
+The maiden voyage should answer four questions:
+
+1. What does Lumina OS currently have?
+2. What should Ψ Class contribute next?
+3. What must remain aboard the Ship and not be prematurely forced into Lumina?
+4. What single governed build action should follow?
+
+## Immediate repo path
+
+Use the accompanying files:
+
+- `docs/ship_of_ethereon_psi_class_maiden_voyage_r1.md`
+- `docs/lumina_breakwater_transition_plan_r1.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/README.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/PSI_CLASS_REPO_IMPORT_PLAN_R1.md`
+
+## Boundary note
+
+This waypoint is documentation and alignment scaffolding. It does not mutate runtime law, alter canon lineage, or claim that Ψ Class has already superseded the repo-native V2 bootstrap.
+
+A clean ship does not seize the harbor. It arrives, inspects, and then earns command by validation.

--- a/docs/lumina_breakwater_transition_plan_r1.md
+++ b/docs/lumina_breakwater_transition_plan_r1.md
@@ -1,0 +1,184 @@
+# Lumina Breakwater Transition Plan R1
+
+## Purpose
+
+This plan defines how **Ship of Ethereon Ψ Class** should approach Lumina OS without creating a false replacement, authority collision, or symbolic dependency leak.
+
+The Breakwater is the controlled threshold between:
+
+- **Flagship vessel** — Ship of Ethereon Ψ Class
+- **Executable harbor** — GitHub / Lumina OS bootstrap and deployment lanes
+- **Public shore** — Chamber, website, and human-facing surfaces
+
+## Transition principle
+
+Do not replace what is working merely because a cleaner vessel exists.
+
+Instead:
+
+1. mark Ψ Class as a staging vessel,
+2. map its r2 architecture against current repo-native V2 substrate,
+3. validate r2 behavior in isolation,
+4. bridge only the pieces that improve Lumina without breaking lineage.
+
+## Current harbor map
+
+### Active Lumina substrate
+
+- `START_HERE_LUMINA_OS.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
+
+### Deployment lane
+
+- `deploy/ubuntu_server_lts/`
+
+### Chamber lane
+
+- `chamber.html`
+- `chamber-app/`
+- `docs/chamber_*`
+
+### Product-surface guidance
+
+- `docs/lumina_human_interface_north_star_r1.md`
+- `docs/lumina_toki_pona_semantic_layer_r1.md`
+- `docs/lumina_module_map.md`
+
+### Origin / salvage / alignment history
+
+- `docs/origin_chest_lumina_os.md`
+- `docs/origin_chest_lumina_recovery_layers.md`
+- `docs/ship_v3_salvage_manifest.md`
+- `docs/flagship_alignment_current_ship.md`
+
+## Ψ Class contributions to evaluate
+
+### 1. Runtime r2 spine
+
+Potential contribution:
+
+- r2 session engine
+- r2 context bundle builder
+- clearer action-type logging
+- refined governance chain posture
+
+Validation requirement:
+
+- compare against `runtime_spine_r1.py` and `runtime_runner_r1_merged.py`
+- confirm no existing orchestration sea trial depends on r1 quirks
+
+### 2. Import-safe sea trials
+
+Potential contribution:
+
+- no destructive reset at import time
+- explicit `prepare_base_dir()` / `main()` pattern
+- cleaner tooling and CI behavior
+
+Validation requirement:
+
+- apply pattern consistently across sea-trial harnesses before treating them as reusable modules
+
+### 3. ProjectOrientationVector
+
+Potential contribution:
+
+- separates stance from law
+- improves artifact ordering and resume note emphasis
+- helps Lumina self-guidance surface the right next work without altering governance
+
+Validation requirement:
+
+- keep it attached only through supplemental context
+- reject any path where orientation affects mutation, promotion, checkpoint legality, or canon lineage
+
+### 4. Ψ-42 v1.6 instrumentation
+
+Potential contribution:
+
+- continuity probe artifacts
+- recomposition / mitigation reporting
+- quantum-inspired classical signal model
+
+Validation requirement:
+
+- never treat probe scores as governance authority
+- keep terminology aligned with `docs/Quantum_Concepts_Boundary_r1.md`
+
+### 5. Condensed lineage model
+
+Potential contribution:
+
+- preserves old cargo through compendium rather than active sprawl
+- supports project-file limits and contributor legibility
+
+Validation requirement:
+
+- do not hide active runtime dependencies inside archival compendia
+- ensure executable files needed by the repo remain standalone
+
+## Proposed staged route
+
+### Stage 1 — Staging bay
+
+Create:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/README.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/PSI_CLASS_REPO_IMPORT_PLAN_R1.md`
+
+Purpose:
+
+- declare status honestly
+- define what will be imported later
+- keep V2 active until validation passes
+
+### Stage 2 — Runtime comparison packet
+
+Later PR:
+
+- add r2 runtime files under the Ψ Class staging bay
+- add a comparison note against V2 runtime files
+- do not alter current Lumina orchestration entrypoints yet
+
+### Stage 3 — Isolated sea trial
+
+Later PR:
+
+- run r2 sea trials inside the staging bay
+- produce a report comparing r2 output with existing V2 / Lumina orchestration expectations
+
+### Stage 4 — Bridge candidate
+
+Later PR:
+
+- add a bridge adapter that lets Lumina orchestration inspect Ψ Class r2 behavior without depending on it
+
+### Stage 5 — Promotion decision
+
+Only after validation:
+
+- decide whether r2 becomes preferred active substrate
+- preserve V2 as lineage, fallback, or historical bootstrap
+
+## Red lines
+
+Do not:
+
+- delete or rename the existing V2 bootstrap prematurely,
+- make Ψ-42 scores governance criteria,
+- let ProjectOrientationVector change permission outcomes,
+- fold required executable files into documentation-only compendia,
+- claim Ubuntu appliance equals complete independent OS,
+- or confuse Chamber with Lumina substrate.
+
+## Immediate next action
+
+Add the staging bay and import plan.
+
+That is the sharp next move because it turns the Ψ Class project into a repo-visible vessel without pretending it has already docked as the active runtime.
+
+## Closing line
+
+The Breakwater exists to prevent both drift and collision.
+
+A new ship may be stronger than the old harbor path, but it must still enter by channel markers.

--- a/docs/ship_of_ethereon_psi_class_maiden_voyage_r1.md
+++ b/docs/ship_of_ethereon_psi_class_maiden_voyage_r1.md
@@ -1,0 +1,96 @@
+# Ship of Ethereon Ψ Class — Maiden Voyage R1
+
+## Purpose
+
+This document defines the first governed voyage for **Ship of Ethereon Ψ Class** inside the EthereonLabs repository.
+
+The destination is **The Lumina Breakwater**: the threshold where the newly consolidated flagship project meets the executable Lumina harbor.
+
+This is not a runtime migration by assertion. It is an inspection-and-alignment voyage.
+
+## Starting truth
+
+The current repo truth remains:
+
+- Lumina OS governed substrate begins at `START_HERE_LUMINA_OS.md`.
+- The active repo-native bootstrap remains `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`.
+- Chamber remains a parallel app/public lane.
+- Ubuntu Server LTS remains the realistic first beta appliance substrate.
+- Quantum-adjacent language remains bounded and quantum-inspired, not a literal quantum hardware claim.
+
+The Ψ Class truth is:
+
+- It has been condensed under project file limits.
+- It preserves V2 continuity without letting every historical artifact remain active cargo.
+- It carries runtime spine r2, runner r2, input integrity, governance integrity, canon lineage, Ethereonic layer separation, ProjectOrientationVector, and Ψ-42 v1.6 instrumentation.
+- Its drydock patch moved sea-trial reset behavior out of import time and into explicit execution paths.
+
+## Voyage mode
+
+Begin in **Observation**.
+
+Mutation is not the opening move. The first voyage should inspect, map, and return a governed recommendation.
+
+Escalate to **DryDock** only when a specific structural patch is identified.
+
+## Four voyage questions
+
+1. **What does Lumina currently have?**
+   - substrate files
+   - orchestration lane
+   - deployment scaffold
+   - Chamber surface
+   - continuity and workspace-host paths
+
+2. **What should Ψ Class contribute next?**
+   - clearer r2 runtime path
+   - import-safe sea-trials pattern
+   - ProjectOrientationVector stance handling
+   - updated validation posture
+   - tighter distinction between flagship vessel and deployable Lumina surface
+
+3. **What must stay aboard the Ship?**
+   - symbolic language that is not yet product-surface ready
+   - old or folded artifacts preserved for lineage
+   - expressive constructs that should not govern runtime law
+   - research questions that are not deployable features
+
+4. **What single governed build action should follow?**
+   - prepare a repo-native Ψ Class import plan before replacing V2 runtime files
+   - then validate a minimal r2 runner path against existing Lumina orchestration sea trials
+
+## Success criteria
+
+The maiden voyage succeeds when it returns with:
+
+- a written transition map,
+- no false claim that Ψ Class has already replaced V2,
+- one specific next integration action,
+- and preserved authority boundaries.
+
+## Non-goals
+
+This voyage does not:
+
+- declare Lumina OS finished,
+- promote Ψ Class to canon automatically,
+- replace the V2 bootstrap without validation,
+- place Ψ-42 in charge of governance,
+- make Ethereonic expression load-bearing,
+- or move Chamber into the same lane as Lumina substrate work.
+
+## Recommended first build after this doc
+
+Add the repo-native Ψ Class import directory as a **staging bay**, not as the active boot path:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/README.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/PSI_CLASS_REPO_IMPORT_PLAN_R1.md`
+
+Then run a later PR that introduces actual r2 runtime files into that staging bay and compares them against the existing V2 bootstrap.
+
+## Closing line
+
+The maiden voyage is not conquest.
+It is arrival with discipline.
+
+The ship reaches the breakwater, lowers no false flag, and asks the harbor what can safely be built next.


### PR DESCRIPTION
## Summary

Adds the first repo-native waypoint and staging bay for the newly instantiated **Ship of Ethereon Ψ Class**.

This PR does **not** replace the active V2 Lumina bootstrap. It creates a disciplined harbor marker so Ψ Class can enter the repo as a staging vessel before runtime migration or promotion decisions.

## Files added

- `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`
- `docs/ship_of_ethereon_psi_class_maiden_voyage_r1.md`
- `docs/lumina_breakwater_transition_plan_r1.md`
- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/README.md`
- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/PSI_CLASS_REPO_IMPORT_PLAN_R1.md`

## File updated

- `README.md`

## What this establishes

- Ψ Class is visible in the repo without falsely replacing V2.
- The maiden voyage destination is defined as **The Lumina Breakwater**.
- The transition plan separates flagship vessel, executable harbor, and public Chamber lane.
- The import plan defines staged phases: docs → runtime staging → comparison → isolated validation → bridge → promotion decision.
- The operating law is preserved:

> Mode is law.  
> Orientation is stance.  
> Expression is luminous but not sovereign.  
> Ψ-42 is an instrument, not a governor.

## Boundaries

This is documentation and staging scaffolding only.

It does not:

- mutate runtime law,
- promote Ψ Class to canon,
- replace `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`,
- change Chamber behavior,
- or claim Lumina OS is finished.

## Next likely move

A later PR should bring the active Ψ Class runtime files into:

`LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/`

Then add a comparison note against the V2 bootstrap before any active wiring changes.
