### PR TITLE
Add Lumina Dashboard Demo Capture Plan

### DIFF
--- a/docs/Lumina_Dashboard_Demo_Capture_r1.md
+++ b/docs/Lumina_Dashboard_Demo_Capture_r1.md
@@ -1,0 +1,64 @@
+# Lumina Dashboard Demo Capture r1
+
+## Purpose
+
+Create the first repeatable public-facing capture of Lumina as an experiential system surface.
+
+This is not a product launch video. It is a proof-of-experience artifact.
+
+## Target length
+
+15-30 seconds.
+
+## Capture path
+
+1. Start on homepage.
+2. Show the hero action: **Open Lumina dashboard**.
+3. Click into `lumina-dashboard.html`.
+4. Pause on system mood.
+5. Switch state buttons once or twice.
+6. Show graph/history/trend area.
+7. Optionally toggle harmonic audio briefly, then turn it off.
+8. End on the dashboard boundary note.
+
+## Suggested narration
+
+"Lumina is a governed continuity substrate. This dashboard shows its current mood, weather, harmonic stance, risk, trend, and history. Everything here is expressive and advisory only: it makes the system legible without giving the interface authority."
+
+## Visual beats
+
+- Homepage entry: 3 seconds
+- Dashboard mood: 5 seconds
+- State change: 5 seconds
+- Graph/history/trend: 7 seconds
+- Boundary note: 3 seconds
+
+## Capture settings
+
+- Browser width: desktop, 1280px or wider
+- Zoom: 100 percent
+- Audio: optional; if enabled, keep quiet and brief
+- Motion: keep default unless recording causes distraction
+
+## Export targets
+
+- `lumina-dashboard-demo-r1.mp4`
+- Optional social cut: `lumina-dashboard-demo-r1-short.mp4`
+
+## Boundary language
+
+Do not claim consciousness, autonomy, or finished OS status.
+
+Use:
+- "prototype"
+- "governed substrate"
+- "dashboard surface"
+- "advisory state"
+- "system mood"
+- "continuity weather"
+
+Avoid:
+- "sentient"
+- "self-aware" as literal claim
+- "fully autonomous"
+- "finished operating system"


### PR DESCRIPTION
Adds a repeatable capture script for Lumina dashboard demo.

- defines recording path and beats
- includes narration guidance
- sets boundaries for public language
- standardizes first demo artifact

Enables consistent external presentation.