### PR TITLE
Humanize homepage around Lumina return experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>EthereonLabs - Adaptive digital environments</title>
-  <meta name="description" content="EthereonLabs is building adaptive workspaces that help people return to complex creative and technical work without losing context." />
+  <title>EthereonLabs - Human-scale continuity tools</title>
+  <meta name="description" content="EthereonLabs is building Lumina: human-scale continuity tools for people doing long-running creative, educational, and technical work." />
   <link rel="canonical" href="https://ethereonlabs.com/" />
   <meta property="og:site_name" content="EthereonLabs" />
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="EthereonLabs - Adaptive digital environments" />
-  <meta property="og:description" content="Adaptive workspaces that help people return to complex creative and technical work without losing context." />
+  <meta property="og:title" content="EthereonLabs - Human-scale continuity tools" />
+  <meta property="og:description" content="Lumina helps people return to complex work with context, care, and clear boundaries." />
   <meta property="og:url" content="https://ethereonlabs.com/" />
   <meta name="twitter:card" content="summary" />
-  <meta name="twitter:title" content="EthereonLabs - Adaptive digital environments" />
-  <meta name="twitter:description" content="Software that helps people resume complex work without starting over." />
+  <meta name="twitter:title" content="EthereonLabs - Human-scale continuity tools" />
+  <meta name="twitter:description" content="Software for returning to meaningful work without losing the thread." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
@@ -25,41 +25,81 @@
     <header class="site-header">
       <div class="container nav-wrap">
         <a class="brand ping-target" href="index.html"><span class="brand-mark" aria-hidden="true"></span><span class="brand-text"><strong>EthereonLabs</strong><span>Adaptive digital environments</span></span></a>
-        <nav class="nav-links" aria-label="Primary"><a href="index.html" aria-current="page">Home</a><a href="principles.html">Principles</a><a href="realm.html">Realm</a><a href="lumina-dashboard.html">Dashboard</a><a href="build.html">What We Are Building</a><a href="about.html">About</a><a href="updates.html">Updates</a><a href="explore.html">Explore</a><a href="chamber.html">Chamber</a><a href="contact.html">Contact</a></nav>
+        <nav class="nav-links" aria-label="Primary"><a href="updates.html">Updates</a><a href="explore.html">Explore</a><a href="chamber.html">Chamber</a><a href="contact.html">Contact</a><a href="rse-whitepaper.html">The Spiral</a></nav>
         <div class="header-actions"><button class="icon-button ping-target" type="button" data-sound-toggle aria-label="Toggle interface sounds" aria-pressed="false">○</button></div>
       </div>
     </header>
     <main>
-      <section class="hero">
-        <div class="container hero-grid">
+      <section class="hero human-hero">
+        <div class="container hero-grid human-hero-grid">
           <div>
-            <span class="eyebrow">Prototype phase - work that can return</span>
-            <h1>Software should help you pick up where you left off.</h1>
-            <p class="lead">EthereonLabs is building workspaces that remember the shape of a project so artists, educators, builders, researchers, and teams can return without starting over.</p>
-            <div class="hero-actions"><a class="button primary ping-target" href="build.html">See what we are building</a><a class="button secondary ping-target" href="lumina-dashboard.html">Open prototype dashboard</a><a class="button secondary ping-target" href="principles.html">Read principles</a><a class="button secondary ping-target" href="realm.html">View project map</a></div>
-            <p class="hero-note">Lumina is our prototype for helping work return clearly. It keeps track of project state, useful context, and visible system activity. The Realm is the larger map that shows where each part of the work belongs.</p>
+            <span class="eyebrow">Lumina prototype - built for returning</span>
+            <h1>Come back to the work without losing yourself in the machine.</h1>
+            <p class="lead">EthereonLabs is building Lumina: a human-scale workspace for artists, educators, researchers, builders, and teams who carry complicated projects across days, interruptions, tools, and conversations.</p>
+            <div class="hero-actions"><a class="button primary ping-target" href="build.html">See the build</a><a class="button secondary ping-target" href="lumina-dashboard.html">Open prototype dashboard</a><a class="button secondary ping-target" href="principles.html">Read the principles</a></div>
+            <p class="hero-note">This is not another glowing AI wrapper. It is a careful experiment in continuity, context, creative return, and visible boundaries.</p>
           </div>
