### PR TITLE
RSE whitepaper: fix mobile metadata wrapping

### DIFF
--- a/rse-whitepaper.html
+++ b/rse-whitepaper.html
@@ -20,7 +20,9 @@
   <link rel="stylesheet" href="assets/css/styles.css" />
   <style>
     .sigil-frame { width: 100%; min-height: 580px; border: 0; border-radius: 24px; background: rgba(6, 9, 19, 0.82); box-shadow: var(--shadow); overflow: hidden; display: block; }
-    @media (max-width: 760px) { .sigil-frame { min-height: 460px; } }
+    .inline-list { display: flex; flex-wrap: wrap; gap: 0.45rem 0.9rem; align-items: center; max-width: 70ch; }
+    .inline-list span { display: inline-flex; }
+    @media (max-width: 760px) { .sigil-frame { min-height: 460px; } .inline-list { display: grid; gap: 0.38rem; font-size: 0.95rem; line-height: 1.38; } .inline-list span { display: block; } }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Purpose
Fixes the mobile formatting issue where the RSE whitepaper metadata runs together, specifically `Author` and `Collaborator` appearing on the same line without spacing.

## Scope
- Updates only `rse-whitepaper.html`
- Adds responsive layout rules for `.inline-list`
- Keeps the page content unchanged
- Keeps header, navigation, background, and resonance effects untouched

## Result
On mobile, the metadata now stacks cleanly:
- Author
- Collaborator
- Affiliation
- Version
- Status

## Reversibility
Easy undo: revert this PR, or remove the `.inline-list` CSS additions from the page-local style block.