### PR TITLE
Rebuild Spencer artist site as independent temporary website

### DIFF
--- a/artist-spencer.html
+++ b/artist-spencer.html
@@ -1,197 +1,230 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Spencer Tracy Brown — Artist</title>
-  <meta name="description" content="A working artist-site draft for Spencer Tracy Brown: visual artist, sculptor, educator, and maker of boundary, sanctuary, and threshold-centered work." />
+  <meta name="description" content="Spencer Tracy Brown is a visual artist, sculptor, and educator working through boundaries, sanctuaries, material presence, and the relationship between self and world." />
   <meta name="robots" content="noindex, nofollow" />
   <meta property="og:site_name" content="Spencer Tracy Brown" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Spencer Tracy Brown — Artist" />
-  <meta property="og:description" content="Visual artist, sculptor, educator, and maker of boundary, sanctuary, and threshold-centered work." />
+  <meta property="og:description" content="Visual artist, sculptor, and educator working through boundaries, sanctuaries, material presence, and the relationship between self and world." />
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="assets/css/styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Work+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="assets/css/artist-spencer.css" />
 </head>
-<body class="artist-page">
-  <div class="artist-grain" aria-hidden="true"></div>
-  <div class="artist-orbit" aria-hidden="true"><span></span><span></span><span></span></div>
-  <div class="page-shell">
-    <header class="site-header artist-header">
-      <div class="container nav-wrap">
-        <a class="brand ping-target" href="index.html">
-          <span class="brand-mark artist-brand-mark" aria-hidden="true">SB</span>
-          <span class="brand-text"><strong>Spencer Tracy Brown</strong><span>Artist · Sculptor · Educator</span></span>
-        </a>
-        <nav class="nav-links" aria-label="Artist site draft navigation">
-          <a href="#work">Work</a>
-          <a href="#statement">Statement</a>
-          <a href="#about">About</a>
-          <a href="#studio">Studio</a>
-          <a href="#contact">Contact</a>
-          <a href="index.html">EthereonLabs</a>
-        </nav>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="masthead" aria-label="Artist website header">
+    <a class="wordmark" href="#top" aria-label="Spencer Tracy Brown home">Spencer Tracy Brown</a>
+    <nav class="site-nav" aria-label="Artist website navigation">
+      <a href="#work">Work</a>
+      <a href="#statement">Statement</a>
+      <a href="#about">About</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </header>
+
+  <main id="main">
+    <section class="cover" id="top" aria-labelledby="cover-title">
+      <div class="cover-copy">
+        <p class="overline">Artist · Sculptor · Educator</p>
+        <h1 id="cover-title">The boundary is never just a line.</h1>
+        <p class="deck">Spencer Tracy Brown makes work about interior worlds, protective spaces, thresholds, material memory, and the visible evidence of transformation.</p>
       </div>
-    </header>
 
-    <main>
-      <section class="artist-hero">
-        <div class="container artist-hero-grid">
-          <div class="artist-hero-copy">
-            <span class="artist-kicker">Working private draft · image placeholders active</span>
-            <h1>Making sanctuaries at the edge of the visible world.</h1>
-            <p class="artist-lead">Spencer Tracy Brown is a visual artist, sculptor, and educator whose work explores boundaries, interior worlds, protection, exposure, and the quiet structures connecting the self to the larger universe.</p>
-            <div class="artist-actions">
-              <a class="button primary" href="#work">Enter the work</a>
-              <a class="button secondary" href="#statement">Read the statement</a>
-            </div>
-          </div>
-          <aside class="hero-art-card placeholder-card" data-placeholder="Hero artwork image">
-            <div class="placeholder-ratio tall">
-              <span>PLACEHOLDER</span>
-              <strong>hero artwork</strong>
-              <small>large vertical piece / installation detail / strongest first impression</small>
-            </div>
-          </aside>
+      <figure class="image-slot hero-slot" aria-label="Hero artwork placeholder">
+        <div class="slot-field">
+          <span class="slot-label">image pending</span>
+          <strong>primary artwork</strong>
+          <em>reserved for a full-bleed work, installation view, or strong detail</em>
         </div>
-      </section>
+        <figcaption>Untitled work placeholder · medium, dimensions, year</figcaption>
+      </figure>
+    </section>
 