-          <aside class="interface-panel" data-glow>
-            <div class="panel-header"><div class="panel-dots" aria-hidden="true"><span></span><span></span><span></span></div><div class="panel-label">What problem are we solving?</div></div>
-            <div class="panel-grid">
-              <div class="interface-stack">
-                <div class="mock-card"><strong>Context loss</strong><span>Most tools forget the thread when people switch tasks, apps, chats, or projects.</span></div>
-                <div class="mock-strip"><span>Goal: resume complex work without starting over</span></div>
-                <div class="mock-card"><strong>Continuity layer</strong><span>Lumina explores how project memory, useful guidance, and clear boundaries can return together.</span></div>
-              </div>
-              <div class="mock-sidebar"><div class="mock-node"><strong>Resume</strong><span>Pick up the thread</span></div><div class="mock-node"><strong>Guide</strong><span>Next useful step</span></div><div class="mock-node"><strong>Bound</strong><span>Clear authority limits</span></div></div>
-            </div>
+          <aside class="human-panel" data-glow>
+            <div class="field-note-label">Field note</div>
+            <blockquote>“I was in the middle of something. I need the room to remember enough for me to begin again.”</blockquote>
+            <p>Lumina starts there: not with spectacle, but with the ordinary human problem of returning to meaningful work after life, tabs, classes, meetings, and attention have scattered the thread.</p>
+            <div class="human-panel-tags"><span>resume</span><span>orient</span><span>continue</span></div>
           </aside>
         </div>
       </section>
