### PR TITLE
Update Ψ Class post-merge posture

### DIFF
--- a/docs/lumina_breakwater_transition_plan_r1.md
+++ b/docs/lumina_breakwater_transition_plan_r1.md
@@ -28,6 +28,11 @@ Instead:
 - `START_HERE_LUMINA_OS.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
 
+### Ψ Class staging bay
+
+- `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/`
+
 ### Deployment lane
 
 - `deploy/ubuntu_server_lts/`
@@ -121,8 +126,11 @@ Validation requirement:
 
 ### Stage 1 — Staging bay
 
-Create:
+Status: **complete as of PR #67**.
 
+Created:
+
+- `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/README.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/PSI_CLASS_REPO_IMPORT_PLAN_R1.md`
 
@@ -134,7 +142,7 @@ Purpose:
 
 ### Stage 2 — Runtime comparison packet
 
-Later PR:
+Next PR:
 
 - add r2 runtime files under the Ψ Class staging bay
 - add a comparison note against V2 runtime files
@@ -173,9 +181,9 @@ Do not:
 
 ## Immediate next action
 
-Add the staging bay and import plan.
+Stage **runtime files** into the Ψ Class bay and add a V2 comparison note before any active wiring changes.
 
-That is the sharp next move because it turns the Ψ Class project into a repo-visible vessel without pretending it has already docked as the active runtime.
+That is the sharp next move because Ψ Class is now repo-visible, but not yet validated as the active runtime substrate.
 
 ## Closing line
 

--- a/docs/ship_of_ethereon_psi_class_maiden_voyage_r1.md
+++ b/docs/ship_of_ethereon_psi_class_maiden_voyage_r1.md
@@ -79,14 +79,28 @@ This voyage does not:
 - make Ethereonic expression load-bearing,
 - or move Chamber into the same lane as Lumina substrate work.
 
-## Recommended first build after this doc
+## Maiden voyage result
 
-Add the repo-native Ψ Class import directory as a **staging bay**, not as the active boot path:
+Status: **complete as repo-visible staging, via PR #67**.
 
+The voyage successfully added a Ψ Class waypoint and staging bay without replacing V2 or changing active runtime wiring:
+
+- `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`
+- `docs/ship_of_ethereon_psi_class_maiden_voyage_r1.md`
+- `docs/lumina_breakwater_transition_plan_r1.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/README.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/PSI_CLASS_REPO_IMPORT_PLAN_R1.md`
 
-Then run a later PR that introduces actual r2 runtime files into that staging bay and compares them against the existing V2 bootstrap.
+## Recommended next build
+
+Introduce actual r2 runtime files into the staging bay and compare them against the existing V2 bootstrap before active wiring changes.
+
+Recommended next files:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/runtime_spine_r2.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/runtime_runner_r2_merged.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/sea_trials_set_one_r1_merged.py`
+- `docs/psi_class_vs_v2_bootstrap_comparison_r1.md`
 
 ## Closing line
 


### PR DESCRIPTION
## Summary

Post-merge cleanup after PR #67.

PR #67 successfully added the Ship of Ethereon Ψ Class waypoint and staging bay. Two docs still described the staging bay as the immediate next action. This update changes their posture so the repo now clearly says:

- Stage 1 is complete.
- The immediate next action is runtime staging plus V2 comparison.
- Ψ Class remains repo-visible but not active runtime substrate yet.

## Files updated

- `docs/lumina_breakwater_transition_plan_r1.md`
- `docs/ship_of_ethereon_psi_class_maiden_voyage_r1.md`

## Boundary

Documentation-only. No runtime files, Chamber files, deployment files, canon lineage, or active Lumina bootstrap paths are changed.
