### PR TITLE
Netlify forms: add plain detection page

### DIFF
--- a/netlify-form-detection.html
+++ b/netlify-form-detection.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EthereonLabs - Netlify Form Detection</title>
+  <meta name="robots" content="noindex" />
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body>
+  <main class="section">
+    <div class="container list-card">
+      <h1>Netlify Form Detection</h1>
+      <p>This plain static form exists so Netlify can register the <strong>ethereon-contact</strong> form channel during deploy.</p>
+      <form name="ethereon-contact" method="POST" data-netlify="true" netlify data-netlify-honeypot="bot-field">
+        <input type="hidden" name="form-name" value="ethereon-contact" />
+        <p style="display:none;">
+          <label>Do not fill this out: <input name="bot-field" /></label>
+        </p>
+        <p>
+          <label>Name<br />
+            <input type="text" name="name" required />
+          </label>
+        </p>
+        <p>
+          <label>Email<br />
+            <input type="email" name="email" required />
+          </label>
+        </p>
+        <p>
+          <label>Signal type<br />
+            <select name="signal_type" required>
+              <option value="General contact">General contact</option>
+              <option value="Early interest">Early interest</option>
+              <option value="Collaboration">Collaboration</option>
+            </select>
+          </label>
+        </p>
+        <p>
+          <label>Message<br />
+            <textarea name="message" required></textarea>
+          </label>
+        </p>
+        <p><button class="button primary" type="submit">Send detection test</button></p>
+      </form>
+      <p><a class="card-link" href="contact.html">Back to contact</a></p>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Purpose
Adds a deliberately plain static HTML form page so Netlify can unmistakably detect and register the `ethereon-contact` form channel during deploy.

## Context
The polished `/contact` form is present and the inline handler works, but Netlify is still rejecting the POST. The likely issue is that Netlify has not registered the form channel. This page gives Netlify the simplest possible static form to scan.

## Changes
- Adds `netlify-form-detection.html`
- Includes a plain `<form name="ethereon-contact" method="POST" data-netlify="true" netlify>` form
- Includes the same field names as the visible contact form:
  - `name`
  - `email`
  - `signal_type`
  - `message`
  - `bot-field`
- Marks the page `noindex`
- Does not alter `/contact` yet

## Scope
- Adds one standalone detection page
- No visual changes to the public contact page
- No JavaScript
- No header/nav/background/global changes

## Sea Trial
After merge/deploy:
1. Open Netlify project `ethereonlabs`.
2. Check whether `Forms` appears in the project sidebar.
3. Confirm form `ethereon-contact` exists.
4. Then test the polished `/contact` form again.

## Reversibility
Easy undo: revert this PR or delete `netlify-form-detection.html` after Netlify has registered the form and the public contact flow is verified.