### PR TITLE
Add GitHub Actions runtime sea trial execution

### DIFF
--- a/.github/workflows/lumina-runtime-sea-trial.yml
+++ b/.github/workflows/lumina-runtime-sea-trial.yml
@@ -1,0 +1,45 @@
+name: Lumina Runtime Sea Trial
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'LuminaOS/bootstrap/Ship_of_Ethereon_V2/**'
+      - '.github/workflows/lumina-runtime-sea-trial.yml'
+      - 'START_HERE_RUNTIME_PATH.md'
+  push:
+    branches:
+      - main
+    paths:
+      - 'LuminaOS/bootstrap/Ship_of_Ethereon_V2/**'
+      - '.github/workflows/lumina-runtime-sea-trial.yml'
+      - 'START_HERE_RUNTIME_PATH.md'
+
+jobs:
+  runtime-sea-trial:
+    name: Run Lumina runtime and sea trial
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Show runtime directory
+        run: |
+          pwd
+          ls -la
+
+      - name: Run baseline runtime
+        run: python runtime_runner_r1_merged.py
+
+      - name: Run sea trial validation
+        run: python sea_trials_set_one_r1_merged.py


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that executes the Lumina runtime and sea trials automatically.

## Why

Execution should not rely solely on local environment.

This turns "execute" into a visible, repeatable, verifiable system behavior.

## What it does

- Runs `runtime_runner_r1_merged.py`
- Runs `sea_trials_set_one_r1_merged.py`
- Executes on push, PR, or manual trigger

## Effect

- Creates a living execution signal in GitHub
- Makes failures visible immediately
- Removes ambiguity about runtime viability

## Design principle

Execution > description

## Merge impact

Safe. Adds CI workflow only.
