### PR TITLE
Begin Ψ Class runtime staging and V2 comparison

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/README_RUNTIME_STAGING_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/README_RUNTIME_STAGING_R1.md
@@ -1,0 +1,64 @@
+# Ψ Class Runtime Staging R1
+
+## Purpose
+
+This directory is the staging bay for Ship of Ethereon Ψ Class runtime files.
+
+This PR begins the runtime-staging process without wiring Ψ Class into active Lumina execution.
+
+## Current status in this staging PR
+
+Staged now:
+
+- `capability_registry_r1.json`
+- `docs/psi_class_vs_v2_bootstrap_comparison_r1.md`
+
+Prepared locally for full import:
+
+- `runtime_spine_r2.py`
+- `runtime_runner_r2_merged.py`
+- `sea_trials_set_one_r1_merged.py`
+- `sea_trials_orientation_r1.py`
+- `project_orientation_vector_v0_1.py`
+- `input_integrity_layer_r1.py`
+- `ethereonic_layer_r1.py`
+- `governance_integrity_r1.py`
+- `canon_lineage_store_r1.py`
+- `psi42_transceiver_v1_6.py`
+
+## Local preflight performed before PR
+
+The prepared runtime files were checked locally before staging:
+
+- project-side `/mnt/data` defaults were removed from staged runtime copies
+- Ψ-42 default artifact paths were converted to repo-local `_runtime_state/psi42_artifacts`
+- `sea_trials_set_one_r1_merged.py` default state root was converted to repo-local `_runtime_state/ethereon_sea_trials_r2_hardening`
+- `ethereonic_layer_r1.py` standalone demo registry path was converted to repo-local `_runtime_state/ethereonic_layer_registry_r1.json`
+- all prepared Python runtime files compiled successfully to a temp cache
+
+## Why the full runtime files are not active yet
+
+The active Lumina substrate remains:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
+
+This staging bay must prove that Ψ Class can coexist with V2 before any active wiring changes.
+
+## Import rule
+
+When the full runtime files are added, do not change active entrypoints in the same step.
+
+The next validation step should check:
+
+1. Python compile from repo path.
+2. Import safety for sea-trial modules.
+3. Minimal `Continuity -> Observation` r2 runner cycle.
+4. ProjectOrientationVector remains supplemental only.
+5. Ψ-42 remains instrumentation only.
+6. V2 bootstrap remains intact.
+
+## Boundary
+
+This directory is staging, not sovereignty.
+
+Mode remains law. Orientation remains stance. Expression remains supplemental. Ψ-42 remains an instrument.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/capability_registry_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/capability_registry_r1.json
@@ -1,0 +1,154 @@
+{
+  "version": "0.4",
+  "description": "Capability registry aligned to the Ethereon Runtime Spine r2 entrypoints while preserving existing authority boundaries.",
+  "capabilities": [
+    {
+      "capability_id": "session_state_manager",
+      "name": "Session State Manager",
+      "module_path": "runtime_spine_r2.py",
+      "status": "active",
+      "category": "structural",
+      "allowed_modes": [
+        "Continuity",
+        "Sandbox",
+        "DryDock",
+        "Observation",
+        "Canon"
+      ],
+      "mutation_scope": "session",
+      "requires_validation": false,
+      "authority_boundary": "Owns active session state, checkpoints, and turn continuity only.",
+      "dependencies": [],
+      "feature_flag": null
+    },
+    {
+      "capability_id": "mode_guard",
+      "name": "Mode Guard",
+      "module_path": "runtime_spine_r2.py",
+      "status": "active",
+      "category": "structural",
+      "allowed_modes": [
+        "Continuity",
+        "Sandbox",
+        "DryDock",
+        "Observation",
+        "Canon"
+      ],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "Owns legality checks for transitions, mutation permission, and promotion gating.",
+      "dependencies": [],
+      "feature_flag": null
+    },
+    {
+      "capability_id": "context_bundle_builder",
+      "name": "Context Bundle Builder",
+      "module_path": "runtime_spine_r2.py",
+      "status": "active",
+      "category": "structural",
+      "allowed_modes": [
+        "Continuity",
+        "Sandbox",
+        "DryDock",
+        "Observation"
+      ],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "Builds bounded, replayable context bundles and separates core from supplemental Ethereonic context.",
+      "dependencies": [],
+      "feature_flag": null
+    },
+    {
+      "capability_id": "input_integrity_assessor",
+      "name": "Input Integrity Assessor",
+      "module_path": "input_integrity_layer_r1.py",
+      "status": "active",
+      "category": "structural",
+      "allowed_modes": [
+        "Continuity",
+        "Sandbox",
+        "DryDock",
+        "Observation",
+        "Canon"
+      ],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "May annotate ambiguity, score candidate interpretations, and recommend clarification or halt behavior. May not alter governance law, canon state, or execute mutating actions on inferred intent alone.",
+      "dependencies": [],
+      "feature_flag": null
+    },
+    {
+      "capability_id": "continuity_assessor",
+      "name": "Continuity Assessor",
+      "module_path": "runtime_runner_r2_merged.py",
+      "status": "experimental",
+      "category": "expressive",
+      "allowed_modes": [
+        "Observation"
+      ],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "May evaluate continuity metrics but may not declare canon state or governance law.",
+      "dependencies": [
+        "session_state_manager"
+      ],
+      "feature_flag": "ETHEREON_OBSERVATION"
+    },
+    {
+      "capability_id": "psi42_probe_interface",
+      "name": "Psi-42 Probe Interface",
+      "module_path": "psi42_transceiver_v1_6.py",
+      "status": "experimental-active",
+      "category": "expressive",
+      "allowed_modes": [
+        "Observation",
+        "Sandbox"
+      ],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "Emits probe metrics and artifacts only; does not govern continuity, canon state, or runtime law.",
+      "dependencies": [
+        "session_state_manager"
+      ],
+      "feature_flag": "ETHEREON_PSI42"
+    },
+    {
+      "capability_id": "resonance_ledger_adapter",
+      "name": "Resonance Ledger Adapter",
+      "module_path": "sea_trials_set_one_r1_merged.py",
+      "status": "experimental",
+      "category": "expressive",
+      "allowed_modes": [
+        "Observation",
+        "Sandbox",
+        "DryDock"
+      ],
+      "mutation_scope": "artifact",
+      "requires_validation": true,
+      "authority_boundary": "May read and emit resonance metadata; may not write governance state.",
+      "dependencies": [
+        "context_bundle_builder"
+      ],
+      "feature_flag": "ETHEREON_RESONANCE"
+    },
+    {
+      "capability_id": "psi42_transceiver_v16",
+      "name": "Psi-42 Transceiver v1.6",
+      "module_path": "psi42_transceiver_v1_6.py",
+      "status": "experimental-active",
+      "category": "expressive",
+      "allowed_modes": [
+        "Observation",
+        "Sandbox"
+      ],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "Owns signal encoding, mitigation, adaptive probe steering, recovery metrics, recomposition reports, and probe artifacts only. Does not own canon state, governance, or primary continuity authority.",
+      "dependencies": [
+        "session_state_manager",
+        "psi42_probe_interface"
+      ],
+      "feature_flag": "ETHEREON_PSI42"
+    }
+  ]
+}

