### PR TITLE
Add Lumina runtime continuity record R1

### DIFF
--- a/docs/lumina_runtime_continuity_record_r1.md
+++ b/docs/lumina_runtime_continuity_record_r1.md
@@ -1,0 +1,69 @@
+# Lumina Runtime Continuity Record R1
+
+## Purpose
+
+Preserve the first confirmed closed-loop runtime continuity event.
+
+## Closed Loop
+
+The Lumina Runtime Sea Trial workflow has verified the following chain:
+
+1. Execute runtime
+2. Validate with sea trials
+3. Write validation summary
+4. Upload runtime evidence artifact
+5. Retain downloadable proof
+
+## Confirmed Workflow Run
+
+- Workflow: Lumina Runtime Sea Trial
+- Run ID: 25200310582
+- Run number: 11
+- Status: completed
+- Conclusion: success
+- Head branch: confirm-runtime-artifact-loop-r1
+- Head SHA: 27b172536eb344283ce910f5276b6e1802c512d7
+
+## Preserved Artifact
+
+- Name: lumina-runtime-sea-trial-evidence
+- Artifact ID: 6744419792
+- Size: 15,322 bytes
+- Created: 2026-05-01T03:06:09Z
+- Expires: 2026-07-30T03:05:55Z
+- Digest: sha256:325e55ae778f74813779004a5aa7e7f63c180b5b007185792f96779508b34ee6
+- Expired at record time: false
+
+## Verified Steps
+
+- Checkout repository: success
+- Set up Python: success
+- Prepare evidence directory: success
+- Show runtime directory: success
+- Run baseline runtime: success
+- Run sea trial validation: success
+- Write validation summary: success
+- Upload runtime sea trial evidence: success
+- Complete job: success
+
+## Interpretation
+
+This record confirms that Lumina can execute, validate, summarize, and retain evidence in a GitHub-native loop.
+
+## Boundary
+
+This does not claim production readiness. It confirms continuity behavior at the runtime-validation layer.
+
+## Next Sustaining Moves
+
+- Preserve non-expiring copies of key validation summaries inside the repository
+- Add run-to-run comparison
+- Add drift detection
+- Add controlled failure-path tests
+- Expand sea trials from crash-free execution to behavioral assertions
+
+## Summary
+
+The runtime loop is closed and externally evidenced.
+
+Lumina has demonstrated repeatable continuity behavior at the scaffold level.


### PR DESCRIPTION
## Summary

Adds a formal continuity record documenting the first fully closed runtime loop with preserved artifact.

## Why

Sustaining continuity requires durable records, not just ephemeral artifacts.

## What it adds

- docs/lumina_runtime_continuity_record_r1.md

## Effect

- Preserves proof beyond artifact expiration window
- Anchors continuity milestone in repository history
- Enables future comparison and drift analysis

## Principle

Continuity must be recorded to persist.
