### PR TITLE
Restore mobile sound toggle visibility

### DIFF
--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -87,7 +87,17 @@ letter-spacing: 0.12em !important;
 font-size: 0.68rem !important;
 }
 .header-actions {
-display: none !important;
+display: flex !important;
+justify-content: flex-end;
+width: 100%;
+gap: 0.4rem;
+}
+.header-actions .icon-button {
+display: inline-flex !important;
+min-width: 34px;
+min-height: 34px;
+font-size: 0.9rem;
+opacity: 0.85;
 }
 .nav-links {
 display: flex !important;


### PR DESCRIPTION
## Summary

Restores the sound toggle button on mobile without disrupting the improved header layout or sliding navigation.

## Changes

- Replaces `.header-actions { display: none }` with a compact flex layout on mobile
- Keeps sound toggle visible in the top right
- Maintains sliding navigation strip and clean brand row

## Why

Previous mobile header refinement unintentionally removed access to sound controls, leaving audio disabled with no way to re-enable.

## Scope

- Website presentation only
- `assets/js/site.js` only
- No runtime or governance changes