--- a/docs/psi_class_vs_v2_bootstrap_comparison_r1.md
+++ b/docs/psi_class_vs_v2_bootstrap_comparison_r1.md
@@ -1,0 +1,124 @@
+# Ψ Class vs V2 Bootstrap Comparison R1
+
+## Purpose
+
+This document compares the newly staged **Ship of Ethereon Ψ Class** runtime files against the existing repo-native **Ship of Ethereon V2** Lumina bootstrap.
+
+It exists to prevent premature replacement.
+
+The Ψ Class runtime is being added as a staging candidate, not as the active Lumina substrate.
+
+## Current active path
+
+The active Lumina bootstrap remains:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
+
+## New staging path
+
+The Ψ Class runtime candidate is staged under:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/`
+
+## What Ψ Class / r2 improves
+
+### 1. Runtime r2 posture
+
+Ψ Class carries the r2 runtime spine and runner, which are intended to improve:
+
+- action-type logging,
+- context-bundle construction,
+- governance-chain reporting,
+- checkpoint/reflection handling,
+- and clearer separation between runtime law and supplemental context.
+
+### 2. Import-safe sea-trial pattern
+
+The staged `sea_trials_set_one_r1_merged.py` has been adjusted for repo staging so importing it is non-destructive. Reset behavior belongs in `prepare_base_dir()` / `main()`, not at import time.
+
+### 3. Repo-local state defaults
+
+Project-side `/mnt/data` defaults have been removed from the staged runtime copies. Staged runtime artifacts should write into local `_runtime_state` paths unless callers provide explicit output directories.
+
+### 4. ProjectOrientationVector
+
+Ψ Class adds a formal stance layer:
+
+- orientation can reorder surfaced artifacts,
+- orientation can improve resume-note emphasis,
+- orientation can help self-guidance decide what to inspect next,
+- but orientation must never alter legality, mutation, promotion, checkpoint validity, canon lineage, or governance outcomes.
+
+### 5. Ψ-42 v1.6 as instrumentation
+
+Ψ Class carries Ψ-42 v1.6 as a quantum-inspired classical signal/probe instrument. It may emit diagnostics and probe artifacts, but it must not govern runtime truth.
+
+## What V2 already handles well
+
+The existing V2 bootstrap remains important because it already contains repo-native Lumina work:
+
+- active Lumina start path and contributor navigation,
+- return / workspace-host bridge paths,
+- bounded self-guidance advisory behavior,
+- orchestration continuity sea trials,
+- quantum-boundary terminology work,
+- and existing integration with the broader Lumina, Chamber, and deployment lanes.
+
+V2 should not be deleted or displaced merely because Ψ Class is cleaner.
+
+## What could break if r2 replaces V2 too early
+
+Premature replacement could break:
+
+- imports that expect the V2 directory layout,
+- orchestration sea trials tied to V2 module names,
+- documentation paths in `START_HERE_LUMINA_OS.md`,
+- bridge files that expect existing r1 runner behavior,
+- deployment scripts that reference V2 assumptions,
+- contributor navigation that distinguishes Lumina substrate from Chamber,
+- or any hidden dependency on r1 defaults.
+
+## Required validation before active wiring
+
+Before Ψ Class can become the preferred active substrate, the repo should verify:
+
+- all staged Python files compile from the repo path,
+- staged sea-trial modules remain non-destructive on import,
+- `RuntimeRunner` can run from the staging bay without `/mnt/data` defaults,
+- `ProjectOrientationVector` remains supplemental only,
+- Ψ-42 outputs remain diagnostics only,
+- canon lineage remains append-only and test-local,
+- V2 bootstrap remains intact,
+- Lumina orchestration sea trials still pass or receive explicit bridge adapters,
+- and no Chamber/public-lane behavior is unintentionally changed.
+
+## Candidate follow-up sea trials
+
+A later staging validation PR should add or run:
+
+1. **Compile check** for all staged runtime files.
+2. **Import safety check** for sea-trial harnesses.
+3. **Minimal r2 runner cycle** from `Continuity` to `Observation`.
+4. **Orientation boundary check** proving orientation does not enter governance payloads.
+5. **Ψ-42 diagnostic check** proving probe artifacts are emitted but not used as permission criteria.
+6. **V2 coexistence check** proving current V2 files remain present and unmodified.
+
+## Recommended next step after this staging PR
+
+Do not wire Ψ Class into Lumina yet.
+
+The next step should be a validation PR that executes the staged runtime in isolation and records a comparison report.
+
+## Decision options after validation
+
+After staging validation, choose one:
+
+1. Promote Ψ Class/r2 to preferred active substrate.
+2. Keep Ψ Class as staging/reference while V2 remains active.
+3. Backport selected Ψ Class improvements into the V2 path.
+
+## Closing line
+
+A cleaner ship still earns command by trial.
+
+The Breakwater holds until the harbor confirms the channel is clear.


### PR DESCRIPTION
## Summary

Begins Stage 2 of the Ship of Ethereon Ψ Class repo path: runtime staging plus V2 comparison.

This PR intentionally does **not** wire Ψ Class into active Lumina execution.

## Files added

- `docs/psi_class_vs_v2_bootstrap_comparison_r1.md`
- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/capability_registry_r1.json`
- `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/README_RUNTIME_STAGING_R1.md`

