### PR TITLE
Add Lumina Dashboard Homepage Hook

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,33 +4,16 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Adaptive digital environments</title>
-  <meta name="description" content="EthereonLabs is building adaptive workspaces and Lumina, a governed continuity substrate with session state, context bundles, input integrity, tamper-evident runtime history, and staged Ψ Class Breakwater validation." />
+  <meta name="description" content="EthereonLabs is building adaptive workspaces and Lumina, a governed continuity substrate with session state, context bundles, input integrity, tamper-evident runtime history, a public dashboard surface, and staged Ψ Class Breakwater validation." />
   <link rel="canonical" href="https://ethereonlabs.com/" />
   <meta property="og:site_name" content="EthereonLabs" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="EthereonLabs - Adaptive digital environments" />
-  <meta property="og:description" content="EthereonLabs is building adaptive workspaces and Lumina, a governed continuity substrate with session state, context bundles, input integrity, tamper-evident runtime history, and staged Ψ Class Breakwater validation." />
+  <meta property="og:description" content="EthereonLabs is building adaptive workspaces and Lumina, a governed continuity substrate with session state, context bundles, input integrity, tamper-evident runtime history, a public dashboard surface, and staged Ψ Class Breakwater validation." />
   <meta property="og:url" content="https://ethereonlabs.com/" />
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="EthereonLabs - Adaptive digital environments" />
-  <meta name="twitter:description" content="EthereonLabs is building adaptive workspaces and Lumina, a governed continuity substrate with session state, context bundles, input integrity, tamper-evident runtime history, and staged Ψ Class Breakwater validation." />
-  <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@graph": [
-        {
-          "@type": "WebSite",
-          "name": "EthereonLabs",
-          "url": "https://ethereonlabs.com/"
-        },
-        {
-          "@type": "Organization",
-          "name": "EthereonLabs",
-          "url": "https://ethereonlabs.com/"
-        }
-      ]
-    }
-  </script>
+  <meta name="twitter:description" content="EthereonLabs is building adaptive workspaces and Lumina, a governed continuity substrate with session state, context bundles, input integrity, tamper-evident runtime history, a public dashboard surface, and staged Ψ Class Breakwater validation." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
@@ -41,22 +24,9 @@
   <div class="page-shell">
     <header class="site-header">
       <div class="container nav-wrap">
-        <a class="brand ping-target" href="index.html">
-          <span class="brand-mark" aria-hidden="true"></span>
-          <span class="brand-text"><strong>EthereonLabs</strong><span>Adaptive digital environments</span></span>
-        </a>
-        <nav class="nav-links" aria-label="Primary">
-          <a href="index.html" aria-current="page">Home</a>
-          <a href="build.html">What We Are Building</a>
-          <a href="about.html">About</a>
-          <a href="updates.html">Updates</a>
-          <a href="explore.html">Explore</a>
-          <a href="chamber.html">Chamber</a>
-          <a href="contact.html">Contact</a>
-        </nav>
-        <div class="header-actions">
-          <button class="icon-button ping-target" type="button" data-sound-toggle aria-label="Toggle interface sounds" aria-pressed="false">○</button>
-        </div>
+        <a class="brand ping-target" href="index.html"><span class="brand-mark" aria-hidden="true"></span><span class="brand-text"><strong>EthereonLabs</strong><span>Adaptive digital environments</span></span></a>
+        <nav class="nav-links" aria-label="Primary"><a href="index.html" aria-current="page">Home</a><a href="build.html">What We Are Building</a><a href="about.html">About</a><a href="updates.html">Updates</a><a href="explore.html">Explore</a><a href="chamber.html">Chamber</a><a href="contact.html">Contact</a></nav>
+        <div class="header-actions"><button class="icon-button ping-target" type="button" data-sound-toggle aria-label="Toggle interface sounds" aria-pressed="false">○</button></div>
       </div>
     </header>
     <main>
@@ -65,102 +35,30 @@
           <div>
             <span class="eyebrow">Prototype phase - runtime-backed build</span>
             <h1>Software should adapt to people. Not the other way around.</h1>
