### PR TITLE
Page-wide Ψ resonance wake (faint rings + thread traces)

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,19 @@
     @media(max-width:760px){.psi-resonance-echo{right:-4.5rem;top:58%;font-size:11rem;opacity:.48}}
     @media(prefers-reduced-motion:reduce){.psi-resonance-echo{animation:none!important}}
   </style>
+  <style>
+    /* PAGE-WIDE PSI RESONANCE WAKE — reversible: remove this style block and the .psi-resonance-wake element. */
+    .psi-resonance-wake{position:fixed;inset:0;z-index:0;pointer-events:none;overflow:hidden;mix-blend-mode:screen;opacity:.72}
+    .psi-resonance-wake span{position:absolute;display:block;pointer-events:none}
+    .wake-ring{right:clamp(1rem,6vw,7rem);top:54%;translate:50% -50%;border-radius:999px;border:1px solid rgba(217,168,78,.085);box-shadow:0 0 34px rgba(217,168,78,.06),inset 0 0 44px rgba(138,164,255,.035);animation:psiWakeRing 28s ease-in-out infinite}
+    .wake-ring-one{width:clamp(16rem,36vw,42rem);height:clamp(16rem,36vw,42rem);animation-delay:-4s}.wake-ring-two{width:clamp(22rem,48vw,58rem);height:clamp(22rem,48vw,58rem);border-color:rgba(126,240,209,.055);animation-duration:34s;animation-delay:-17s}.wake-ring-three{width:clamp(30rem,64vw,76rem);height:clamp(30rem,64vw,76rem);border-color:rgba(217,183,255,.045);animation-duration:42s;animation-delay:-25s}
+    .wake-thread{right:clamp(3rem,12vw,14rem);top:54%;width:clamp(18rem,42vw,54rem);height:1px;background:linear-gradient(90deg,transparent,rgba(217,168,78,.17),rgba(255,235,190,.26),transparent);box-shadow:0 0 16px rgba(217,168,78,.12);transform-origin:right center;opacity:0;animation:psiWakeThread 24s ease-in-out infinite}
+    .wake-thread-one{rotate:-16deg;animation-delay:-7s}.wake-thread-two{rotate:11deg;animation-duration:31s;animation-delay:-19s}.wake-thread-three{rotate:-4deg;animation-duration:37s;animation-delay:-28s;background:linear-gradient(90deg,transparent,rgba(126,240,209,.10),rgba(255,235,190,.20),transparent)}
+    @keyframes psiWakeRing{0%,100%{opacity:.10;transform:scale(.90)}45%{opacity:.30;transform:scale(1.035)}68%{opacity:.16;transform:scale(1.12)}}
+    @keyframes psiWakeThread{0%,100%{opacity:0;translate:0 0;transform:scaleX(.62)}22%{opacity:.16;translate:-3vw -10px;transform:scaleX(.88)}48%{opacity:.28;translate:-10vw 8px;transform:scaleX(1.04)}72%{opacity:.08;translate:-18vw -6px;transform:scaleX(.74)}}
+    @media(max-width:760px){.psi-resonance-wake{opacity:.48}.wake-ring-three,.wake-thread-three{display:none}.wake-thread{right:2.5rem;width:60vw}}
+    @media(prefers-reduced-motion:reduce){.psi-resonance-wake *{animation:none!important}}
+  </style>
 </head>
 <body>
   <div class="rse-flow-field" aria-hidden="true">
@@ -51,6 +64,10 @@
   </div>
   <div class="orbit-field" aria-hidden="true"><span></span><span></span><span></span></div>
   <div class="psi-resonance-echo" aria-hidden="true">Ψ</div>
+  <div class="psi-resonance-wake" aria-hidden="true">
+    <span class="wake-ring wake-ring-one"></span><span class="wake-ring wake-ring-two"></span><span class="wake-ring wake-ring-three"></span>
+    <span class="wake-thread wake-thread-one"></span><span class="wake-thread wake-thread-two"></span><span class="wake-thread wake-thread-three"></span>
+  </div>
   <div class="page-shell">
     <header class="site-header">
       <div class="container nav-wrap">


### PR DESCRIPTION
## Purpose
Adds a restrained page-wide resonance wake around the existing Ψ echo: faint pulsing rings plus a few low-opacity thread traces.

## Scope
- Builds on PR #150’s page-wide Ψ echo
- Leaves hero sigil intact
- Leaves header untouched
- Leaves page layout and content untouched
- Uses HTML/CSS only; no JavaScript

## Design Constraint
The hero remains the artifact. This wake is only ambient field residue.

## Reversibility
Easy undo path:
1. Revert this PR, or
2. Remove the `.psi-resonance-wake` element from `index.html`, and
3. Remove the inline `PAGE-WIDE PSI RESONANCE WAKE` style block.

## Sea Trial Notes
Watch for subtle emanation, not spectacle. If it feels like a screensaver, reduce opacity or revert.