-      <section class="artist-section artist-intro-strip">
-        <div class="container intro-grid">
-          <article>
-            <small>Core language</small>
-            <h2>Boundary. Sanctuary. Threshold. Return.</h2>
-          </article>
-          <p>Across drawing, sculpture, objects, public work, and teaching, Brown treats art as a place where hidden relationships become visible. The work is philosophical without leaving the material world: surface, weight, gesture, containment, rupture, and care.</p>
-        </div>
-      </section>
-
-      <section class="artist-section" id="work">
-        <div class="container">
-          <div class="artist-section-header">
-            <span class="artist-kicker">Selected work</span>
-            <h2>Bodies of work</h2>
-            <p>These are draft containers. Titles, dates, media, dimensions, and final images can be refined as the archive comes aboard.</p>
-          </div>
-
-          <div class="portfolio-grid">
-            <article class="portfolio-card feature-card">
-              <div class="placeholder-ratio wide"><span>PLACEHOLDER</span><strong>Boundaries</strong><small>series image / detail / installation view</small></div>
-              <div class="portfolio-copy">
-                <h3>Boundaries</h3>
-                <p>Work about edges: the lines we draw to protect, divide, reveal, and define ourselves. Boundary is treated not as a wall, but as a charged place where identity is negotiated.</p>
-              </div>
-            </article>
-            <article class="portfolio-card">
-              <div class="placeholder-ratio square"><span>PLACEHOLDER</span><strong>Sanctuaries</strong><small>quiet, luminous, protective work</small></div>
-              <div class="portfolio-copy">
-                <h3>Sanctuaries</h3>
-                <p>Places of refuge, inwardness, and repair. These works ask what it means to build shelter for the self without disappearing from the world.</p>
-              </div>
-            </article>
-            <article class="portfolio-card">
-              <div class="placeholder-ratio square"><span>PLACEHOLDER</span><strong>Sculpture / objects</strong><small>ceramic, constructed, mixed media</small></div>
-              <div class="portfolio-copy">
-                <h3>Sculpture & Objects</h3>
-                <p>Material experiments in form, weight, tension, and presence. The object becomes a witness: something made, held, marked, and transformed.</p>
-              </div>
-            </article>
-            <article class="portfolio-card">
-              <div class="placeholder-ratio square"><span>PLACEHOLDER</span><strong>Public / teaching</strong><small>murals, student work, community work</small></div>
-              <div class="portfolio-copy">
-                <h3>Teaching & Public Work</h3>
-                <p>Creative practice extended into classrooms, murals, community spaces, and student-centered making. Teaching appears here as a living part of the practice.</p>
-              </div>
-            </article>
-            <article class="portfolio-card">
-              <div class="placeholder-ratio square"><span>PLACEHOLDER</span><strong>Drawings / studies</strong><small>sketchbook, process, mark-making</small></div>
-              <div class="portfolio-copy">
-                <h3>Drawings & Studies</h3>
-                <p>Studies, diagrams, marks, fragments, and visual research. This section can hold the thinking-before-the-object and the object-before-the-thought.</p>
-              </div>
-            </article>
-            <article class="portfolio-card">
-              <div class="placeholder-ratio square"><span>PLACEHOLDER</span><strong>Archive</strong><small>older works / experiments / odd treasures</small></div>
-              <div class="portfolio-copy">
-                <h3>Archive & Experiments</h3>
-                <p>A space for works that do not behave neatly: early explorations, unresolved sparks, almost-forgotten paths, and strange little doors worth keeping open.</p>
-              </div>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="artist-section statement-section" id="statement">
-        <div class="container statement-grid">
-          <div>
-            <span class="artist-kicker">Artist statement draft</span>
-            <h2>The work begins where separation starts to fail.</h2>
-          </div>
-          <div class="statement-copy">
-            <p>My work circles the places where the self meets the world: the skin of an object, the boundary of a room, the fragile line between protection and isolation, the threshold where something private becomes visible.</p>
-            <p>I am interested in how forms hold memory. A surface can become a record of pressure, care, repetition, or rupture. A sculpture can behave like a sanctuary, a wound, a diagram, or a body. A mark can point inward and outward at the same time.</p>
-            <p>Underlying the work is a belief that the universe is not separate from the self. To make something is to participate in the shape of the whole. Art becomes a way to notice that participation, to give it form, and to ask what kind of world we are helping to create.</p>
-          </div>
-        </div>
-      </section>
-
-      <section class="artist-section" id="about">
-        <div class="container about-grid">
-          <div class="portrait-card placeholder-card">
-            <div class="placeholder-ratio portrait"><span>PLACEHOLDER</span><strong>artist portrait</strong><small>photo of Spencer / studio portrait / Ethereonized optional</small></div>
-          </div>
-          <div class="about-copy">
-            <span class="artist-kicker">About the artist</span>
-            <h2>Artist, sculptor, educator, maker of thresholds.</h2>
-            <p>Spencer Tracy Brown is an Arizona-based visual artist and high-school art educator working across sculpture, drawing, mixed media, public art, and conceptual systems. His practice is rooted in questions of interconnectedness, selfhood, sanctuary, and transformation.</p>
-            <p>As an educator, Brown’s studio practice extends into mentorship, student-centered exhibitions, public art experiences, and the belief that art class can become a place where young people learn to make meaning with their own hands.</p>
-            <div class="bio-tags" aria-label="Artist keywords">
-              <span>Visual artist</span><span>Sculptor</span><span>Educator</span><span>Boundary work</span><span>Sanctuary work</span><span>Public art</span>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="artist-section studio-section" id="studio">
-        <div class="container">
-          <div class="artist-section-header compact">
-            <span class="artist-kicker">Studio life</span>
-            <h2>Process, companions, evidence of making.</h2>
-          </div>
-          <div class="studio-grid">
-            <article class="studio-card placeholder-card"><div class="placeholder-ratio square"><span>PLACEHOLDER</span><strong>studio table</strong><small>tools, clay, paint, scraps, notes</small></div></article>
-            <article class="studio-card placeholder-card"><div class="placeholder-ratio square"><span>PLACEHOLDER</span><strong>Twee-Twee cameo</strong><small>companion, witness, studio presence</small></div></article>
-            <article class="studio-card placeholder-card"><div class="placeholder-ratio square"><span>PLACEHOLDER</span><strong>classroom / public art</strong><small>student work, mural, installation</small></div></article>
-          </div>
-        </div>
-      </section>
-
-      <section class="artist-section contact-section" id="contact">
-        <div class="container contact-grid">
-          <div>
-            <span class="artist-kicker">Contact</span>
-            <h2>Exhibitions, commissions, collaborations, studio visits.</h2>
-          </div>
-          <div class="contact-panel">
-            <p>This draft can later connect to a dedicated email, contact form, newsletter, shop, CV, or press kit.</p>
-            <a class="button primary" href="mailto:hello@example.com">Replace with artist email</a>
-            <a class="button secondary" href="index.html">Return to EthereonLabs</a>
-          </div>
-        </div>
-      </section>
-    </main>
-
-    <footer class="footer artist-footer">
-      <div class="container footer-row">
-        <div>Spencer Tracy Brown — Artist site working draft.</div>
-        <div><span data-year></span></div>
+    <section class="intro-band" aria-label="Artist practice summary">
+      <div class="intro-number">01</div>
+      <div>
+        <h2>Work rooted in sanctuary, rupture, and repair.</h2>
+        <p>Brown’s practice moves between sculpture, drawing, mixed media, public work, and teaching. The work is quiet but not passive: it asks how a form protects, how a surface remembers, and how the self participates in the larger field around it.</p>
       </div>
