### PR TITLE
Trigger runtime sea trial (first execution)

### DIFF
--- a/START_HERE_RUNTIME_PATH.md
+++ b/START_HERE_RUNTIME_PATH.md
@@ -81,6 +81,14 @@ From here you can:
 
 ---
 
+## GitHub Actions verification
+
+This runtime path is also checked by the `Lumina Runtime Sea Trial` workflow.
+
+The workflow runs the baseline runtime and sea-trial validation so GitHub can report whether the executable path still holds.
+
+---
+
 ## What this file is NOT
 
 This is not philosophy.


### PR DESCRIPTION
## Purpose

Trigger the Lumina Runtime Sea Trial workflow to produce the first observable execution result.

## What changed

- Minor update to START_HERE_RUNTIME_PATH.md

## Why

The workflow requires a PR or push affecting watched paths to execute.

This PR exists solely to initiate the first runtime verification.

## Expected result

- GitHub Actions will run the runtime and sea trials
- We will observe pass/fail and logs

## Note

No functional changes. This is an execution trigger.
