### PR TITLE
RSE golden ratio: give caption breathing room

### DIFF
--- a/rse-whitepaper.html
+++ b/rse-whitepaper.html
@@ -32,10 +32,10 @@
     .golden-label, .golden-phi-text { font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
     .golden-label { font-size: 10px; letter-spacing: 0.16em; fill: rgba(255,235,190,0.82); }
     .golden-phi-text { font-size: 10px; letter-spacing: 0.08em; fill: rgba(255,235,190,0.86); }
-    .golden-ratio-note { margin: -0.7rem 1.1rem 1rem; color: rgba(255,235,190,0.62); font-size: 0.72rem; letter-spacing: 0.12em; text-transform: uppercase; }
+    .golden-ratio-note { margin: 0.45rem 1.1rem 1rem; color: rgba(255,235,190,0.62); font-size: 0.72rem; line-height: 1.45; letter-spacing: 0.12em; text-transform: uppercase; }
     @keyframes goldenSpiralTrace { 0% { stroke-dashoffset: 760; opacity: 0.36; } 45% { opacity: 0.92; } 100% { stroke-dashoffset: 0; opacity: 0.72; } }
     @media (prefers-reduced-motion: reduce) { .golden-spiral { animation: none !important; stroke-dashoffset: 0; } .golden-orbit animateMotion { display: none; } }
-    @media (max-width: 760px) { .sigil-frame { min-height: 460px; } .inline-list { display: grid; gap: 0.38rem; font-size: 0.95rem; line-height: 1.38; } .inline-list span { display: block; } .golden-ratio-artifact { margin-top: 0.15rem; border-radius: 18px; } .golden-label { font-size: 8.7px; letter-spacing: 0.14em; } .golden-phi-text { font-size: 9px; } .golden-ratio-note { margin: -0.55rem 0.95rem 0.9rem; font-size: 0.62rem; letter-spacing: 0.09em; } }
+    @media (max-width: 760px) { .sigil-frame { min-height: 460px; } .inline-list { display: grid; gap: 0.38rem; font-size: 0.95rem; line-height: 1.38; } .inline-list span { display: block; } .golden-ratio-artifact { margin-top: 0.15rem; border-radius: 18px; } .golden-label { font-size: 8.7px; letter-spacing: 0.14em; } .golden-phi-text { font-size: 9px; } .golden-ratio-note { margin: 0.4rem 0.95rem 0.95rem; font-size: 0.62rem; line-height: 1.45; letter-spacing: 0.09em; } }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Purpose
Fixes the slightly obscured golden-ratio caption below the SVG artifact.

## Scope
- Updates only `rse-whitepaper.html`
- Adjusts only `.golden-ratio-note` spacing/line-height
- Leaves the SVG, spiral animation, moving point, φ badge, header, navigation, backgrounds, and global effects untouched
- No JavaScript

## Change
- Removes the negative top margin that pulled the caption upward
- Adds a modest positive top margin and line-height so the caption can wrap cleanly on mobile

## Reversibility
Easy undo: revert this PR, or restore the previous `.golden-ratio-note` margins.

## Sea Trial
Confirm the caption reads cleanly without adding visual heaviness.