-    </footer>
-  </div>
-  <script src="assets/js/site.js"></script>
+    </section>
+
+    <section class="section works-section" id="work" aria-labelledby="work-title">
+      <div class="section-head">
+        <p class="overline">Selected work</p>
+        <h2 id="work-title">Bodies of work</h2>
+        <p>These are clean archival containers for future images, titles, dates, media, dimensions, and deeper project pages.</p>
+      </div>
+
+      <div class="work-grid">
+        <article class="work-card large-card">
+          <figure class="image-slot landscape">
+            <div class="slot-field">
+              <span class="slot-label">image pending</span>
+              <strong>Boundaries</strong>
+              <em>series image / installation detail / wall view</em>
+            </div>
+          </figure>
+          <div class="work-meta">
+            <p class="work-index">I</p>
+            <h3>Boundaries</h3>
+            <p>Edges, divisions, skins, thresholds, and the emotional charge of separation. Boundary becomes a site of pressure rather than a simple limit.</p>
+            <dl>
+              <div><dt>Status</dt><dd>Series placeholder</dd></div>
+              <div><dt>Media</dt><dd>mixed media / sculpture / installation</dd></div>
+            </dl>
+          </div>
+        </article>
+
+        <article class="work-card">
+          <figure class="image-slot square">
+            <div class="slot-field">
+              <span class="slot-label">image pending</span>
+              <strong>Sanctuaries</strong>
+              <em>protective forms / quiet interior spaces</em>
+            </div>
+          </figure>
+          <div class="work-meta">
+            <p class="work-index">II</p>
+            <h3>Sanctuaries</h3>
+            <p>Work about shelter, inwardness, care, and the difficult act of staying open while remaining protected.</p>
+          </div>
+        </article>
+
+        <article class="work-card">
+          <figure class="image-slot square">
+            <div class="slot-field">
+              <span class="slot-label">image pending</span>
+              <strong>Sculpture</strong>
+              <em>ceramic / constructed / object-based work</em>
+            </div>
+          </figure>
+          <div class="work-meta">
+            <p class="work-index">III</p>
+            <h3>Sculpture & Objects</h3>
+            <p>Material forms that carry weight, touch, tension, fragility, and evidence of making.</p>
+          </div>
+        </article>
+
+        <article class="work-card">
+          <figure class="image-slot square">
+            <div class="slot-field">
+              <span class="slot-label">image pending</span>
+              <strong>Drawings</strong>
+              <em>studies / marks / visual research</em>
+            </div>
+          </figure>
+          <div class="work-meta">
+            <p class="work-index">IV</p>
+            <h3>Drawings & Studies</h3>
+            <p>Sketches, fragments, studies, diagrams, and the thinking that happens before a work becomes fixed.</p>
+          </div>
+        </article>
+
+        <article class="work-card">
+          <figure class="image-slot square">
+            <div class="slot-field">
+              <span class="slot-label">image pending</span>
+              <strong>Public work</strong>
+              <em>murals / installations / student-centered projects</em>
+            </div>
+          </figure>
+          <div class="work-meta">
+            <p class="work-index">V</p>
+            <h3>Public & Educational Work</h3>
+            <p>Murals, exhibitions, classroom projects, and public-facing creative environments where art becomes shared space.</p>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="statement-panel" id="statement" aria-labelledby="statement-title">
+      <div class="statement-title">
+        <p class="overline">Artist statement draft</p>
+        <h2 id="statement-title">My work begins where the self meets the world.</h2>
+      </div>
+      <div class="statement-copy">
+        <p>I return to boundaries because they are never neutral. A boundary can protect, divide, reveal, conceal, invite, refuse, or hold a wound closed long enough for it to become something else.</p>
+        <p>I am interested in objects and images that behave like thresholds. A surface may become a skin. A sculpture may become a shelter. A mark may become a record of pressure, repetition, care, or rupture.</p>
+        <p>Underneath the work is a belief that making is participation. The universe is not somewhere else; it is implicated in the hand, the room, the material, the student, the viewer, and the object that remains after attention has passed through it.</p>
+      </div>
+    </section>
+
+    <section class="section about-section" id="about" aria-labelledby="about-title">
+      <figure class="image-slot portrait-slot" aria-label="Artist portrait placeholder">
+        <div class="slot-field">
+          <span class="slot-label">image pending</span>
+          <strong>artist portrait</strong>
+          <em>studio portrait / working image / environmental portrait</em>
+        </div>
+        <figcaption>Portrait placeholder · replace with final artist image</figcaption>
+      </figure>
+
+      <div class="about-copy">
+        <p class="overline">About</p>
+        <h2 id="about-title">Spencer Tracy Brown is an Arizona-based artist and educator.</h2>
+        <p>Brown works across sculpture, drawing, mixed media, public art, and teaching. His practice is shaped by questions of interconnectedness, interiority, protection, transformation, and the ways material forms can hold meaning.</p>
+        <p>As an educator, he treats the classroom as a living studio: a place where young artists learn to make visible choices, build confidence, and understand art as a serious way of thinking.</p>
+        <ul class="tag-list" aria-label="Artist keywords">
+          <li>visual artist</li>
+          <li>sculptor</li>
+          <li>educator</li>
+          <li>boundary</li>
+          <li>sanctuary</li>
+          <li>public work</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="studio-strip" aria-label="Studio and process placeholders">
+      <div class="studio-card">
+        <figure class="image-slot mini-slot">
+          <div class="slot-field">
+            <span class="slot-label">image pending</span>
+            <strong>studio table</strong>
+          </div>
+        </figure>
+        <p>Tools, scraps, fragments, clay, paint, evidence.</p>
+      </div>
+      <div class="studio-card">
+        <figure class="image-slot mini-slot">
+          <div class="slot-field">
+            <span class="slot-label">image pending</span>
+            <strong>Twee-Twee</strong>
+          </div>
+        </figure>
+        <p>Companion, witness, studio presence.</p>
+      </div>
+      <div class="studio-card">
+        <figure class="image-slot mini-slot">
+          <div class="slot-field">
+            <span class="slot-label">image pending</span>
+            <strong>classroom</strong>
+          </div>
+        </figure>
+        <p>Teaching as an extension of the practice.</p>
+      </div>
+    </section>
+
+    <section class="contact-section" id="contact" aria-labelledby="contact-title">
+      <p class="overline">Contact</p>
+      <h2 id="contact-title">Exhibitions, commissions, collaborations, studio visits.</h2>
+      <div class="contact-row">
+        <a href="mailto:hello@example.com">replace-with-artist-email@example.com</a>
+        <span>CV / press kit coming soon</span>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <span>© 2026 Spencer Tracy Brown</span>
+    <span>Temporary review page · not indexed · final domain forthcoming</span>
+  </footer>
 </body>
 </html>

