### PR TITLE
Fix: Correct runtime sea trial artifact path

### DIFF
--- a/.github/workflows/lumina-runtime-sea-trial.yml
+++ b/.github/workflows/lumina-runtime-sea-trial.yml
@@ -34,22 +34,22 @@ jobs:
           python-version: '3.11'
 
       - name: Prepare evidence directory
-        run: mkdir -p ../../../runtime-sea-trial-evidence
+        run: mkdir -p "$GITHUB_WORKSPACE/runtime-sea-trial-evidence"
 
       - name: Show runtime directory
         run: |
-          pwd | tee ../../../runtime-sea-trial-evidence/runtime-directory.txt
-          ls -la | tee ../../../runtime-sea-trial-evidence/runtime-directory-listing.txt
+          pwd | tee "$GITHUB_WORKSPACE/runtime-sea-trial-evidence/runtime-directory.txt"
+          ls -la | tee "$GITHUB_WORKSPACE/runtime-sea-trial-evidence/runtime-directory-listing.txt"
 
       - name: Run baseline runtime
         run: |
           set -o pipefail
-          python runtime_runner_r1_merged.py 2>&1 | tee ../../../runtime-sea-trial-evidence/baseline-runtime-output.txt
+          python runtime_runner_r1_merged.py 2>&1 | tee "$GITHUB_WORKSPACE/runtime-sea-trial-evidence/baseline-runtime-output.txt"
 
       - name: Run sea trial validation
         run: |
           set -o pipefail
-          python sea_trials_set_one_r1_merged.py 2>&1 | tee ../../../runtime-sea-trial-evidence/sea-trial-output.txt
+          python sea_trials_set_one_r1_merged.py 2>&1 | tee "$GITHUB_WORKSPACE/runtime-sea-trial-evidence/sea-trial-output.txt"
 
       - name: Write validation summary
         if: always()
@@ -71,8 +71,8 @@ jobs:
             echo "- runtime-directory-listing.txt"
             echo "- baseline-runtime-output.txt"
             echo "- sea-trial-output.txt"
-          } | tee ../../../runtime-sea-trial-evidence/validation-summary.md
-          cat ../../../runtime-sea-trial-evidence/validation-summary.md >> "$GITHUB_STEP_SUMMARY"
+          } | tee "$GITHUB_WORKSPACE/runtime-sea-trial-evidence/validation-summary.md"
+          cat "$GITHUB_WORKSPACE/runtime-sea-trial-evidence/validation-summary.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload runtime sea trial evidence
         if: always()


### PR DESCRIPTION
This PR fixes the artifact upload failure in the Lumina Runtime Sea Trial workflow.

### Issue
Evidence was written to a relative path (`../../../runtime-sea-trial-evidence`) but uploaded from `runtime-sea-trial-evidence/`, causing the upload step to fail.

### Fix
- Standardized all evidence writes to `$GITHUB_WORKSPACE/runtime-sea-trial-evidence`
- Ensures artifact uploader can consistently find and upload files

### Result
- Runtime remains unchanged (already passing)
- Sea trials remain unchanged (already passing)
- Artifact upload will now succeed, preserving evidence as intended

This completes the validation loop: execution → validation → preservation.