### PR TITLE
Fix: restore homepage header + site shell after Lumina update

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,52 +11,73 @@
   <meta property="og:title" content="EthereonLabs - Lumina OS" />
   <meta property="og:description" content="Lumina OS restores context, recommends next steps, and routes execution through governed runtime systems." />
   <meta property="og:url" content="https://ethereonlabs.com/" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="EthereonLabs - Lumina OS" />
+  <meta name="twitter:description" content="A governed continuity substrate for restoring project state and guiding next steps." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="assets/css/styles.css" />
 </head>
 <body>
+  <div class="rse-flow-field" aria-hidden="true">
+    <span></span><span></span><span></span><span></span><span></span>
+  </div>
+  <div class="orbit-field" aria-hidden="true"><span></span><span></span><span></span></div>
   <div class="page-shell">
+    <header class="site-header">
+      <div class="container nav-wrap">
+        <a class="brand ping-target" href="index.html"><span class="brand-mark" aria-hidden="true"></span><span class="brand-text"><strong>EthereonLabs</strong><span>Adaptive digital environments</span></span></a>
+        <nav class="nav-links" aria-label="Primary"><a href="index.html" aria-current="page">Home</a><a href="principles.html">Principles</a><a href="realm.html">Realm</a><a href="lumina-dashboard.html">Dashboard</a><a href="about.html">About</a><a href="updates.html">Updates</a><a href="explore.html">Explore</a><a href="chamber.html">Chamber</a><a href="contact.html">Contact</a></nav>
+        <div class="header-actions"><button class="icon-button ping-target" type="button" data-sound-toggle aria-label="Toggle interface sounds" aria-pressed="false">○</button></div>
+      </div>
+    </header>
     <main>
       <section class="hero">
         <div class="container">
           <span class="eyebrow">Lumina OS — continuity substrate</span>
           <h1>Return to complex work without starting over.</h1>
           <p class="lead">Lumina OS restores project state, surfaces what changed, recommends next steps, and routes execution through governed runtime systems. It is designed to preserve continuity while keeping human consent and system boundaries intact.</p>
-        </div>
-      </section>
-
-      <section class="section">
-        <div class="container">
-          <h2>What Lumina does</h2>
-          <div class="grid-3">
-            <div class="card"><h3>Restore context</h3><p>Returns to the latest known project state without guessing.</p></div>
-            <div class="card"><h3>Guide next steps</h3><p>Recommends actions based on restored context and orientation.</p></div>
-            <div class="card"><h3>Preserve continuity</h3><p>Records checkpoints, lineage, and runtime evidence.</p></div>
+          <div class="hero-actions">
+            <a class="button primary ping-target" href="lumina.html">Open Lumina page</a>
+            <a class="button secondary ping-target" href="lumina-dashboard.html">View dashboard</a>
+            <a class="button secondary ping-target" href="principles.html">Read principles</a>
+            <a class="button secondary ping-target" href="roadmap.html">Open roadmap</a>
           </div>
         </div>
       </section>
-
       <section class="section">
-        <div class="container">
-          <h2>Runtime foundation</h2>
-          <p class="section-copy">Lumina OS operates on a governed runtime scaffold including a runtime spine, context loader, decision engine, orchestrator, and validation system. Advisory outputs remain subordinate to runtime governance.</p>
+        <div class="container"><div class="section-header"><div><h2>What Lumina does</h2><p class="section-copy">Lumina is moving from interface concept into governed continuity infrastructure. Its purpose is to help complex work resume from the latest known state instead of forcing people to reconstruct context by hand.</p></div></div><div class="grid-3"><article class="card" data-glow><h3>Restore context</h3><p>Returns to the latest known project state, working surface, and recent orientation without guessing.</p></article><article class="card" data-glow><h3>Guide next steps</h3><p>Recommends actions from restored context while keeping the human in charge.</p></article><article class="card" data-glow><h3>Preserve continuity</h3><p>Records checkpoints, lineage, runtime evidence, and advisory history so progress can be audited.</p></article></div></div>
+      </section>
+      <section class="section">
+        <div class="container grid-2">
+          <article class="timeline" data-glow><h3>1. Restore the workspace</h3><p>Lumina is built to recover a project’s working state: notes, prior action, current mode, known references, and the surrounding context needed to resume.</p></article>
+          <article class="timeline" data-glow><h3>2. Recommend without sovereignty</h3><p>The decision engine proposes next actions from restored context and orientation, but it does not become authority. Runtime governance still decides what is allowed.</p></article>
+          <article class="timeline" data-glow><h3>3. Route through runtime</h3><p>The orchestrator passes advisory actions through governed runtime execution, preserving checkpoints and boundaries instead of bypassing the system.</p></article>
+          <article class="timeline" data-glow><h3>4. Preserve evidence</h3><p>Sea trials, behavioral assertions, drift checks, and validation records keep the project grounded in inspectable proof rather than presentation alone.</p></article>
         </div>
       </section>
