### PR TITLE
Add quantum language ecology notes

### DIFF
--- a/docs/quantum_language_ecology_notes_001.md
+++ b/docs/quantum_language_ecology_notes_001.md
@@ -1,0 +1,204 @@
+# Quantum Language Ecology Notes 001
+
+## Purpose
+
+This note preserves a design reflection on quantum computing languages and frameworks as they may relate to EthereonLabs, Lumina OS, and future research tooling.
+
+The goal is not to claim that Lumina is quantum or that quantum tooling validates Ethereon concepts.
+
+The goal is to preserve a careful map of where quantum language ecosystems may become useful as:
+
+- research tools
+- analogy discipline
+- simulation scaffolds
+- conceptual design references
+
+## Boundary statement
+
+Quantum language ecosystems are relevant as research tooling and metaphor discipline, not as proof that Lumina is quantum.
+
+Quantum terminology may be used when clearly labeled as quantum-inspired, quantum-adjacent, or metaphorical.
+
+Quantum tools must not define Lumina runtime authority, governance law, canon state, continuity proof, or identity claims.
+
+## Categories
+
+### Python-based frameworks
+
+These are the most practical near-term tools because they fit the current Python-centered research and runtime environment.
+
+#### Qiskit
+
+Best fit:
+- general quantum research sandbox
+- circuit experiments
+- educational demos
+- optimization / chemistry / finance examples
+
+Interpretation:
+Qiskit is the most likely first quantum framework to inspect if the project needs actual quantum-circuit experiments.
+
+Do not introduce Qiskit unless there is a bounded research question.
+
+#### Cirq
+
+Best fit:
+- lower-level circuit design
+- NISQ-era device thinking
+- gate scheduling
+- hardware-aware circuit modeling
+
+Interpretation:
+Cirq is useful as a reference for precise circuit control and near-term hardware realism.
+
+It is less public-facing than Qiskit and should remain research-oriented.
+
+#### PennyLane
+
+Best fit:
+- quantum machine learning
+- differentiable quantum circuits
+- hybrid classical/quantum ML experiments
+- PyTorch / TensorFlow-adjacent workflows
+
+Interpretation:
+PennyLane may become relevant if Lumina explores quantum-inspired learning experiments or differentiable circuit analogies.
+
+Do not confuse quantum ML tooling with proof of cognitive continuity.
+
+### Standalone high-level quantum languages
+
+These matter as design references more than immediate implementation targets.
+
+#### Q#
+
+Best fit:
+- structured quantum program design
+- large-scale quantum application thinking
+- explicit quantum/classical separation
+
+Interpretation:
+Q# is useful as an example of how quantum logic can be structured safely and intentionally.
+
+It is not a near-term Lumina dependency.
+
+#### Silq
+
+Best fit:
+- conceptual model for automatic uncomputation
+- safe cleanup of temporary quantum data
+- reducing residue from intermediate state
+
+Interpretation:
+Silq is conceptually important for Ethereon/Lumina.
+
+Its uncomputation principle maps strongly to a core boundary idea:
+
+> temporary computation should not contaminate durable state.
+
+Possible analogy:
+- clear temporary symbolic state
+- prevent expressive overlays from leaking into governance
+- avoid residue from exploratory scaffolds becoming load-bearing
+- ensure intermediate constructs are cleaned after use
+
+Silq is not needed as a tool right now, but its design principle is worth preserving.
+
+### Low-level quantum instruction languages
+
+These are useful as references for hardware-facing representation, not for current project adoption.
+
+#### OpenQASM
+
+Best fit:
+- low-level quantum circuit representation
+- hardware-targeted instruction descriptions
+- interoperability reference
+
+Interpretation:
+OpenQASM may be useful if EthereonLabs ever needs to represent actual circuits explicitly or document quantum experiments at the instruction level.
+
+#### Quil
+
+Best fit:
+- quantum/classical shared-memory reference
+- Rigetti-style instruction thinking
+- hybrid control models
+
+Interpretation:
+Quil is interesting because it highlights quantum/classical interaction as part of the program model.
+
+It may be conceptually useful when thinking about hybrid control loops, but it is not a near-term dependency.
+
+## Ethereon / Lumina interpretation
+
+```text
+Qiskit    → general quantum research sandbox
+Cirq      → low-level circuit/control thinking
+PennyLane → quantum ML / differentiable circuit experiments
+Q#        → structured quantum program design reference
+Silq      → safe cleanup / uncomputation design principle
+OpenQASM  → low-level circuit representation reference
+Quil      → quantum/classical shared-memory reference
+```
+
+## Current decision
+
+Do not add quantum frameworks or languages to the active stack.
+
+Preserve the map. Use quantum terminology carefully. Keep all quantum references clearly bounded.
+
+## Adoption rule
+
+Quantum tooling may be considered only when all of the following are true:
+
+1. There is a concrete research question.
+2. The experiment can be separated from runtime governance.
+3. The output is treated as research data, not continuity proof.
+4. The tool has a bounded role and can be removed without damaging core architecture.
+
+## Boundary rule
+
+Quantum tools may not own:
+
+- mode legality
+- canon promotion
+- checkpoint legality
+- session continuity authority
+- identity claims
+- governance records
+- runtime law
+
+Quantum tools may emit:
+
+- research artifacts
+- circuit descriptions
+- experiment outputs
+- educational demos
+- analogy notes
+
+## Future trigger points
+
+Revisit this note when:
+
+- the project needs a bounded quantum-circuit experiment
+- RSE research requires explicit circuit simulation or analogy testing
+- quantum-inspired language needs sharper technical grounding
+- quantum ML becomes relevant to a real experiment
+- Silq-style cleanup/uncomputation becomes useful as a design pattern for symbolic state hygiene
+
+## Current stack relationship
+
+This note extends the broader language ecology map without changing the core stack.
+
+Current practical stack remains:
+
+```text
+Python      → runtime spine, orchestration, sea trials
+JavaScript  → website and interface behavior
+JSON        → registries, payloads, state, governance data
+Markdown    → human-readable documentation
+.lx Lisp    → symbolic continuity notation
+```
+
+Quantum tooling remains outside the active stack until a specific research need justifies it.


### PR DESCRIPTION
## Summary

Adds a forward-looking document capturing quantum computing language ecosystems and their proper role in the project.

## Purpose

- Preserve architectural boundaries regarding quantum concepts
- Prevent misuse of quantum terminology as proof of continuity or intelligence
- Provide a disciplined future reference for research tooling

## Includes

- docs/quantum_language_ecology_notes_001.md

## Scope

- Documentation only
- No runtime or site changes