--- a/assets/css/artist-spencer.css
+++ b/assets/css/artist-spencer.css
@@ -1,356 +1,510 @@
 :root {
-  --artist-bg: #090806;
-  --artist-panel: rgba(255, 248, 233, 0.07);
-  --artist-panel-strong: rgba(255, 248, 233, 0.11);
-  --artist-line: rgba(243, 209, 139, 0.22);
-  --artist-line-strong: rgba(243, 209, 139, 0.42);
-  --artist-text: #fff7e8;
-  --artist-muted: #d7c7a7;
-  --artist-gold: #e7bd62;
-  --artist-clay: #b7794d;
-  --artist-blue: #5477b8;
-  --artist-shadow: 0 24px 70px rgba(0, 0, 0, 0.44);
+  --paper: #f4eee3;
+  --paper-warm: #ebe0d0;
+  --ink: #211c18;
+  --muted: #6f6256;
+  --quiet: #9b8d7f;
+  --clay: #9b5d3d;
+  --sand: #c8ad86;
+  --line: rgba(33, 28, 24, 0.16);
+  --line-strong: rgba(33, 28, 24, 0.34);
+  --max: 1220px;
+  --gutter: clamp(1rem, 4vw, 3rem);
+  --serif: "Libre Baskerville", Georgia, serif;
+  --sans: "Work Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-body.artist-page {
-  color: var(--artist-text);
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  color: var(--ink);
   background:
-    radial-gradient(circle at 16% 14%, rgba(183, 121, 77, 0.22), transparent 34%),
-    radial-gradient(circle at 86% 12%, rgba(84, 119, 184, 0.18), transparent 33%),
-    radial-gradient(circle at 52% 104%, rgba(231, 189, 98, 0.14), transparent 38%),
-    linear-gradient(180deg, #0a0806 0%, #15100b 48%, #070604 100%);
+    radial-gradient(circle at 8% 12%, rgba(155, 93, 61, 0.13), transparent 26rem),
+    radial-gradient(circle at 92% 6%, rgba(200, 173, 134, 0.22), transparent 24rem),
+    linear-gradient(180deg, var(--paper) 0%, #f8f3eb 48%, var(--paper-warm) 100%);
+  font-family: var(--sans);
+  line-height: 1.5;
 }
 
-.artist-page .site-header {
-  background: rgba(10, 8, 6, 0.74);
-  border-bottom-color: rgba(243, 209, 139, 0.12);
-}
-
-.artist-brand-mark {
-  font-size: 0;
-  background:
-    radial-gradient(circle at 30% 25%, rgba(231, 189, 98, 0.42), transparent 52%),
-    linear-gradient(135deg, rgba(183, 121, 77, 0.24), rgba(84, 119, 184, 0.12));
-  border-color: var(--artist-line-strong);
-}
-
-.artist-brand-mark::before {
-  content: "SB";
-  font-family: "Instrument Serif", Georgia, serif;
-  font-size: 1.1rem;
-  letter-spacing: 0.03em;
-  transform: translate(-50%, -50%);
-  color: var(--artist-text);
-}
-
-.artist-brand-mark::after {
-  border-color: rgba(255, 247, 232, 0.26);
-}
-
-.artist-page .nav-links a:hover,
-.artist-page .nav-links a[aria-current="page"] {
-  background: rgba(231, 189, 98, 0.11);
-}
-
-.artist-grain {
+body::before {
+  content: "";
   position: fixed;
   inset: 0;
   pointer-events: none;
   opacity: 0.22;
-  z-index: 0;
-  background-image:
-    radial-gradient(circle at 20% 30%, rgba(255,255,255,0.18) 0 1px, transparent 1px),
-    radial-gradient(circle at 70% 60%, rgba(255,255,255,0.14) 0 1px, transparent 1px);
-  background-size: 54px 54px, 79px 79px;
-  mix-blend-mode: overlay;
+  background-image: linear-gradient(rgba(33, 28, 24, 0.05) 1px, transparent 1px);
+  background-size: 100% 14px;
+  mix-blend-mode: multiply;
 }
 
-.artist-orbit {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  overflow: hidden;
-  z-index: 0;
-}
+img { max-width: 100%; display: block; }
 
-.artist-orbit span {
+a { color: inherit; }
+
+.skip-link {
   position: absolute;
-  border: 1px solid rgba(231, 189, 98, 0.13);
-  border-radius: 999px;
-  filter: blur(0.2px);
+  left: 1rem;
+  top: 1rem;
+  transform: translateY(-200%);
+  background: var(--ink);
+  color: var(--paper);
+  padding: 0.65rem 0.9rem;
+  z-index: 100;
 }
 
-.artist-orbit span:nth-child(1) { width: 620px; height: 620px; right: -210px; top: -140px; }
-.artist-orbit span:nth-child(2) { width: 380px; height: 380px; left: -120px; top: 38%; }
-.artist-orbit span:nth-child(3) { width: 520px; height: 180px; left: 48%; bottom: -40px; transform: rotate(-8deg); }
+.skip-link:focus { transform: translateY(0); }
 
-.artist-hero {
-  padding: 5.2rem 0 3.6rem;
-}
-
-.artist-hero-grid,
-.intro-grid,
-.statement-grid,
-.about-grid,
-.contact-grid {
-  display: grid;
-  gap: 2rem;
-  align-items: center;
-}
-
-.artist-hero-grid { grid-template-columns: minmax(0, 1fr) minmax(320px, 0.78fr); }
-.intro-grid { grid-template-columns: 0.85fr 1.15fr; }
-.statement-grid { grid-template-columns: 0.8fr 1.2fr; align-items: start; }
-.about-grid { grid-template-columns: 0.72fr 1.28fr; }
-.contact-grid { grid-template-columns: 0.95fr 1.05fr; }
-
-.artist-kicker {
-  display: inline-flex;
-  width: fit-content;
-  color: var(--artist-gold);
-  border: 1px solid rgba(231, 189, 98, 0.26);
-  background: rgba(231, 189, 98, 0.07);
-  padding: 0.44rem 0.78rem;
-  border-radius: 999px;
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.artist-hero h1,
-.artist-section h2 {
-  font-family: "Instrument Serif", Georgia, serif;
-  font-weight: 400;
-  letter-spacing: -0.035em;
-}
-
-.artist-hero h1 {
-  margin: 1rem 0 1.2rem;
-  font-size: clamp(3.3rem, 7.4vw, 7.2rem);
-  line-height: 0.92;
-  max-width: 11ch;
-}
-
-.artist-lead {
-  max-width: 62ch;
-  font-size: 1.12rem;
-  line-height: 1.8;
-  color: var(--artist-muted);
-}
-
-.artist-actions {
+.masthead {
+  width: min(var(--max), calc(100% - (var(--gutter) * 2)));
+  margin: 0 auto;
+  padding: 1.25rem 0;
   display: flex;
-  gap: 0.9rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.wordmark {
+  font-family: var(--serif);
+  font-size: clamp(1.02rem, 2vw, 1.35rem);
+  text-decoration: none;
+  letter-spacing: -0.02em;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.85rem, 2vw, 1.7rem);
   flex-wrap: wrap;
-  margin-top: 1.5rem;
+  justify-content: flex-end;
 }
 
-.artist-page .button.primary {
-  background: linear-gradient(135deg, rgba(231, 189, 98, 0.22), rgba(84, 119, 184, 0.12));
-  border-color: rgba(231, 189, 98, 0.46);
+.site-nav a {
+  text-decoration: none;
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
 }
 
-.artist-page .button.secondary {
-  background: rgba(255, 248, 233, 0.045);
-  border-color: rgba(255, 248, 233, 0.12);
+.site-nav a:hover { color: var(--ink); }
+
+main,
+.site-footer {
+  width: min(var(--max), calc(100% - (var(--gutter) * 2)));
+  margin: 0 auto;
 }
 
-.hero-art-card,
-.portrait-card,
-.portfolio-card,
-.studio-card,
-.contact-panel,
-.artist-intro-strip .container,
-.statement-section .container {
-  background: linear-gradient(180deg, rgba(255, 248, 233, 0.08), rgba(12, 9, 6, 0.82));
-  border: 1px solid var(--artist-line);
-  border-radius: 30px;
-  box-shadow: var(--artist-shadow);
+.cover {
+  min-height: calc(100vh - 86px);
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(320px, 0.78fr);
+  align-items: center;
+  gap: clamp(2rem, 5vw, 5rem);
+  padding: clamp(3rem, 7vw, 7rem) 0;
 }
 
-.hero-art-card { padding: 1rem; transform: rotate(1.2deg); }
-.portrait-card { padding: 1rem; transform: rotate(-1deg); }
-.artist-intro-strip .container,
-.statement-section .container { padding: 1.5rem; }
+.cover-copy {
+  max-width: 760px;
+}
 
-.placeholder-ratio {
+.overline,
+.slot-label,
+.work-index,
+figcaption,
+.site-footer,
+dt,
+.contact-row span {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1,
+h2,
+h3 {
+  font-family: var(--serif);
+  font-weight: 400;
+  letter-spacing: -0.04em;
+}
+
+h1 {
+  margin-bottom: 1.25rem;
+  max-width: 10.5ch;
+  font-size: clamp(4rem, 10vw, 10.5rem);
+  line-height: 0.88;
+}
+
+.deck {
+  max-width: 48rem;
+  color: var(--muted);
+  font-size: clamp(1.08rem, 1.8vw, 1.38rem);
+  line-height: 1.75;
+}
+
+.image-slot {
+  margin: 0;
+}
+
+.slot-field {
   position: relative;
+  min-height: 20rem;
   display: grid;
   place-items: center;
   text-align: center;
-  min-height: 260px;
-  overflow: hidden;
-  border-radius: 24px;
-  border: 1px dashed rgba(231, 189, 98, 0.38);
+  padding: 2rem;
   background:
-    linear-gradient(135deg, rgba(231, 189, 98, 0.11), rgba(84, 119, 184, 0.08)),
-    repeating-linear-gradient(45deg, rgba(255,255,255,0.025) 0 10px, transparent 10px 20px);
+    linear-gradient(135deg, rgba(33, 28, 24, 0.035), rgba(155, 93, 61, 0.07)),
+    repeating-linear-gradient(45deg, rgba(33, 28, 24, 0.045) 0 1px, transparent 1px 16px);
+  border: 1px solid var(--line);
+  box-shadow: inset 0 0 0 0.65rem rgba(244, 238, 227, 0.72);
 }
 
-.placeholder-ratio::before {
+.slot-field::before,
+.slot-field::after {
   content: "";
   position: absolute;
-  inset: 18px;
-  border: 1px solid rgba(255, 247, 232, 0.13);
-  border-radius: 19px;
+  inset: 1.25rem;
+  border: 1px solid rgba(33, 28, 24, 0.14);
+  pointer-events: none;
 }
 
-.placeholder-ratio span,
-.placeholder-ratio strong,
-.placeholder-ratio small {
+.slot-field::after {
+  inset: 2rem;
+  border-style: dashed;
+  opacity: 0.7;
+}
+
+.slot-field strong,
+.slot-field em,
+.slot-label {
   position: relative;
   z-index: 1;
   display: block;
 }
 
-.placeholder-ratio span {
-  color: var(--artist-gold);
-  font-size: 0.72rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  margin-bottom: 0.7rem;
-}
-
-.placeholder-ratio strong {
-  font-family: "Instrument Serif", Georgia, serif;
-  font-size: clamp(1.8rem, 4vw, 3.2rem);
+.slot-field strong {
+  font-family: var(--serif);
   font-weight: 400;
-  color: var(--artist-text);
+  font-size: clamp(1.7rem, 4vw, 3.4rem);
+  letter-spacing: -0.04em;
 }
 
-.placeholder-ratio small {
-  max-width: 28ch;
-  margin-top: 0.7rem;
-  color: var(--artist-muted);
-  line-height: 1.5;
+.slot-field em {
+  max-width: 25ch;
+  margin-top: 0.65rem;
+  color: var(--muted);
+  font-style: normal;
+  font-size: 0.9rem;
 }
 
-.placeholder-ratio.tall { min-height: 560px; }
-.placeholder-ratio.wide { min-height: 340px; }
-.placeholder-ratio.square { aspect-ratio: 1 / 1; min-height: 0; }
-.placeholder-ratio.portrait { min-height: 560px; }
+.hero-slot .slot-field { min-height: clamp(29rem, 68vh, 43rem); }
 
-.artist-section {
-  padding: 2rem 0 4.75rem;
+figcaption {
+  margin-top: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: none;
+  font-weight: 500;
 }
 
-.artist-intro-strip small {
-  color: var(--artist-gold);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+.intro-band {
+  display: grid;
+  grid-template-columns: 5rem minmax(0, 1fr);
+  gap: clamp(1rem, 4vw, 4rem);
+  padding: clamp(2rem, 5vw, 4rem) 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
 }
 
-.artist-intro-strip h2,
-.artist-section-header h2,
-.statement-section h2,
+.intro-number {
+  color: var(--clay);
+  font-family: var(--serif);
+  font-size: 2.25rem;
+}
+
+.intro-band h2,
+.section-head h2,
+.statement-title h2,
 .about-copy h2,
-.contact-grid h2 {
-  font-size: clamp(2.25rem, 4.5vw, 4.8rem);
+.contact-section h2 {
+  margin-bottom: 1rem;
+  font-size: clamp(2.4rem, 5.2vw, 5.6rem);
   line-height: 0.98;
 }
 
-.artist-intro-strip p,
+.intro-band p,
+.section-head p,
 .statement-copy p,
 .about-copy p,
-.contact-panel p,
-.portfolio-copy p {
-  color: var(--artist-muted);
-  line-height: 1.75;
+.work-meta p,
+.studio-card p {
+  color: var(--muted);
 }
 
-.artist-section-header {
+.intro-band p {
+  max-width: 65rem;
+  font-size: clamp(1.05rem, 1.7vw, 1.35rem);
+  line-height: 1.8;
+}
+
+.section {
+  padding: clamp(4rem, 8vw, 8rem) 0;
+}
+
+.section-head {
+  max-width: 760px;
+  margin-bottom: clamp(2rem, 5vw, 4rem);
+}
+
+.work-grid {
   display: grid;
-  gap: 0.8rem;
-  margin-bottom: 1.3rem;
-  max-width: 780px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
 }
 
-.artist-section-header.compact { margin-bottom: 1.2rem; }
-
-.portfolio-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.portfolio-card {
-  overflow: hidden;
-}
-
-.portfolio-card.feature-card {
+.work-card {
   grid-column: span 2;
-}
-
-.portfolio-copy {
-  padding: 1.1rem 1.1rem 1.25rem;
-}
-
-.portfolio-copy h3,
-.bio-tags span {
-  margin: 0 0 0.5rem;
-}
-
-.portfolio-copy h3 {
-  font-family: "Instrument Serif", Georgia, serif;
-  font-size: 2rem;
-  font-weight: 400;
-}
-
-.statement-copy p:first-child {
-  margin-top: 0;
-}
-
-.bio-tags {
   display: flex;
-  gap: 0.65rem;
+  flex-direction: column;
+  border-top: 1px solid var(--line-strong);
+  padding-top: 0.85rem;
+}
+
+.large-card {
+  grid-column: span 4;
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+  gap: clamp(1rem, 3vw, 2rem);
+  align-items: start;
+}
+
+.landscape .slot-field { min-height: 30rem; }
+.square .slot-field { aspect-ratio: 1 / 1; min-height: 0; }
+
+.work-meta {
+  padding-top: 1rem;
+}
+
+.work-meta h3 {
+  margin-bottom: 0.7rem;
+  font-size: clamp(1.85rem, 3vw, 3rem);
+  line-height: 1.02;
+}
+
+.work-index {
+  color: var(--clay);
+  margin-bottom: 0.65rem;
+}
+
+dl {
+  display: grid;
+  gap: 0.7rem;
+  margin: 1.4rem 0 0;
+}
+
+dl div {
+  border-top: 1px solid var(--line);
+  padding-top: 0.7rem;
+}
+
+dt { margin-bottom: 0.2rem; }
+
+dd {
+  margin: 0;
+  color: var(--ink);
+}
+
+.statement-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 0.76fr) minmax(0, 1.24fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  padding: clamp(3rem, 6vw, 6rem) 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.statement-copy {
+  max-width: 770px;
+}
+
+.statement-copy p {
+  font-size: clamp(1.05rem, 1.55vw, 1.28rem);
+  line-height: 1.85;
+}
+
+.statement-copy p + p { margin-top: 1.35rem; }
+
+.about-section {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.72fr) minmax(0, 1.28fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: center;
+}
+
+.portrait-slot .slot-field { min-height: clamp(25rem, 55vw, 42rem); }
+
+.about-copy p {
+  max-width: 680px;
+  font-size: 1.05rem;
+  line-height: 1.8;
+}
+
+.tag-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.75rem 0 0;
+  display: flex;
+  gap: 0.6rem;
   flex-wrap: wrap;
-  margin-top: 1.2rem;
 }
 
-.bio-tags span {
-  display: inline-flex;
-  padding: 0.55rem 0.78rem;
+.tag-list li {
+  padding: 0.45rem 0.68rem;
+  border: 1px solid var(--line);
   border-radius: 999px;
-  border: 1px solid rgba(231, 189, 98, 0.22);
-  background: rgba(231, 189, 98, 0.07);
-  color: var(--artist-muted);
-  font-size: 0.88rem;
+  color: var(--muted);
+  font-size: 0.82rem;
 }
 
-.studio-grid {
+.studio-strip {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  padding-bottom: clamp(4rem, 8vw, 8rem);
 }
 
-.studio-card { padding: 0.9rem; }
-.contact-panel { padding: 1.3rem; display: flex; gap: 0.8rem; flex-wrap: wrap; align-items: center; }
-.contact-panel p { flex-basis: 100%; margin-top: 0; }
-.artist-footer { border-top-color: rgba(243, 209, 139, 0.12); }
+.studio-card {
+  border-top: 1px solid var(--line-strong);
+  padding-top: 0.85rem;
+}
 
-@media (max-width: 980px) {
-  .artist-hero-grid,
-  .intro-grid,
-  .statement-grid,
-  .about-grid,
-  .contact-grid,
-  .portfolio-grid,
-  .studio-grid {
+.mini-slot .slot-field {
+  min-height: 15rem;
+}
+
+.mini-slot .slot-field strong {
+  font-size: clamp(1.4rem, 2.6vw, 2.2rem);
+}
+
+.studio-card p {
+  margin: 0.9rem 0 0;
+}
+
+.contact-section {
+  padding: clamp(3rem, 6vw, 6rem) 0;
+  border-top: 1px solid var(--line);
+}
+
+.contact-section h2 {
+  max-width: 12ch;
+}
+
+.contact-row {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+}
+
+.contact-row a {
+  display: inline-flex;
+  padding: 0.9rem 1.1rem;
+  border: 1px solid var(--line-strong);
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.26);
+}
+
+.contact-row a:hover {
+  border-color: var(--ink);
+}
+
+.site-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 1.5rem 0 2rem;
+  border-top: 1px solid var(--line);
+  letter-spacing: 0.08em;
+}
+
+@media (max-width: 900px) {
+  .masthead {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .site-nav {
+    justify-content: flex-start;
+  }
+
+  .cover,
+  .intro-band,
+  .large-card,
+  .statement-panel,
+  .about-section,
+  .studio-strip {
     grid-template-columns: 1fr;
   }
-  .portfolio-card.feature-card { grid-column: auto; }
-  .placeholder-ratio.tall,
-  .placeholder-ratio.portrait { min-height: 420px; }
+
+  .work-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .work-card,
+  .large-card {
+    grid-column: auto;
+  }
+
+  h1 {
+    max-width: none;
+    font-size: clamp(4rem, 18vw, 7rem);
+  }
+
+  .hero-slot .slot-field,
+  .portrait-slot .slot-field,
+  .landscape .slot-field {
+    min-height: 24rem;
+  }
 }
 
-@media (max-width: 760px) {
-  .artist-hero { padding: 2.6rem 0 2.3rem; }
-  .artist-hero h1 { max-width: none; }
-  .artist-actions .button,
-  .contact-panel .button { width: 100%; }
-  .placeholder-ratio.tall,
-  .placeholder-ratio.portrait,
-  .placeholder-ratio.wide { min-height: 320px; }
-  .artist-intro-strip .container,
-  .statement-section .container { padding: 1rem; }
+@media (max-width: 560px) {
+  :root { --gutter: 0.85rem; }
+
+  .site-nav a {
+    font-size: 0.72rem;
+  }
+
+  .cover {
+    padding-top: 2.2rem;
+  }
+
+  h1 {
+    font-size: clamp(3.4rem, 20vw, 5.6rem);
+  }
+
+  .intro-band {
+    gap: 0.5rem;
+  }
+
+  .slot-field {
+    box-shadow: inset 0 0 0 0.4rem rgba(244, 238, 227, 0.72);
+  }
+
+  .slot-field::before { inset: 0.8rem; }
+  .slot-field::after { inset: 1.35rem; }
 }

--- a/docs/spencer_artist_site_staging_notes_r1.md
+++ b/docs/spencer_artist_site_staging_notes_r1.md
@@ -1,13 +1,23 @@
-# Spencer Artist Site — Hidden Staging Draft r1
+# Spencer Artist Site — Temporary Independent Website r2
 
-## Recommended temporary home
+## Current decision
 
-Use the EthereonLabs repository as a private-ish staging page:
+This page should feel like Spencer Tracy Brown's artist website, not like an EthereonLabs subpage.
+
+EthereonLabs is only the temporary host.
+
+## Temporary URL after merge
+
+`https://ethereonlabs.com/artist-spencer.html`
+
+## Current files
 
 - `artist-spencer.html`
 - `assets/css/artist-spencer.css`
 
-Do not add it to the main navigation yet.
+The page no longer imports the shared EthereonLabs stylesheet or site JavaScript. It uses a standalone visual system so the artist site can later be lifted into its own domain with minimal cleanup.
+
+## Indexing / privacy note
 
 The page includes:
 
@@ -15,35 +25,42 @@ The page includes:
 <meta name="robots" content="noindex, nofollow" />
 ```
 
-That discourages indexing, but it is not true password protection. Anyone with the URL could still view it once deployed.
+This discourages search indexing, but it is not real privacy or password protection. Anyone with the URL can view it after deployment.
 
-## Suggested URL while staged
+## Visual direction
 
-`https://ethereonlabs.com/artist-spencer.html`
+Direction: Desert Modern / contemporary artist monograph.
 
-Later, once the final domain exists, this page can be cloned into the new site and redirected from EthereonLabs if desired.
+Key qualities:
+
+- warm paper ground
+- charcoal text
+- clay and sand accents
+- quiet serif headline typography
+- minimal navigation
+- image-first portfolio structure
+- no glow, orbit, dashboard, or interface-system language
 
 ## Placeholder inventory
 
-Current placeholders:
+Current image placeholders:
 
-1. hero artwork
-2. Boundaries series image
-3. Sanctuaries series image
-4. sculpture / objects image
-5. teaching / public work image
-6. drawings / studies image
-7. archive / experiments image
-8. artist portrait
-9. studio table
-10. Twee-Twee cameo
-11. classroom / public art
+1. primary artwork / hero image
+2. Boundaries
+3. Sanctuaries
+4. Sculpture & Objects
+5. Drawings & Studies
+6. Public & Educational Work
+7. artist portrait
+8. studio table
+9. Twee-Twee
+10. classroom / teaching
 
 ## Next refinements
 
-- Replace placeholder images with real image paths.
-- Add titles, years, media, and dimensions.
-- Decide whether the final visual system should remain dark/desert/gold or move toward a cleaner white gallery style.
-- Add CV page.
-- Add contact email.
-- Add optional statement page if the homepage becomes too long.
+- Replace placeholders with final image paths.
+- Add artwork titles, years, media, and dimensions.
+- Add a CV page or downloadable CV.
+- Replace placeholder contact email.
+- Decide whether the final domain is `spencertracybrown.com`, `spencerbrown.art`, or another dedicated artist URL.
+- Later, remove `noindex` only when the dedicated artist site is ready for public discovery.


### PR DESCRIPTION
## Summary

Rebuilds the Spencer Tracy Brown artist staging page so it reads as an independent artist website temporarily hosted by EthereonLabs, rather than an EthereonLabs-style subpage.

## Changes

- Removes dependency on the shared EthereonLabs stylesheet and site JavaScript from `artist-spencer.html`
- Replaces the previous dark/glow/interface feel with a standalone Desert Modern / contemporary artist monograph visual system
- Updates `assets/css/artist-spencer.css` as a fully standalone design layer
- Updates staging notes to clarify that EthereonLabs is only the temporary host

## Temporary URL after merge

`https://ethereonlabs.com/artist-spencer.html`

## Notes

The page still includes `noindex, nofollow` while staged. This discourages indexing, but it is not password protection.