### PR TITLE
Add language ecology notes

### DIFF
--- a/docs/language_ecology_notes_001.md
+++ b/docs/language_ecology_notes_001.md
@@ -1,0 +1,187 @@
+# Language Ecology Notes 001
+
+## Purpose
+
+This note preserves a design reflection on powerful but niche languages that may eventually matter to EthereonLabs, Lumina OS, or related runtime/interface work.
+
+The goal is not to add languages casually. The goal is to keep future substrate choices disciplined.
+
+> Lumina should not become a random pile of languages. Each language must earn a clear role.
+
+## Current core stack
+
+The present stack remains:
+
+```text
+Python      → runtime spine, orchestration, sea trials
+JavaScript  → website and interface behavior
+JSON        → registries, payloads, state, governance data
+Markdown    → human-readable documentation
+.lx Lisp    → symbolic continuity notation
+```
+
+This stack should remain primary until a new language solves a sharp problem that the current stack cannot solve cleanly.
+
+## Practical future candidates
+
+### Elixir
+
+Best fit:
+- concurrent live service layer
+- always-on backend orchestration
+- multi-user session handling
+- message passing
+- presence/state channels
+
+Interpretation:
+Elixir may become relevant if Lumina grows into a live, distributed, multi-session environment. It is less an OS substrate and more a living backend nervous system.
+
+Do not introduce Elixir until concurrency and live-session orchestration become a real bottleneck.
+
+### Zig
+
+Best fit:
+- native helpers
+- portable system utilities
+- low-level device or OS-adjacent work
+- performance-sensitive tools
+- cross-compilation targets
+
+Interpretation:
+Zig is the most relevant low-level future candidate. It may matter if Lumina needs small native components that must be safer and cleaner than C.
+
+Do not introduce Zig until Python or shell tooling clearly stops being enough for substrate utilities.
+
+### R
+
+Best fit:
+- statistical analysis
+- continuity metrics
+- resonance trend analysis
+- experimental visualization
+- research graphics
+
+Interpretation:
+R is not a core runtime language for Lumina. It may become useful for analysis and visualization if the project accumulates enough real metrics to justify it.
+
+Do not introduce R for general app logic.
+
+### Nim
+
+Best fit:
+- readable compiled utilities
+- Python-like syntax with compiled performance
+
+Interpretation:
+Nim is interesting but does not currently solve a sharp enough problem. It sits between Python convenience and Zig-native seriousness.
+
+Do not prioritize Nim unless a specific tool would benefit from it more than either Python or Zig.
+
+## Architecture / cognition candidates
+
+### Prolog
+
+Best fit:
+- facts and rules
+- governance inference
+- constraint modeling
+- mode legality experiments
+- explainable decision logic
+
+Interpretation:
+Prolog is conceptually important. It maps strongly to governance questions such as: what follows from these rules, facts, and constraints?
+
+Possible future role:
+- experimental governance model
+- rule simulation
+- explainability layer
+
+Do not let Prolog replace existing governance code unless the rule system has proven itself in isolated experiments.
+
+### Haskell
+
+Best fit:
+- purity discipline
+- side-effect control
+- type-driven design thinking
+- boundary modeling
+
+Interpretation:
+Haskell is valuable as an architectural lens more than a near-term dependency. It reinforces the core Ethereon rule that expressive/symbolic layers must not secretly mutate structural law.
+
+Use Haskell ideas before using Haskell code.
+
+### Forth
+
+Best fit:
+- tiny command substrate
+- stack-based experimentation
+- embedded or minimal runtime ideas
+- vocabulary-building metaphors
+
+Interpretation:
+Forth is inspirational for minimal extensible systems. It may matter if Lumina ever explores embedded hardware, ultra-small interpreters, or command vocabularies.
+
+Probably conceptual, not near-term practical.
+
+## Ranking for Ethereon / Lumina relevance
+
+### Near-future practical relevance
+
+```text
+1. Elixir — concurrent backend / live service layer
+2. Zig    — native substrate utilities
+3. R      — analytics and visualization only
+```
+
+### Architecture / cognition relevance
+
+```text
+1. Prolog  — governance rules and inference
+2. Haskell — purity and boundary discipline
+3. Forth   — tiny extensible command substrate
+```
+
+### Lower priority
+
+```text
+Nim — interesting, but not currently solving a sharp need
+```
+
+## Adoption rule
+
+A new language may be considered only when all three are true:
+
+1. A real project need exists.
+2. The current stack solves it poorly.
+3. The new language has a bounded role and authority boundary.
+
+If a language cannot be assigned a clear role, do not add it.
+
+## Boundary rule
+
+No language may become load-bearing by accident.
+
+Any new language must declare:
+
+- what it owns
+- what it may read
+- what it may emit
+- what it must not govern
+- whether it is runtime, tooling, research, or symbolic notation
+
+## Future trigger points
+
+Revisit this note when:
+
+- Lumina needs live multi-user backend orchestration
+- runtime utilities require native performance or portability
+- continuity/resonance metrics become large enough for serious analytics
+- governance rules become complex enough to test with inference systems
+- symbolic notation begins turning into controlled tooling
+
+## Current decision
+
+Do not add any of these languages yet.
+
+Preserve the map. Keep the stack disciplined.


### PR DESCRIPTION
## Summary

Adds a forward-looking document capturing language ecosystem strategy and future candidates.

## Purpose

- Prevent random language sprawl
- Assign clear roles to potential future languages
- Preserve architectural reasoning

## Includes

- docs/language_ecology_notes_001.md

## Scope

- Documentation only
- No runtime or site changes