### PR TITLE
Contact form: use inline Netlify success state

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -37,7 +37,11 @@
     .contact-form textarea { min-height: 150px; resize: vertical; }
     .contact-form input:focus, .contact-form select:focus, .contact-form textarea:focus { border-color: rgba(126,240,209,0.52); box-shadow: 0 0 0 3px rgba(126,240,209,0.08); }
     .contact-form .hidden-field { position: absolute; left: -5000px; opacity: 0; pointer-events: none; }
-    .form-note { color: rgba(196,209,255,0.72); font-size: 0.92rem; line-height: 1.55; margin-top: 0.75rem; }
+    .form-note, .form-status { color: rgba(196,209,255,0.72); font-size: 0.92rem; line-height: 1.55; margin-top: 0.75rem; }
+    .form-status { border: 1px solid rgba(126,240,209,0.22); border-radius: 18px; background: rgba(6,9,19,0.62); padding: 1rem; }
+    .form-status strong { color: rgba(255,235,190,0.9); }
+    .form-status[hidden] { display: none; }
+    .contact-form-card.is-sent .contact-form { display: none; }
     @keyframes signalPulse { 0%, 100% { opacity: 0.18; transform: scale(0.92); } 50% { opacity: 0.52; transform: scale(1.05); } }
     @keyframes signalTrace { 0% { stroke-dashoffset: 210; opacity: 0.24; } 55% { opacity: 0.86; } 100% { stroke-dashoffset: 0; opacity: 0.58; } }
     @media (max-width: 760px) { .contact-signal { border-radius: 24px; } .contact-signal svg { min-height: 240px; } .signal-label { font-size: 8.8px; letter-spacing: 0.12em; } .signal-caption { margin: -0.15rem 1rem 1rem; font-size: 0.86rem; } .contact-form-card { border-radius: 24px; } }
@@ -51,11 +55,45 @@
     <main>
       <section class="hero"><div class="container"><span class="eyebrow">Signal and contact</span><h1>Send a signal into Ethereon.</h1><p class="lead">If you want to follow the build, express early interest, or begin a thoughtful collaboration, this page keeps the path simple and direct. No perfect pitch required — just a clear note about what drew you here.</p></div></section>
       <section class="section"><div class="container contact-signal" data-glow aria-label="Contact signal beacon"><svg viewBox="0 0 720 260" role="img" aria-labelledby="contact-signal-title contact-signal-desc"><title id="contact-signal-title">Contact signal beacon</title><desc id="contact-signal-desc">A central Psi signal node sending two paths toward early interest and collaboration.</desc><defs><radialGradient id="contactNodeGlow" cx="50%" cy="50%" r="55%"><stop offset="0%" stop-color="rgba(255,235,190,0.22)"/><stop offset="52%" stop-color="rgba(126,240,209,0.08)"/><stop offset="100%" stop-color="rgba(126,240,209,0)"/></radialGradient></defs><rect x="0" y="0" width="720" height="260" fill="url(#contactNodeGlow)"/><circle class="signal-ring ring-one" cx="360" cy="130" r="58"/><circle class="signal-ring ring-two" cx="360" cy="130" r="92"/><circle class="signal-ring ring-three" cx="360" cy="130" r="126"/><path class="signal-thread" d="M 360 130 C 300 72, 206 62, 118 86"/><path class="signal-thread secondary" d="M 360 130 C 428 184, 526 194, 612 166"/><circle class="signal-node" cx="360" cy="130" r="44"/><text class="signal-core" x="360" y="143" text-anchor="middle">Ψ</text><circle cx="116" cy="86" r="5" fill="rgba(255,235,190,0.92)"/><circle cx="612" cy="166" r="5" fill="rgba(126,240,209,0.92)"/><text class="signal-label" x="82" y="60">Early Interest</text><text class="signal-label" x="548" y="198">Collaboration</text><text class="signal-label" x="294" y="222">Choose the channel · send the signal</text></svg><p class="signal-caption">Two clear channels: follow the project as it opens, or begin a deeper conversation around adaptive environments, continuity, design, and creative tooling.</p></div></section>