-
       <section class="section">
-        <div class="container">
-          <h2>Sea trial status</h2>
-          <p class="section-copy">Lumina has passed runtime validation for governed transitions, checkpoint continuity, symbolic boundary enforcement, canon lineage integrity, and orchestration continuity.</p>
+        <div class="container feature-callout">
+          <small>Current sea-trial status</small>
+          <h2>Lumina has crossed from thesis into tested scaffold.</h2>
+          <p class="section-copy">The current runtime lane validates governed transitions, checkpoint continuity, symbolic-boundary enforcement, canon lineage integrity, orchestration continuity, behavioral assertions, and drift detection. This does not claim production readiness; it confirms a working continuity substrate under active hardening.</p>
+          <div class="hero-actions">
+            <a class="button primary ping-target" href="lumina-dashboard.html">Open prototype dashboard</a>
+            <a class="button secondary ping-target" href="updates.html">See recent updates</a>
+            <a class="button secondary ping-target" href="realm.html">View project map</a>
+          </div>
         </div>
       </section>
-
       <section class="section">
-        <div class="container">
-          <h2>Boundary</h2>
-          <p class="section-copy">Lumina provides guidance, not authority. All actions remain subject to human approval and runtime governance constraints.</p>
-        </div>
+        <div class="container"><div class="section-header"><div><h2>Runtime foundation</h2><p class="section-copy">Under the public surface is a governed runtime scaffold. This layer defines what can happen, what must be recorded, what must remain optional, and what requires validation before promotion.</p></div></div><div class="grid-3"><article class="card" data-glow><h3>Runtime spine</h3><p>Coordinates session state, checkpoints, mode transitions, context bundles, governance logs, and capability exposure.</p></article><article class="card" data-glow><h3>Context loader</h3><p>Restores minimal working context from runtime state so the system can resume from evidence instead of assumption.</p></article><article class="card" data-glow><h3>Decision engine</h3><p>Produces bounded recommendations from context and orientation while remaining subordinate to runtime law.</p></article><article class="card" data-glow><h3>Orchestrator</h3><p>Connects restored context, recommendation, and governed execution into a repeatable continuity loop.</p></article><article class="card" data-glow><h3>Canon lineage</h3><p>Keeps promoted structural states append-only so the project can evolve without rewriting its own history.</p></article><article class="card" data-glow><h3>Sea trials</h3><p>Stress-test transitions, mutation boundaries, promotion gates, checkpoint resume, drift, and orchestration continuity.</p></article></div></div>
       </section>
-
+      <section class="section">
+        <div class="container status-banner"><div><small>Truth boundary</small><h3>Guidance is not authority.</h3><p class="section-copy">Lumina may recommend. Humans approve. Runtime governance constrains. Poetic language may guide the design, but it does not become hidden system law.</p></div><a class="button primary ping-target" href="principles.html">Read principles</a></div>
+      </section>
     </main>
+    <footer class="footer"><div class="container footer-row"><div><a href="index.html">EthereonLabs</a></div><div><span data-year></span></div></div></footer>
   </div>
+  <script src="assets/js/site.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Corrects missing header/navigation caused by previous merge.

- Restores site header + nav
- Restores background layers
- Preserves Lumina OS updated messaging

This is a corrective PR to stabilize the homepage after PR #140.