### PR TITLE
Add Lisp interop future note and README pointer

### DIFF
--- a/lumina/lisp/README.md
+++ b/lumina/lisp/README.md
@@ -31,7 +31,20 @@ lumina/lisp/
   inspections/
   governance/
   flows/
+  notes/
 ```
+
+## Important Note (Interop + Future Direction)
+
+See:
+
+```
+lumina/lisp/notes/lisp_interop_future_note_001.md
+```
+
+This note captures why Lisp is being used as a symbolic layer first, and outlines potential future integration paths (Hy, Clojure, etc.).
+
+Do not introduce executable Lisp without revisiting that document.
 
 ## Naming pattern
 

--- a/lumina/lisp/notes/lisp_interop_future_note_001.md
+++ b/lumina/lisp/notes/lisp_interop_future_note_001.md
@@ -1,0 +1,98 @@
+# Lisp Interop Future Note 001
+
+## Why this note exists
+
+This note preserves a design conversation about major Lisp dialects and their relationship to other host ecosystems.
+
+The purpose is not to choose an executable Lisp runtime now. The purpose is to keep future-us from forgetting the useful architectural lesson:
+
+> Lisp does not need to live alone. Its modern strength is often as a symbolic shape of thought embedded beside another practical runtime.
+
+## Dialect / host ecosystem observations
+
+### Clojure + JVM
+
+Clojure is the strongest serious systems example. It gains power by riding the JVM and Java library ecosystem.
+
+Relevance to Lumina:
+- useful systems-scale reference
+- good model for shared-runtime interoperability
+- probably not the immediate path
+
+### Hy + Python
+
+Hy is the most tempting future technical fit because Lumina already leans Python. It compiles Lisp-style syntax into Python ASTs and can use Python libraries.
+
+Relevance to Lumina:
+- strongest possible future bridge to Python runtime work
+- should not be adopted too early
+- risk: blurs the boundary between symbolic notation and executable behavior
+
+### Emacs Lisp + C
+
+Emacs Lisp matters less as a direct technical choice and more as a philosophical model. Emacs demonstrates a workspace that can be reshaped from within by a Lisp-like extension language.
+
+Relevance to Lumina:
+- best conceptual model for Lumina Studio / Chamber-as-workspace
+- supports the idea of an environment extended by symbolic structures
+- useful precedent for interactive, inspectable, user-shaped systems
+
+### Fennel + Lua
+
+Fennel is lightweight and compiles to Lua. It is a good model for embedding expressive syntax inside lightweight host environments.
+
+Relevance to Lumina:
+- useful model for future lightweight scripting
+- not an immediate priority
+
+### Common Lisp + C/C++
+
+Common Lisp remains powerful for standalone systems and FFI-based high-performance integration.
+
+Relevance to Lumina:
+- valuable precedent
+- probably not the right next step
+- stronger as a long-horizon reference than as current implementation choice
+
+## Ethereon / Lumina interpretation
+
+Best conceptual model: Emacs Lisp
+Best practical future fit: Hy + Python
+Best systems-scale model: Clojure + JVM
+Best lightweight embed model: Fennel + Lua
+Best power tool, not now: Common Lisp
+
+## Current decision
+
+Do not adopt executable Lisp yet.
+
+Keep the current `.lx` layer:
+- non-executable
+- human-readable
+- symbolic
+- continuity-oriented
+- explicitly non-authoritative
+
+## Possible future path
+
+```text
+Phase 1: .lx notation            current
+Phase 2: .lx read-only parser
+Phase 3: .lx to JSON summaries
+Phase 4: .lx dashboard display
+Phase 5: limited safe commands
+```
+
+Each phase must preserve the boundary:
+
+> Symbolic notation may clarify meaning, but it must not silently become runtime law.
+
+## Trigger for revisiting
+
+Revisit this note when one of these becomes true:
+
+- Lisp notes are being used regularly enough to need search, parsing, or indexing
+- dashboard display of symbolic session state becomes useful
+- Lumina Studio needs a small extension language
+- Python runtime work would benefit from a Lisp-shaped authoring layer
+- repeated `.lx` patterns become stable enough to formalize


### PR DESCRIPTION
## Summary

Adds a forward-looking note on Lisp dialect interop and future integration strategy.

## Includes

- lumina/lisp/notes/lisp_interop_future_note_001.md
- README update pointing to the note

## Purpose

- Preserve architectural reasoning about Lisp as symbolic layer vs executable runtime
- Prevent premature adoption of executable Lisp (Hy, etc.)
- Provide future integration roadmap

## Scope

- Documentation only
- No runtime or site changes