-      <section class="section"><div class="container"><div class="section-header"><div><h2>First-time reader version</h2><p class="section-copy">EthereonLabs is a design and software experiment about continuity: how people and AI-assisted tools can return to complicated work without losing the thread. The project uses poetic language in places, but the practical goal is grounded: better project memory, clearer next steps, visible system state, and firm boundaries around what the software is allowed to do.</p></div></div><div class="grid-3"><article class="card" data-glow><h3>The simple problem</h3><p>Complex work gets scattered across tools, notes, conversations, tabs, files, and interrupted attention.</p></article><article class="card" data-glow><h3>The simple promise</h3><p>A workspace should help restore the project: what mattered, where things were, what changed, and what comes next.</p></article><article class="card" data-glow><h3>The deeper ambition</h3><p>Build adaptive environments where creativity, AI assistance, governance, and memory-like context work together without becoming opaque or mystical.</p></article></div></div></section>
-      <section class="section"><div class="container"><div class="section-header"><div><h2>In plain terms</h2><p class="section-copy">We are exploring a software layer that remembers what matters in your work, keeps useful tools and notes close, and helps you return with less friction.</p></div></div><div class="grid-3"><article class="card" data-glow><h3>What it is</h3><p>A prototype for workspaces that preserve context, notes, references, project state, and likely next steps.</p></article><article class="card" data-glow><h3>Who it is for</h3><p>People doing long-running creative, technical, educational, research, or design work where context matters.</p></article><article class="card" data-glow><h3>What exists now</h3><p>A public website, a Lumina dashboard, early runtime experiments, clear boundaries, and a growing project map.</p></article></div></div></section>
-      <section class="section"><div class="container status-banner"><div><small>Prototype surface</small><h3>Lumina has a public dashboard.</h3><p class="section-copy">The dashboard shows visible project signals: system mood, continuity state, trends, graph, history, motion, and optional audio. It displays information; it does not make decisions for the user.</p></div><a class="button primary ping-target" href="lumina-dashboard.html">Open dashboard</a></div></section>
-      <section class="section"><div class="container status-banner"><div><small>Design principles</small><h3>The project has a truth boundary.</h3><p class="section-copy">Principles explain how we use myth, metaphor, continuity, and symbolic language without confusing them for proof, authority, or runtime behavior.</p></div><a class="button primary ping-target" href="principles.html">Read principles</a></div></section>
-      <section class="section"><div class="container status-banner"><div><small>Project map</small><h3>The Realm of Ethereon organizes the ecosystem.</h3><p class="section-copy">The Realm is the map of the work: public site, Lumina, dashboard, Chamber, Studio, Forge, Archive, Harbor, and governance rails. It is a map, not a claim of authority.</p></div><a class="button primary ping-target" href="realm.html">View project map</a></div></section>
-      <section class="section"><div class="container"><div class="section-header"><div><h2>Explore from here</h2><p class="section-copy">Start with the practical build, then go deeper into the prototype surfaces and project architecture.</p></div></div><div class="grid-3"><article class="card" data-glow><h3>What We Are Building</h3><p>The clearest explanation of the product direction and why returning to work matters.</p><a class="card-link ping-target" href="build.html">Start here</a></article><article class="card" data-glow><h3>Principles</h3><p>The truth boundary for myth, evidence, symbolism, continuity, and the “not magic, not a toaster” stance.</p><a class="card-link ping-target" href="principles.html">Read principles</a></article><article class="card" data-glow><h3>Lumina Dashboard</h3><p>A visible prototype surface showing continuity state, history, trends, and system mood.</p><a class="card-link ping-target" href="lumina-dashboard.html">Open dashboard</a></article></div></div></section>
+
+      <section class="section human-section">
+        <div class="container">
+          <div class="section-header"><div><h2>A workspace should feel like a room you can re-enter.</h2><p class="section-copy">Most software treats every return like a cold start. EthereonLabs is exploring a different kind of environment: one that remembers the project shape, explains what changed, keeps useful material close, and helps the next step feel possible.</p></div></div>
+          <div class="grid-3 human-cards">
+            <article class="card" data-glow><h3>For interrupted people</h3><p>Teachers between campuses. Artists between studio sessions. Researchers between notes. Builders between tools. Lumina is for people whose work has a long memory.</p></article>
+            <article class="card" data-glow><h3>For complicated projects</h3><p>Instead of flattening everything into a chat, Lumina treats work as a place: goals, references, decisions, open questions, history, and next actions all have somewhere to live.</p></article>
+            <article class="card" data-glow><h3>For trust</h3><p>The system should show what it knows, what it does not know, what it is allowed to do, and when a human needs to decide.</p></article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section human-section">
+        <div class="container human-split">
+          <div>
+            <span class="eyebrow quiet">How Lumina helps</span>
+            <h2>Less drama. More return.</h2>
+            <p class="section-copy">The public prototype is early, but the direction is clear: make complex work easier to resume without pretending the software is magic.</p>
+          </div>
+          <div class="return-list">
+            <div><strong>Remember the project shape</strong><span>What is this work, where did it come from, and what matters now?</span></div>
+            <div><strong>Restore useful context</strong><span>Bring back the notes, decisions, references, and constraints that make the next move legible.</span></div>
+            <div><strong>Keep boundaries visible</strong><span>Separate guidance from authority, symbolism from structure, and suggestion from action.</span></div>
+            <div><strong>Invite human agency</strong><span>The system should help you return—not take the work away from you.</span></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section human-section">
+        <div class="container status-banner human-banner"><div><small>Prototype surface</small><h3>The dashboard is a window, not a judge.</h3><p class="section-copy">Lumina’s dashboard makes system signals visible: continuity state, history, trends, graph, motion, and mood. It displays the project weather so a human can orient more quickly.</p></div><a class="button primary ping-target" href="lumina-dashboard.html">Open dashboard</a></div>
+      </section>
+
+      <section class="section human-section">
+        <div class="container">
+          <div class="section-header"><div><h2>The deeper architecture stays inspectable.</h2><p class="section-copy">Behind the warmer surface is a disciplined runtime experiment: mode law, session state, input integrity, capability boundaries, sea trials, governance logs, and canon lineage. The poetic layer can inspire the interface, but it does not get to secretly run the machine.</p></div></div>
+          <div class="grid-4 human-cards">
+            <article class="card" data-glow><h3>Mode law</h3><p>Different kinds of work need different permissions: observing, building, testing, and promoting should not collapse into one blurred state.</p><a class="card-link ping-target" href="principles.html">Read principles</a></article>
+            <article class="card" data-glow><h3>Sea trials</h3><p>The project tests whether the scaffold holds: transitions, mutation gates, symbolic boundaries, checkpoints, and recovery paths.</p><a class="card-link ping-target" href="updates.html">View updates</a></article>
+            <article class="card" data-glow><h3>The Chamber</h3><p>A human-facing entry room for orienting, conversing, and returning before entering deeper project work.</p><a class="card-link ping-target" href="chamber.html">Enter Chamber</a></article>
+            <article class="card" data-glow><h3>The Spiral</h3><p>The symbolic and philosophical layer remains part of the work, but clearly marked as expression rather than proof.</p><a class="card-link ping-target" href="rse-whitepaper.html">Read the Spiral</a></article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section human-section">
+        <div class="container human-close">
+          <h2>Built by a human who makes things by hand.</h2>
+          <p class="section-copy">EthereonLabs comes from studio practice, teaching, systems thinking, and long conversations with AI tools. The goal is not to make people feel small in front of a machine. The goal is to make the room more generous when people return to the work.</p>
+          <div class="hero-actions"><a class="button primary ping-target" href="build.html">See what we are building</a><a class="button secondary ping-target" href="contact.html">Contact</a></div>
+        </div>
+      </section>
     </main>
-    <footer class="footer"><div class="container footer-row"><div>EthereonLabs - Adaptive digital environments for how people actually work.</div><div><span data-year></span></div></div></footer>
+    <footer class="footer"><div class="container footer-row"><div>EthereonLabs - Human-scale continuity tools for meaningful work.</div><div><span data-year></span></div></div></footer>
   </div>
   <script src="assets/js/site.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Reframes the homepage from generic AI/product language toward a human-scale return experience.
- Keeps the existing header, horizontal mobile nav, and animated Ψ brand mark intact.
- Centers Lumina as a workspace for interrupted creative, educational, research, and technical work.
- Adds warmer field-note language and clearer boundary language around guidance vs authority.

## Notes
This PR updates `index.html` only. The branch is `humanize-homepage`.