### PR TITLE
Add executable runtime entry path (START_HERE_RUNTIME_PATH)

### DIFF
--- a/START_HERE_RUNTIME_PATH.md
+++ b/START_HERE_RUNTIME_PATH.md
@@ -1,0 +1,96 @@
+# START HERE — Runtime Path (Executable Entry)
+
+This file exists to answer one question clearly:
+
+**How do I enter this repository and actually run something?**
+
+---
+
+## Step 1 — Go to the runtime substrate
+
+Navigate to:
+
+```
+LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/
+```
+
+This is where execution lives.
+
+---
+
+## Step 2 — Run the baseline runtime
+
+Primary entry file:
+
+```
+runtime_runner_r1_merged.py
+```
+
+Run it locally with:
+
+```
+python runtime_runner_r1_merged.py
+```
+
+---
+
+## Step 3 — Run a validation (sea trial)
+
+Example:
+
+```
+python sea_trials_set_one_r1_merged.py
+```
+
+This validates that the runtime spine, governance checks, and execution flow are functioning.
+
+---
+
+## Step 4 — Observe output
+
+You are looking for:
+
+- no crashes
+- structured output
+- evidence of governance checks
+- traceable execution steps
+
+If it runs cleanly, the substrate is alive.
+
+---
+
+## Step 5 — Understand what just happened
+
+Interpretation:
+
+- runtime_runner = execution path
+- sea_trials = validation layer
+- governance files = rule enforcement
+- psi42_transceiver = bounded signal/analysis layer
+
+---
+
+## Step 6 — Next moves
+
+From here you can:
+
+- modify runtime behavior
+- add new validation tests
+- connect Chamber → runtime (future)
+- extend orchestration layer
+
+---
+
+## What this file is NOT
+
+This is not philosophy.
+This is not symbolic.
+This is not staging.
+
+This is the **entry point for execution**.
+
+---
+
+## One-line summary
+
+> If you want to prove this system exists, run the runtime and watch it behave.


### PR DESCRIPTION
## Summary

Adds a clear, minimal, executable entry path for the repository.

## Why

The repo has strong orientation (Realm, districts, start-here docs), but lacked a simple:

enter → run → validate → interpret

flow.

This PR adds that missing bridge.

## What it adds

- START_HERE_RUNTIME_PATH.md

Provides:
- exact runtime path
- exact file to run
- validation step (sea trials)
- expected outputs
- interpretation guidance

## Design principle

This file intentionally avoids symbolic, poetic, or architectural expansion.

It is purely operational.

## Effect

- Lowers barrier to entry
- Makes Lumina OS provable through execution
- Converts orientation into action

## Relation to existing structure

- Complements START_HERE_HUMANS.md (orientation)
- Complements START_HERE_LUMINA_OS.md (architecture)
- Anchors both in actual runtime behavior

## Merge impact

Safe. Documentation only. No runtime changes.
