### PR TITLE
Add Lumina runtime validation record R1

### DIFF
--- a/docs/lumina_runtime_validation_record_r1.md
+++ b/docs/lumina_runtime_validation_record_r1.md
@@ -1,0 +1,53 @@
+# Lumina Runtime Validation Record R1
+
+## Event
+
+First successful GitHub-native execution of the Lumina runtime and sea trial workflow.
+
+## Trigger
+
+Pull Request #121 — runtime path update used to initiate workflow execution.
+
+## Workflow
+
+Lumina Runtime Sea Trial
+
+## Result
+
+Status: completed
+Conclusion: success
+
+## Verified Steps
+
+- Repository checkout
+- Python environment setup (3.11)
+- Runtime directory resolution
+- Baseline runtime execution (`runtime_runner_r1_merged.py`)
+- Sea trial validation (`sea_trials_set_one_r1_merged.py`)
+
+All steps executed without failure.
+
+## Significance
+
+This is the first external, reproducible verification that:
+
+- the Lumina runtime executes in a clean environment
+- sea trial validation completes successfully
+- the repository contains a self-verifying execution path
+
+## Boundary Note
+
+This record confirms execution viability.
+
+It does not claim completeness, stability under all conditions, or production readiness.
+
+## Next Phase
+
+- Capture runtime output as artifacts
+- Expand sea trials
+- Introduce failure-path tests
+- Connect Chamber to runtime execution
+
+## Summary
+
+Lumina OS has transitioned from conceptual architecture to externally validated runtime substrate.


### PR DESCRIPTION
## Summary

Adds a formal validation record documenting the first successful GitHub-native execution of the Lumina runtime.

## Why

Milestones should be preserved as structured artifacts, not just observed transiently.

## What it adds

- docs/lumina_runtime_validation_record_r1.md

## Effect

- Creates an auditable execution record
- Anchors the transition from architecture to runtime validation

## Principle

If it matters, record it.