-      <section class="section"><div class="container contact-form-card" data-glow><small>Transmit a message</small><h2>Write directly from the site.</h2><p class="section-copy">Choose the path that best fits your signal. Messages submitted here are handled through Netlify Forms and can be routed to the EthereonLabs inbox.</p><form class="contact-form" name="ethereon-contact" method="POST" data-netlify="true" data-netlify-honeypot="bot-field" action="/contact-success/"><input type="hidden" name="form-name" value="ethereon-contact" /><input type="hidden" name="subject" data-remove-prefix value="New EthereonLabs signal from website" /><p class="hidden-field"><label>Do not fill this out: <input name="bot-field" /></label></p><label>Name<input type="text" name="name" autocomplete="name" required /></label><label>Email<input type="email" name="email" autocomplete="email" required /></label><label>Signal type<select name="signal_type" required><option value="">Choose a channel</option><option value="Early interest">Early interest</option><option value="Collaboration">Collaboration</option><option value="General contact">General contact</option></select></label><label>Message<textarea name="message" required placeholder="Tell us what drew you here, what you are curious about, or what kind of collaboration you imagine."></textarea></label><button class="button primary ping-target" type="submit">Transmit message</button></form><p class="form-note">Prefer old-school contact? The direct email link remains below as a fallback.</p></div></section>
+      <section class="section"><div class="container contact-form-card" data-glow><small>Transmit a message</small><h2>Write directly from the site.</h2><p class="section-copy">Choose the path that best fits your signal. Messages submitted here are handled through Netlify Forms and can be routed to the EthereonLabs inbox.</p><form class="contact-form" name="ethereon-contact" method="POST" data-netlify="true" data-netlify-honeypot="bot-field"><input type="hidden" name="form-name" value="ethereon-contact" /><input type="hidden" name="subject" data-remove-prefix value="New EthereonLabs signal from website" /><p class="hidden-field"><label>Do not fill this out: <input name="bot-field" /></label></p><label>Name<input type="text" name="name" autocomplete="name" required /></label><label>Email<input type="email" name="email" autocomplete="email" required /></label><label>Signal type<select name="signal_type" required><option value="">Choose a channel</option><option value="Early interest">Early interest</option><option value="Collaboration">Collaboration</option><option value="General contact">General contact</option></select></label><label>Message<textarea name="message" required placeholder="Tell us what drew you here, what you are curious about, or what kind of collaboration you imagine."></textarea></label><button class="button primary ping-target" type="submit">Transmit message</button></form><div class="form-status" data-form-status hidden role="status" aria-live="polite"></div><p class="form-note">Prefer old-school contact? The direct email link remains below as a fallback.</p></div></section>
       <section class="section"><div class="container grid-2"><article class="contact-card" data-glow><small>Early interest</small><h3>Follow the first wave</h3><p>Use this path if you want project updates, future prototype invitations, or a closer view of how EthereonLabs develops from concept into working environment.</p><a class="card-link ping-target" href="mailto:rowan@ethereonlabs.com?subject=EthereonLabs%20Early%20Interest">Email for early interest</a></article><article class="contact-card" data-glow><small>Collaboration</small><h3>Start a thoughtful exchange</h3><p>Use this path for design discussion, creative tooling, interface experiments, adaptive workflow ideas, or collaboration inquiries connected to the EthereonLabs direction.</p><a class="card-link ping-target" href="mailto:rowan@ethereonlabs.com?subject=EthereonLabs%20Collaboration">Email for collaboration</a></article></div></section>
       <section class="section"><div class="container grid-2"><article class="list-card" data-glow><h3>Direct email</h3><p>For anything that does not fit neatly into a category, the direct address is still the simplest route.</p><a class="card-link ping-target" href="mailto:rowan@ethereonlabs.com">rowan@ethereonlabs.com</a></article><article class="list-card" data-glow><h3>See the current direction</h3><p>The best way to understand what the conversation is about is to see the current direction pages first.</p><div class="hero-actions"><a class="button secondary ping-target" href="specimen.html">Open interface specimen</a><a class="button secondary ping-target" href="lumina.html">See Lumina direction</a><a class="button secondary ping-target" href="chamber.html">Enter Chamber</a></div></article></div></section>
     </main>
     <footer class="footer"><div class="container footer-row"><div><a href="index.html">EthereonLabs</a></div><div><span data-year></span></div></div></footer>
-  </div><script src="assets/js/site.js"></script>
+  </div><script src="assets/js/site.js"></script><script>
+    (function () {
+      var form = document.querySelector('form[name="ethereon-contact"]');
+      if (!form || !window.fetch || !window.URLSearchParams) return;
+      var card = form.closest('.contact-form-card');
+      var status = document.querySelector('[data-form-status]');
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+        var button = form.querySelector('button[type="submit"]');
+        var formData = new FormData(form);
+        if (!formData.get('form-name')) formData.set('form-name', form.getAttribute('name'));
+        if (button) { button.disabled = true; button.textContent = 'Transmitting…'; }
+        fetch('/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams(formData).toString()
+        }).then(function (response) {
+          if (!response.ok) throw new Error('Submission failed');
+          form.reset();
+          if (card) card.classList.add('is-sent');
+          if (status) {
+            status.hidden = false;
+            status.innerHTML = '<strong>Signal received.</strong><br />Thank you — your message has entered the EthereonLabs contact channel.';
+          }
+        }).catch(function () {
+          if (status) {
+            status.hidden = false;
+            status.innerHTML = '<strong>The signal did not complete.</strong><br />Please use the direct email link below while we inspect the channel.';
+          }
+        }).finally(function () {
+          if (button) { button.disabled = false; button.textContent = 'Transmit message'; }
+        });
+      });
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Purpose
Stops the post-submit 404 loop by removing the custom redirect dependency and handling successful Netlify form submission inline on the contact page.

## Finding
The success pages exist in GitHub, but the live site still produced a blank/404 path after form submission. The redirect target is therefore the fragile part. The sturdier approach is to submit to Netlify via `fetch('/')` and show a success state in place.

## Changes
- Removes the form `action` redirect
- Submits the Netlify form with JavaScript using URL-encoded form data
- Shows an inline `Signal received` confirmation after a successful response
- Shows a fallback error message if submission fails
- Keeps the Netlify form attributes so Netlify can still detect the form at deploy time
- Keeps direct email links as fallback

## Scope
- Updates only `contact.html`
- No header, navigation, signal beacon, global background, or other-page changes
- Keeps `contact-success.html` and `/contact-success/` in the repo as harmless fallback pages

## Reversibility
Easy undo: revert this PR, or restore the form action and remove the inline status block/script.

## Sea Trial
After merge/deploy, submit a test message. Expected result: stay on `/contact`, form hides, and an inline `Signal received` confirmation appears without routing to Netlify's 404 page.