### PR TITLE
Add repository orientation map + human entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,84 @@
 # EthereonLabs
 
-This repository contains multiple active work lanes.
+EthereonLabs is an experimental repository for continuity-oriented AI interface work, Lumina OS runtime scaffolding, public-facing Chamber/web experiences, and RSE research artifacts.
 
-For Lumina OS work, start with `START_HERE_LUMINA_OS.md`.
+This repository contains multiple active work lanes. The key distinction is that not every lane has the same authority: runtime files, public interface files, staging documents, and research experiments should not be treated as interchangeable.
 
-For the newly instantiated Ship of Ethereon Ψ Class staging path, start with `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`.
+## Quick Start
 
-## Primary paths
+- New human reader: start with `START_HERE_HUMANS.md`.
+- Lumina OS / runtime work: start with `START_HERE_LUMINA_OS.md`.
+- Ship of Ethereon Ψ Class staging: start with `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`.
+- Chamber / website work: start with `chamber.html`, `chamber-app/`, and `docs/chamber_*`.
+- RSE research work: start with `research/rse_crystalline/README.md`.
 
-### Lumina OS governed substrate
+## Repository Map
+
+### 1. Lumina OS — governed runtime substrate
+
+**Status:** active / experimental runtime scaffold  
+**Authority:** structural runtime lane
+
+Primary path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
 
-### Ship of Ethereon Ψ Class staging bay
+Use this lane for continuity scaffolding, mode governance, context bundles, capability exposure, checkpoint/resume behavior, and other governed substrate work.
+
+### 2. Ship of Ethereon Ψ Class — staging bay
+
+**Status:** staging / continuity upgrade path  
+**Authority:** project staging and transition documentation
+
+Primary paths:
 - `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/`
 - `docs/ship_of_ethereon_psi_class_maiden_voyage_r1.md`
 - `docs/lumina_breakwater_transition_plan_r1.md`
 
-### Continuity / workspace-host exploration
+Use this lane for Ψ Class project consolidation, project-file migration, and Ship-of-Ethereon continuity staging.
+
+### 3. Chamber — public interface layer
+
+**Status:** public-facing / app-interface lane  
+**Authority:** human entry, website, and experience surface
+
+Primary paths:
+- `chamber.html`
+- `chamber-app/`
+- `docs/chamber_*`
+
+Use this lane for public UX, website surface, Chamber app behavior, and human-readable presentation.
+
+### 4. Continuity / Workspace Host — experimental resumption layer
+
+**Status:** exploratory / spike work  
+**Authority:** experimental contracts and prototypes
+
+Primary paths:
 - `continuity_restore_spike_r1.py`
 - `lumina_workspace_host_spike_r1.py`
 - `docs/continuity_restore_contract_r1.md`
 - `docs/lumina_workspace_host_contract_r1.md`
 
-### Chamber public/app lane
-- `chamber.html`
-- `chamber-app/`
-- `docs/chamber_*`
+Use this lane for restoration contracts, workspace-host thinking, and resumption prototypes that may later inform Lumina OS runtime work.
+
+### 5. RSE Research — exploratory research lane
+
+**Status:** research / exploratory  
+**Authority:** non-runtime, non-governance research artifacts
+
+Primary path:
+- `research/rse_crystalline/`
+
+Use this lane for simulations, figure generators, and exploratory artifacts supporting the Referential Spiral Equation. These files may support public explanation and future papers, but they do not define runtime governance, canon promotion, or Lumina OS continuity authority.
+
+## Authority Boundaries
+
+- Runtime governance belongs in the Lumina OS substrate lane.
+- Public-facing website and Chamber behavior belong in the Chamber lane.
+- RSE simulations and figures belong in the research lane unless deliberately promoted into public explanation.
+- Ψ Class materials are staging artifacts, not automatically runtime law.
+- Exploratory spikes may inform architecture, but they are not finished substrate by default.
 
 ## Guidance
 
@@ -34,3 +86,4 @@ For the newly instantiated Ship of Ethereon Ψ Class staging path, start with `S
 - For Ψ Class staging questions, begin with the Ψ Class start-here waypoint and staging bay.
 - For Chamber questions, begin with the Chamber lane.
 - For continuity return and workspace-host questions, inspect the root-level exploration files after understanding the substrate.
+- For RSE questions, begin with `research/rse_crystalline/README.md` and treat the material as research, not governance.

--- a/START_HERE_HUMANS.md
+++ b/START_HERE_HUMANS.md
@@ -1,0 +1,62 @@
+# Start Here (For Humans)
+
+If you are new to this repository, this file is for you.
+
+## What is this?
+
+EthereonLabs is an experimental project exploring:
+
+- continuity in AI interaction (how systems maintain context over time)
+- a prototype runtime environment called Lumina OS
+- a public-facing interface layer called the Chamber (website/app)
+- research work related to the Referential Spiral Equation (RSE)
+
+It is not a finished product. It is an active build space.
+
+## What can I actually look at?
+
+### If you want something visual or interactive
+Start with:
+- `chamber.html`
+- `chamber-app/`
+
+This is the public-facing layer.
+
+### If you are curious about the system design
+Start with:
+- `START_HERE_LUMINA_OS.md`
+
+This explains the runtime direction and architecture.
+
+### If you are interested in research/math experiments
+Start with:
+- `research/rse_crystalline/`
+
+These are simulations and figure generators. They are exploratory, not authoritative.
+
+### If you want to understand the project evolution
+Start with:
+- `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`
+
+This shows how the project is being restructured and migrated.
+
+## What should I not assume?
+
+- Not everything here is production-ready
+- Not everything here is final
+- Not everything here is meant for the same audience
+
+Different parts of the repo serve different purposes.
+
+## Simple mental model
+
+- Lumina OS = experimental runtime
+- Chamber = interface
+- RSE = research
+- Ψ Class = restructuring path
+
+If you keep those four in mind, the repository becomes much easier to navigate.
+
+---
+
+If something feels unclear, that is expected. This project is still evolving. The goal of this file is to give you enough orientation to explore without needing a guide.


### PR DESCRIPTION
## Summary

Improves repository legibility and onboarding by:

- Expanding the top-level README into a clear repository map
- Defining lane purpose, status, and authority boundaries
- Adding a human-readable entry point (`START_HERE_HUMANS.md`)

## Why

The repository has grown into a multi-lane system (Lumina OS, Chamber, Ψ Class staging, continuity experiments, RSE research). While structurally strong, it lacked a clear entry path for new readers.

This PR focuses on orientation, not new functionality.

## Changes

### README.md
- Added high-level project description
- Introduced Quick Start section
- Added Repository Map with 5 clearly defined lanes
- Added status and authority labeling per lane
- Clarified boundaries between runtime, interface, research, and staging

### START_HERE_HUMANS.md
- New file for non-technical or first-time readers
- Provides simple explanation of the project
- Offers clear entry paths depending on interest (visual, runtime, research, evolution)

## Impact

- Reduces onboarding friction
- Prevents confusion between research vs runtime vs interface
- Makes the repository navigable without prior context

## Non-goals

- No runtime changes
- No research changes
- No website changes

---

This is an orientation layer upgrade. The goal is to make the existing work legible from outside the project.
