### PR TITLE
RSE visual: center and scale artifact on mobile

### DIFF
--- a/assets/artifacts/prisma-sigil.html
+++ b/assets/artifacts/prisma-sigil.html
@@ -7,6 +7,12 @@
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
 
+    html, body {
+      width: 100%;
+      min-height: 100%;
+      overflow: hidden;
+    }
+
     body {
       background: #060913;
       display: flex;
@@ -14,18 +20,24 @@
       justify-content: center;
       min-height: 100vh;
       font-family: Georgia, serif;
+      padding: clamp(10px, 3vw, 24px);
     }
 
     .wrap {
       position: relative;
-      width: 520px;
-      height: 520px;
+      width: min(520px, calc(100vw - 24px));
+      aspect-ratio: 1;
+      height: auto;
+      flex: 0 0 auto;
     }
 
     canvas {
       position: absolute;
       inset: 0;
-      border-radius: 52px;
+      width: 100%;
+      height: 100%;
+      border-radius: clamp(34px, 10vw, 52px);
+      display: block;
     }
 
     .eq-label {
@@ -54,6 +66,17 @@
     .corner.tr { top: 18px; right: 18px; border-width: 1px 1px 0 0; }
     .corner.bl { bottom: 18px; left: 18px; border-width: 0 0 1px 1px; }
     .corner.br { bottom: 18px; right: 18px; border-width: 0 1px 1px 0; }
+
+    @media (max-width: 760px) {
+      body { align-items: center; padding: 12px; }
+      .wrap { width: min(520px, calc(100vw - 24px)); }
+      .eq-label { display: none; }
+      .corner { width: 18px; height: 18px; }
+      .corner.tl { top: 15px; left: 15px; }
+      .corner.tr { top: 15px; right: 15px; }
+      .corner.bl { bottom: 15px; left: 15px; }
+      .corner.br { bottom: 15px; right: 15px; }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Purpose
Fixes the mobile centering issue for the animated RSE / Prisma sigil artifact.

## Root Cause
The artifact iframe is responsive, but the artifact content inside it was fixed at 520px × 520px. On narrow screens, that caused the visual to feel clipped/off-center instead of naturally scaled.

## Scope
- Updates only `assets/artifacts/prisma-sigil.html`
- Makes the artifact wrapper responsive with `width: min(520px, calc(100vw - 24px))`
- Preserves the canvas drawing logic and existing animation
- Hides the small equation label on mobile to reduce crowding
- Leaves `rse-whitepaper.html`, header, nav, page content, and resonance effects untouched

## Reversibility
Easy undo: revert this PR, or restore the prior fixed `.wrap` / `canvas` CSS in `assets/artifacts/prisma-sigil.html`.

## Sea Trial
Check the whitepaper page on mobile and confirm the RSE card reads as centered within its frame rather than clipped to one side.