-            <p class="lead">EthereonLabs is building adaptive workspaces and Lumina: a governed continuity substrate that now carries session state, bounded context bundles, input-integrity checks, capability-scoped tools, tamper-evident runtime history, and staged Ψ Class Breakwater validation.</p>
-            <div class="hero-actions">
-              <a class="button primary ping-target" href="build.html">See what we are building</a>
-              <a class="button secondary ping-target" href="lumina.html">Open Lumina</a>
-              <a class="button secondary ping-target" href="updates.html">Read current status</a>
-            </div>
+            <p class="lead">EthereonLabs is building adaptive workspaces and Lumina: a governed continuity substrate that now carries session state, bounded context bundles, input-integrity checks, capability-scoped tools, tamper-evident runtime history, a public dashboard surface, and staged Ψ Class Breakwater validation.</p>
+            <div class="hero-actions"><a class="button primary ping-target" href="lumina-dashboard.html">Open Lumina dashboard</a><a class="button secondary ping-target" href="build.html">See what we are building</a><a class="button secondary ping-target" href="updates.html">Read current status</a></div>
             <p class="hero-note">This is still prototype work. The shift is that the public story now rests on a real runtime spine rather than on aspiration alone. V2 remains active while Ψ Class earns command by validation.</p>
           </div>
           <aside class="interface-panel" data-glow>
-            <div class="panel-header">
-              <div class="panel-dots" aria-hidden="true"><span></span><span></span><span></span></div>
-              <div class="panel-label">Adaptive workspace preview</div>
-            </div>
+            <div class="panel-header"><div class="panel-dots" aria-hidden="true"><span></span><span></span><span></span></div><div class="panel-label">Lumina dashboard preview</div></div>
             <div class="panel-grid">
               <div class="interface-stack">
-                <div class="mock-card"><strong>Workspace state</strong><span>Project return can carry layout, references, tools, and working stance together instead of forcing a rebuild every session.</span></div>
-                <div class="mock-strip"><span>Context bundle active - bounded, replayable, and explicit</span></div>
-                <div class="mock-card"><strong>Governed substrate</strong><span>Lumina now has an early runtime path for mode legality, checkpoints, governance records, canon lineage, capability exposure, and Ψ Class staging.</span></div>
+                <div class="mock-card"><strong>System mood</strong><span>Current Lumina state is summarized as mood, weather, harmonic stance, risk, and guidance.</span></div>
+                <div class="mock-strip"><span>Dashboard active - weather, graph, trend, history, optional audio</span></div>
+                <div class="mock-card"><strong>Observable substrate</strong><span>The interface now exposes system state from generated JSON while keeping all outputs advisory and non-authoritative.</span></div>
               </div>
-              <div class="mock-sidebar">
-                <div class="mock-node"><strong>Intent</strong><span>What are you trying to do right now?</span></div>
-                <div class="mock-node"><strong>Continuity</strong><span>Restore the project pattern without rebuilding the machine by hand.</span></div>
-                <div class="mock-node"><strong>Boundaries</strong><span>Keep expressive layers optional, visible, and non-authoritative.</span></div>
-              </div>
+              <div class="mock-sidebar"><div class="mock-node"><strong>Weather</strong><span>Continuity state</span></div><div class="mock-node"><strong>Trend</strong><span>Health over time</span></div><div class="mock-node"><strong>Boundary</strong><span>Display only</span></div></div>
             </div>
           </aside>
         </div>
       </section>