## What this establishes

- Adds the V2 comparison document required by the post-merge posture update.
- Starts the Ψ Class runtime staging bay with the capability registry.
- Records the local preflight preparation for the runtime files before full import.
- Keeps active Lumina substrate untouched.

## Local preflight completed before PR

Prepared local copies of the Ψ Class runtime files were checked before this PR:

- removed project-side `/mnt/data` defaults from staged runtime copies
- converted Ψ-42 artifact defaults to repo-local `_runtime_state/psi42_artifacts`
- converted `sea_trials_set_one_r1_merged.py` state root to repo-local `_runtime_state/ethereon_sea_trials_r2_hardening`
- converted `ethereonic_layer_r1.py` demo registry path to repo-local `_runtime_state/ethereonic_layer_registry_r1.json`
- compiled all prepared Python runtime files successfully to a temp cache

## Important limitation / honesty note

The full large Python runtime files are **not yet committed in this PR**. They were prepared locally, but the current connector file-write path could not cleanly stream the full runtime file set into GitHub in this pass.

Rather than falsely claiming complete runtime import, this PR preserves the completed comparison and staging scaffolding and makes the remaining import step explicit.

## Remaining runtime files to add in follow-up

- `runtime_spine_r2.py`
- `runtime_runner_r2_merged.py`
- `sea_trials_set_one_r1_merged.py`
- `sea_trials_orientation_r1.py`
- `project_orientation_vector_v0_1.py`
- `input_integrity_layer_r1.py`
- `ethereonic_layer_r1.py`
- `governance_integrity_r1.py`
- `canon_lineage_store_r1.py`
- `psi42_transceiver_v1_6.py`

## Boundary

Documentation/staging only.

No changes to:

- `START_HERE_LUMINA_OS.md`
- active V2 bootstrap entrypoints
- Lumina orchestration files
- Ubuntu deployment files
- Chamber files
- canon lineage

## Next move

Use either a direct repository upload route or a smaller batched file-write pass to commit the prepared runtime files into:

`LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/runtime/`

Then run isolated staging validation before any active wiring changes.