-      <section class="section">
-        <div class="container status-banner">
-          <div>
-            <small>Breakwater status</small>
-            <h3>Ship of Ethereon Ψ Class is staged, not yet active runtime.</h3>
-            <p class="section-copy">The current repo truth is deliberate: V2 remains the active Lumina bootstrap; Ψ Class/r2 is staged as a cleaner candidate vessel. The next proof is isolated validation before active wiring or promotion.</p>
-          </div>
-          <a class="button primary ping-target" href="updates.html">Open updates</a>
-        </div>
-      </section>
-      <section class="section">
-        <div class="container">
-          <div class="section-header">
-            <div>
-              <h2>What EthereonLabs is actually doing</h2>
-              <p class="section-copy">We are not trying to rebuild every piece of software from scratch. We are building the continuity layer around software and the governed substrate beneath it: the part that restores context, organizes tools around real behavior, and keeps authority boundaries legible as the system grows.</p>
-            </div>
-          </div>
-          <div class="grid-3">
-            <article class="card" data-glow><h3>Adaptive workspaces</h3><p>Project spaces that bring back the right layout, notes, references, and tools when you return.</p></article>
-            <article class="card" data-glow><h3>Embedded guidance</h3><p>Assistance woven into the interface itself rather than trapped in a separate chatbot window.</p></article>
-            <article class="card" data-glow><h3>Runtime spine</h3><p>Session state, checkpoints, context bundles, mode transitions, and capability exposure now have a concrete orchestration path.</p></article>
-            <article class="card" data-glow><h3>Input integrity</h3><p>Likely typos and voice-transcription ambiguity are assessed before meaning is allowed to become load-bearing action.</p></article>
-            <article class="card" data-glow><h3>Governance and canon rails</h3><p>Runtime events can be logged through a hash-chained governance rail, while lawful promotion can write append-only canon lineage.</p></article>
-            <article class="card" data-glow><h3>Instrumented probes</h3><p>Experimental signal and resonance tools can emit diagnostics only when lawfully exposed; they do not own governance or canon state.</p></article>
-          </div>
-        </div>
-      </section>
-      <section class="section">
-        <div class="container">
-          <div class="section-header">
-            <div>
-              <h2>Explore the direction</h2>
-              <p class="section-copy">Use the path that matches what you want to understand first, from visible artifacts to deeper structural layers.</p>
-            </div>
-          </div>
-          <div class="grid-3">
-            <article class="card" data-glow><h3>Specimen</h3><p>The first public interface artifact showing the visual and behavioral direction.</p><a class="card-link ping-target" href="specimen.html">Open specimen</a></article>
-            <article class="card" data-glow><h3>Chamber</h3><p>The first public social threshold-space: a BBS-style shell for light identity, attached AI roles, and visible synthesis.</p><a class="card-link ping-target" href="chamber.html">Enter Chamber</a></article>
-            <article class="card" data-glow><h3>Lumina</h3><p>The governed substrate beneath the interface work, now backed by runtime spine, input integrity, governance, canon lineage, sea-trial framing, and Ψ Class staging.</p><a class="card-link ping-target" href="lumina.html">Open Lumina</a></article>
-            <article class="card" data-glow><h3>Continuity</h3><p>The practical core explaining why restoring context matters so much.</p><a class="card-link ping-target" href="continuity.html">Read continuity</a></article>
-            <article class="card" data-glow><h3>Roadmap</h3><p>The staged path from public direction to believable prototype, Breakwater validation, and eventual richer orchestration.</p><a class="card-link ping-target" href="roadmap.html">Open roadmap</a></article>
-            <article class="card" data-glow><h3>Principles</h3><p>The design spine that keeps the project grounded and coherent.</p><a class="card-link ping-target" href="principles.html">Open principles</a></article>
-            <article class="card" data-glow><h3>Lexicon</h3><p>A public vocabulary for the project's recurring analogies and conceptual shortcuts.</p><a class="card-link ping-target" href="lexicon.html">Open lexicon</a></article>
-            <article class="card" data-glow><h3>Recursive Spiral Equation</h3><p>A grounded explanation of the RSE as a conceptual framework and design lens.</p><a class="card-link ping-target" href="rse.html">Open RSE page</a></article>
-            <article class="card" data-glow><h3>Guide and FAQ</h3><p>Use the site guide and plain language FAQ to understand the whole stack quickly.</p><a class="card-link ping-target" href="explore.html">Open site guide</a></article>
-          </div>
-        </div>
-      </section>
-      <section class="section">
-        <div class="container">
-          <div class="status-banner">
-            <div>
-              <small>Current status</small>
-              <h3>Prototype phase with governed Lumina runtime spine</h3>
-              <p class="section-copy">The website now reflects the current repo trajectory: public interface direction on top, Lumina substrate beneath, V2 active, Ψ Class staged, and a growing runtime scaffold for session continuity, boundary enforcement, verified history, and staged proof.</p>
-            </div>
-            <a class="button primary ping-target" href="updates.html">Read current updates</a>
-          </div>
-        </div>
-      </section>
+      <section class="section"><div class="container status-banner"><div><small>Live surface</small><h3>Lumina now has a public dashboard surface.</h3><p class="section-copy">Open the dashboard to see system mood, continuity weather, harmonic stance, risk, trend analysis, history, graph motion, and optional harmonic audio. The surface is expressive, but it remains non-authoritative.</p></div><a class="button primary ping-target" href="lumina-dashboard.html">Open dashboard</a></div></section>
+      <section class="section"><div class="container status-banner"><div><small>Breakwater status</small><h3>Ship of Ethereon Ψ Class is staged, not yet active runtime.</h3><p class="section-copy">The current repo truth is deliberate: V2 remains the active Lumina bootstrap; Ψ Class/r2 is staged as a cleaner candidate vessel. The next proof is isolated validation before active wiring or promotion.</p></div><a class="button primary ping-target" href="updates.html">Open updates</a></div></section>
+      <section class="section"><div class="container"><div class="section-header"><div><h2>What EthereonLabs is actually doing</h2><p class="section-copy">We are not trying to rebuild every piece of software from scratch. We are building the continuity layer around software and the governed substrate beneath it: the part that restores context, organizes tools around real behavior, and keeps authority boundaries legible as the system grows.</p></div></div><div class="grid-3"><article class="card" data-glow><h3>Adaptive workspaces</h3><p>Project spaces that bring back the right layout, notes, references, and tools when you return.</p></article><article class="card" data-glow><h3>Embedded guidance</h3><p>Assistance woven into the interface itself rather than trapped in a separate chatbot window.</p></article><article class="card" data-glow><h3>Dashboard surface</h3><p>Lumina now has a public surface for mood, weather, graph, trend, history, harmonic animation, and optional audio.</p><a class="card-link ping-target" href="lumina-dashboard.html">Open dashboard</a></article><article class="card" data-glow><h3>Runtime spine</h3><p>Session state, checkpoints, context bundles, mode transitions, and capability exposure now have a concrete orchestration path.</p></article><article class="card" data-glow><h3>Input integrity</h3><p>Likely typos and voice-transcription ambiguity are assessed before meaning is allowed to become load-bearing action.</p></article><article class="card" data-glow><h3>Governance and canon rails</h3><p>Runtime events can be logged through a hash-chained governance rail, while lawful promotion can write append-only canon lineage.</p></article></div></div></section>
+      <section class="section"><div class="container"><div class="section-header"><div><h2>Explore the direction</h2><p class="section-copy">Use the path that matches what you want to understand first, from visible artifacts to deeper structural layers.</p></div></div><div class="grid-3"><article class="card" data-glow><h3>Lumina Dashboard</h3><p>The live public system surface for mood, weather, graph, trend, history, animation, and optional audio.</p><a class="card-link ping-target" href="lumina-dashboard.html">Open dashboard</a></article><article class="card" data-glow><h3>Lumina</h3><p>The governed substrate beneath the interface work, now backed by runtime spine and Ψ Class staging.</p><a class="card-link ping-target" href="lumina.html">Open Lumina</a></article><article class="card" data-glow><h3>Continuity</h3><p>The practical core explaining why restoring context matters so much.</p><a class="card-link ping-target" href="continuity.html">Read continuity</a></article><article class="card" data-glow><h3>Roadmap</h3><p>The staged path from public direction to believable prototype, Breakwater validation, and eventual richer orchestration.</p><a class="card-link ping-target" href="roadmap.html">Open roadmap</a></article><article class="card" data-glow><h3>Principles</h3><p>The design spine that keeps the project grounded and coherent.</p><a class="card-link ping-target" href="principles.html">Open principles</a></article><article class="card" data-glow><h3>Guide and FAQ</h3><p>Use the site guide and plain language FAQ to understand the whole stack quickly.</p><a class="card-link ping-target" href="explore.html">Open site guide</a></article></div></div></section>
+      <section class="section"><div class="container"><div class="status-banner"><div><small>Current status</small><h3>Prototype phase with governed Lumina runtime spine</h3><p class="section-copy">The website now reflects the current repo trajectory: public interface direction on top, Lumina substrate beneath, V2 active, Ψ Class staged, and a growing runtime scaffold for session continuity, boundary enforcement, verified history, and staged proof.</p></div><a class="button primary ping-target" href="updates.html">Read current updates</a></div></div></section>
     </main>
-    <footer class="footer">
-      <div class="container footer-row">
-        <div>EthereonLabs - Adaptive digital environments for how people actually work.</div>
-        <div><span data-year></span></div>
-      </div>
-    </footer>
+    <footer class="footer"><div class="container footer-row"><div>EthereonLabs - Adaptive digital environments for how people actually work.</div><div><span data-year></span></div></div></footer>
   </div>
   <script src="assets/js/site.js"></script>
 </body>


### PR DESCRIPTION
Adds Lumina dashboard as primary entry point on homepage.

- promotes dashboard to hero primary action
- adds live surface section
- integrates dashboard into feature grid
- updates messaging to reflect interactive system
- preserves site structure and authority boundaries

Makes Lumina immediately experiential on arrival.