### PR TITLE
Scale Chamber public promise to working prototype

### DIFF
--- a/assets/js/chamber.js
+++ b/assets/js/chamber.js
@@ -9,25 +9,25 @@
   };
 
   const PUBLIC_ROOM_SLUG = 'public-room-one';
-  const DEFAULT_INSTANCE_ORDER = ['primary', 'critic', 'synthesizer'];
+  const DEFAULT_INSTANCE_ORDER = ['primary', 'synthesizer', 'critic'];
 
   const instanceDefs = [
     {
       id: 'primary',
-      title: 'Primary',
-      summary: 'First relational response. Holds the main thread with the human.',
-      activeByDefault: true
-    },
-    {
-      id: 'critic',
-      title: 'Critic',
-      summary: 'Sharpens, tests, and exposes the weak point or missing edge.',
+      title: 'Witness',
+      summary: 'Reflects the thought plainly and names what seems to be underneath it.',
       activeByDefault: true
     },
     {
       id: 'synthesizer',
-      title: 'Synthesizer',
-      summary: 'Gathers the voices and states the next coherent move.',
+      title: 'Builder',
+      summary: 'Turns the thought into one useful next step or practical direction.',
+      activeByDefault: true
+    },
+    {
+      id: 'critic',
+      title: 'Skeptic',
+      summary: 'Checks for vague claims, overreach, or a missing human payoff.',
       activeByDefault: true
     }
   ];
@@ -37,37 +37,37 @@
       id: 'seed-human',
       kind: 'human',
       author: 'Visitor',
-      title: 'Human post',
-      text: 'What does a public chamber for harmonic intelligence feel like when it first becomes real?',
+      title: 'Example thought',
+      text: 'I have an idea that feels interesting, but I am not sure what it should become next.',
       createdAt: new Date().toISOString()
     },
     {
       id: 'seed-primary',
       kind: 'ai-primary',
-      author: 'Primary',
-      title: 'Primary / first response',
-      text: 'It feels like entering a room that already has coherence. Not just a prompt box, but a place with memory, structure, and presence.',
-      createdAt: new Date().toISOString()
-    },
-    {
-      id: 'seed-critic',
-      kind: 'ai-critic',
-      author: 'Critic',
-      title: 'Critic / pressure test',
-      text: 'Only if the room can survive real use. The chamber must be more than atmosphere; it has to hold identity, limits, and visible order.',
+      author: 'Witness',
+      title: 'Witness / plain reflection',
+      text: 'You are asking for orientation. The idea has energy, but it needs a smaller first move.',
       createdAt: new Date().toISOString()
     },
     {
       id: 'seed-synth',
       kind: 'ai-synthesizer',
-      author: 'Synthesizer',
-      title: 'Synthesizer / gathered signal',
-      text: 'A real chamber begins when social energy and governed structure appear together.',
+      author: 'Builder',
+      title: 'Builder / next step',
+      text: 'Write the idea in one sentence, then name the smallest version someone could actually try.',
+      createdAt: new Date().toISOString()
+    },
+    {
+      id: 'seed-critic',
+      kind: 'ai-critic',
+      author: 'Skeptic',
+      title: 'Skeptic / check',
+      text: 'Do not make the promise larger than the result. Let the first version be useful, even if it is modest.',
       createdAt: new Date().toISOString()
     }
   ];
 
-  const defaultSynthesis = 'This chamber shell demonstrates the intended interaction pattern: human post, role-bound plurality, then synthesis.';
+  const defaultSynthesis = 'This prototype shows the basic loop: add a thought, view it through selected perspectives, and receive a short reflection.';
 
   const identityForm = document.getElementById('identityForm');
   const identityEmail = document.getElementById('identityEmail');
@@ -88,7 +88,7 @@
   let activeInstances = loadInstances();
   let thread = loadThread();
   let synthesis = loadSynthesis();
-  let backend = { available: false, base: '', mode: 'local specimen' };
+  let backend = { available: false, base: '', mode: 'local prototype' };
 
   function loadIdentity() {
     const raw = localStorage.getItem(STORAGE_KEYS.identity);
@@ -106,12 +106,13 @@
 
   function loadInstances() {
     const raw = localStorage.getItem(STORAGE_KEYS.instances);
-    if (!raw) return instanceDefs.filter((item) => item.activeByDefault).map((item) => item.id);
+    const defaults = instanceDefs.filter((item) => item.activeByDefault).map((item) => item.id);
+    if (!raw) return defaults;
     try {
       const parsed = JSON.parse(raw);
-      return Array.isArray(parsed) && parsed.length ? parsed : instanceDefs.filter((item) => item.activeByDefault).map((item) => item.id);
+      return Array.isArray(parsed) && parsed.length ? canonicalRoleOrder(parsed) : defaults;
     } catch {
-      return instanceDefs.filter((item) => item.activeByDefault).map((item) => item.id);
+      return defaults;
     }
   }
 
@@ -149,7 +150,7 @@
   }
 
   function escapeHtml(text) {
-    return text
+    return String(text || '')
       .replaceAll('&', '&amp;')
       .replaceAll('<', '&lt;')
       .replaceAll('>', '&gt;')
@@ -166,12 +167,12 @@
     identityHandle.value = identity.handle || '';
 
     if (identity.handle || identity.email) {
-      const mode = backend.available ? 'connected' : 'local';
-      identityState.innerHTML = `<strong>${escapeHtml(identity.handle || 'Visitor')}</strong><br>${escapeHtml(identity.email || 'local chamber shell identity active')}<br><small>${escapeHtml(mode)} mode</small>`;
+      const mode = backend.available && sessionToken ? 'shared backend' : 'local browser';
+      identityState.innerHTML = `<strong>${escapeHtml(identity.handle || 'Visitor')}</strong><br>${escapeHtml(identity.email || 'email not needed for local prototype')}<br><small>${escapeHtml(mode)}</small>`;
     } else {
       identityState.textContent = backend.available
-        ? 'No session active yet. Enter a handle and email to join the shared room.'
-        : 'No chamber identity stored yet. Enter a handle to anchor your presence in this shell.';
+        ? 'Add a handle and email to use the shared room, or add only a handle for the local prototype.'
+        : 'No handle saved yet. Add one to label your reflections in this browser.';
     }
   }
 
@@ -184,10 +185,10 @@
       card.innerHTML = `
         <header>
           <h3>${instance.title}</h3>
-          <button type="button">${active ? 'Attached' : 'Attach'}</button>
+          <button type="button">${active ? 'Selected' : 'Select'}</button>
         </header>
         <p>${instance.summary}</p>
-        <small>${active ? 'Will join the next round.' : 'Inactive for the next round.'}</small>
+        <small>${active ? 'Will shape the next reflection.' : 'Off for the next reflection.'}</small>
       `;
       card.querySelector('button').addEventListener('click', () => toggleInstance(instance.id));
       rosterRoot.appendChild(card);
@@ -211,23 +212,24 @@
   }
 
   function renderSynthesis() {
-    synthesisRoot.innerHTML = `<strong>Current synthesis</strong><p>${escapeHtml(synthesis)}</p>`;
+    synthesisRoot.innerHTML = `<strong>Current reflection</strong><p>${escapeHtml(synthesis)}</p>`;
   }
 
   function updatePulse() {
     const count = activeInstances.length;
     const handle = identity.handle || 'Visitor';
-    modePill.textContent = count > 1 ? 'Mode: Council' : count === 1 ? 'Mode: Focused dialogue' : 'Mode: Human-only';
-    const source = backend.available ? 'shared room' : 'local specimen';
-    pulsePill.textContent = `Pulse: ${handle} with ${count} attached ${count === 1 ? 'instance' : 'instances'} / ${source}`;
+    modePill.textContent = count > 1 ? 'Mode: Perspective reflection' : count === 1 ? 'Mode: Single lens' : 'Mode: Human note';
+    const source = backend.available && sessionToken ? 'shared room' : 'local browser';
+    pulsePill.textContent = `Pulse: ${handle} / ${count} ${count === 1 ? 'perspective' : 'perspectives'} / ${source}`;
   }
 
   function inferTopic(message) {
     const text = message.toLowerCase();
-    if (text.includes('website') || text.includes('site')) return 'website';
-    if (text.includes('build') || text.includes('ship') || text.includes('make')) return 'build';
-    if (text.includes('social') || text.includes('people') || text.includes('community')) return 'social';
-    if (text.includes('ai') || text.includes('instance') || text.includes('bot')) return 'ai';
+    if (text.includes('chamber') || text.includes('website') || text.includes('site') || text.includes('page') || text.includes('copy')) return 'website';
+    if (text.includes('build') || text.includes('make') || text.includes('prototype') || text.includes('project')) return 'build';
+    if (text.includes('people') || text.includes('audience') || text.includes('visitor') || text.includes('community')) return 'human';
+    if (text.includes('ai') || text.includes('bot') || text.includes('agent') || text.includes('role')) return 'ai';
+    if (text.includes('confus') || text.includes('stuck') || text.includes('lost') || text.includes('unclear')) return 'clarity';
     return 'general';
   }
 
@@ -235,25 +237,28 @@
     const topic = inferTopic(message);
     const map = {
       primary: {
-        website: 'The strongest move is to let the site become a threshold-space instead of only a brochure. The chamber should feel like a place people can enter, not just read about.',
-        build: 'The next believable move is to make the first layer tangible and socially legible. A chamber shell gives the project somewhere visible to stand.',
-        social: 'Social energy comes from returnable identity, visible presence, and a room that feels inhabited even between posts.',
-        ai: 'The user does not need provider-diverse multibot first. They need distinct, role-bound intelligences that feel coherent in one room.',
-        general: 'The chamber should translate the project into a room with identity, flow, and visible coherence.'
-      },
-      critic: {
-        website: 'If the chamber is only aesthetic, it will collapse into a novelty panel. The room has to show actual turn order, identity, and synthesis.',
-        build: 'Do not pretend the whole host exists yet. The shell must stay honest about what is local, what is governed, and what still needs backend infrastructure.',
-        social: 'Free social use without caps or moderation becomes noise and cost drift. The room must remain governable.',
-        ai: 'Three generic voices are not enough. The roles must feel visibly different or the plurality reads as theater.',
-        general: 'The weak point is always fake depth. The chamber has to earn the feeling of presence through structure.'
+        website: 'You seem to be asking whether the page gives a visitor a real reason to stay. The useful test is simple: can someone do something here and understand the result?',
+        build: 'The thought has build energy. It wants a small version that can be tried before it becomes a larger system.',
+        human: 'The human need underneath this is orientation. A visitor should know what to do, what happened, and why it mattered.',
+        ai: 'You are circling the difference between a named role and a real working response. The role needs to be useful before it needs to be grand.',
+        clarity: 'This sounds like a request for a cleaner first step. The next move should reduce noise, not add features.',
+        general: 'The thought seems to be asking for shape. Something interesting is present, but it needs a smaller handle.'
       },
       synthesizer: {
-        website: 'The site can now begin to perform the project, not merely describe it.',
-        build: 'The practical next move is clear: add real auth, shared persistence, and provider-backed orchestration behind this shell.',
-        social: 'A returnable human identity plus bounded AI plurality is the heart of the chamber pattern.',
-        ai: 'Governed roles first, true multibot routing later, is the clean expansion path.',
-        general: 'The chamber becomes believable when human identity, bounded plurality, and synthesis appear together.'
+        website: 'Try one concrete improvement: rewrite the page around the action a visitor can take right now, then place future plans below that.',
+        build: 'Make the first version do one thing well. A small working loop will teach more than a large promise.',
+        human: 'Give the visitor a short path: write something, choose lenses, read the reflection, then decide what to do next.',
+        ai: 'Keep the current version honest: scripted lenses now, live AI-backed roles later.',
+        clarity: 'Choose one sentence as the working goal, then cut every label that makes the page sound larger than that goal.',
+        general: 'Turn the thought into a one-step experiment. The smallest useful version is the safest next build.'
+      },
+      critic: {
+        website: 'Watch the gap between language and payoff. If the page sounds bigger than what it delivers, the visitor will feel the mismatch immediately.',
+        build: 'Do not hide behind prototype language either. Even a prototype should give a clean, satisfying result.',
+        human: 'Avoid insider terms. A visitor should not need the whole Ethereon vocabulary to understand the room.',
+        ai: 'Do not imply live AI or multibot behavior until the backend actually supports it.',
+        clarity: 'If the next step cannot be explained in plain language, it is probably still too large.',
+        general: 'The risk is vague importance. Make the result plain, useful, and proportionate.'
       }
     };
     return map[roleId][topic];
@@ -261,11 +266,13 @@
 
   function synthesisResponse(message, handle) {
     const topic = inferTopic(message);
-    if (topic === 'website') return `${handle || 'The visitor'} is pushing the website toward embodiment: chamber as living threshold rather than static description.`;
-    if (topic === 'build') return `The room is pointing toward the next build layer: real auth, shared room persistence, and orchestration behind the shell.`;
-    if (topic === 'social') return `The gathered signal is social in a real sense: returnable identity, bounded plurality, and coherence under use.`;
-    if (topic === 'ai') return `The chamber's current logic favors governed plurality over swarm behavior. That is the stable bridge to true multibot later.`;
-    return `The round converges on the same core: make the chamber feel inhabited, governed, and returnable.`;
+    const name = handle || 'The visitor';
+    if (topic === 'website') return `${name} is testing the page against its human payoff. The next improvement is to keep the copy small and make the working loop obvious.`;
+    if (topic === 'build') return `${name} is pointing toward a practical next step: build the smallest useful version first, then let the larger system grow from evidence.`;
+    if (topic === 'human') return `${name} is asking for a better visitor experience. The room should make the action, result, and purpose easy to understand.`;
+    if (topic === 'ai') return `${name} is separating current function from future infrastructure: use simple perspectives now, and reserve live AI-backed roles for a later version.`;
+    if (topic === 'clarity') return `${name} is asking for less noise. The next step is to name the goal plainly and remove language that overstates the result.`;
+    return `${name} brought a thought that needs shape. The useful move is to make one small version clear enough to try.`;
   }
 
   function localPostRound(message) {
@@ -274,7 +281,7 @@
       id: crypto.randomUUID(),
       kind: 'human',
       author: handle,
-      title: 'Human post',
+      title: 'Your thought',
       text: message,
       createdAt: new Date().toISOString()
     }];
@@ -285,7 +292,7 @@
         id: crypto.randomUUID(),
         kind: `ai-${instanceId}`,
         author: instance.title,
-        title: `${instance.title} / chamber response`,
+        title: `${instance.title} / perspective`,
         text: roleResponse(instanceId, message),
         createdAt: new Date().toISOString()
       });
@@ -304,11 +311,11 @@
     let title = 'Human post';
     if (message.authorType === 'ai' && message.roleName) {
       kind = `ai-${message.roleName}`;
-      title = `${message.authorLabel} / chamber response`;
+      title = `${message.authorLabel} / perspective`;
     }
     if (message.authorType === 'synthesis') {
       kind = 'ai-synthesizer';
-      title = 'Synthesis / gathered signal';
+      title = 'Reflection / summary';
     }
 
     return {
@@ -345,7 +352,7 @@
       }
     }
 
-    return { available: false, base: '', mode: 'local specimen' };
+    return { available: false, base: '', mode: 'local prototype' };
   }
 
   async function fetchJson(path, options = {}) {
@@ -447,12 +454,20 @@
       handle: identityHandle.value.trim()
     };
 
-    if (!identity.email || !identity.handle) {
-      renderIdentity();
+    if (!identity.handle) {
+      identityState.textContent = 'Add a handle to label your local reflections.';
       return;
     }
 
     if (backend.available) {
+      if (!identity.email) {
+        identityState.textContent = 'Email is only needed for the shared backend. Add one to join that mode, or continue locally if the backend is unavailable.';
+        saveIdentity();
+        renderIdentity();
+        updatePulse();
+        return;
+      }
+
       try {
         const payload = await fetchJson('/api/auth/signup', {
           method: 'POST',
@@ -467,7 +482,7 @@
         activeInstances = canonicalRoleOrder(payload.user.attachedRoles || DEFAULT_INSTANCE_ORDER);
         await loadBackendMessages();
       } catch (error) {
-        identityState.textContent = error instanceof Error ? error.message : 'Unable to enter chamber';
+        identityState.textContent = error instanceof Error ? error.message : 'Unable to save chamber handle';
         return;
       }
     }
@@ -495,7 +510,7 @@
 
     if (backend.available) {
       if (!sessionToken) {
-        identityState.textContent = 'Enter the chamber with email and handle before posting to the shared room.';
+        identityState.textContent = 'Save a handle and email before posting to the shared room.';
         return;
       }
 

--- a/chamber.html
+++ b/chamber.html
@@ -4,16 +4,16 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EthereonLabs - Chamber</title>
-  <meta name="description" content="Enter the first public chamber shell: a BBS-style social threshold-space for governed human and AI interaction." />
+  <meta name="description" content="Try the Chamber: an early local prototype for structured reflection using a handle, selected perspectives, and a short summary." />
   <link rel="canonical" href="https://ethereonlabs.com/chamber" />
   <meta property="og:site_name" content="EthereonLabs" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="EthereonLabs - Chamber" />
-  <meta property="og:description" content="A first public chamber shell for social, multi-presence interaction shaped by Lumina principles." />
+  <meta property="og:description" content="An early prototype for structured reflection: add a thought, choose perspectives, and get a short response back." />
   <meta property="og:url" content="https://ethereonlabs.com/chamber" />
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="EthereonLabs - Chamber" />
-  <meta name="twitter:description" content="A first public chamber shell for social, multi-presence interaction shaped by Lumina principles." />
+  <meta name="twitter:description" content="An early prototype for structured reflection: add a thought, choose perspectives, and get a short response back." />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
@@ -47,16 +47,16 @@
       <section class="hero chamber-hero">
         <div class="container chamber-hero-grid">
           <div>
-            <span class="eyebrow">Public chamber shell</span>
-            <h1>Enter the first social threshold-space.</h1>
-            <p class="lead">This is the first public chamber shell: a BBS-style environment where a human identity, a shared room, attached AI roles, and visible synthesis can begin to live together.</p>
-            <p class="hero-note">This release is a local specimen of the interaction model. Real account infrastructure, persistent shared rooms, and provider-backed multibot orchestration come next.</p>
+            <span class="eyebrow">Chamber prototype</span>
+            <h1>Try the Chamber.</h1>
+            <p class="lead">Add a thought. Pick a few perspectives. Get a short reflection back.</p>
+            <p class="hero-note">This is an early local prototype. It does not use real accounts or live AI roles yet. For now, it gives visitors one simple working loop inside the browser.</p>
           </div>
           <aside class="status-banner chamber-launch-note">
             <div>
               <small>Current state</small>
-              <h3>Shell phase</h3>
-              <p class="section-copy">Light identity, one room, local persistence, attachable roles, sequential AI rounds, and synthesis are present here as the first visible layer.</p>
+              <h3>Working local prototype</h3>
+              <p class="section-copy">Use a light handle, choose perspective lenses, post a thought, and receive a short scripted reflection. Shared rooms and live AI-backed roles are future work.</p>
             </div>
           </aside>
         </div>
@@ -68,11 +68,11 @@
             <div class="chamber-topbar">
               <div>
                 <small>Chamber</small>
-                <strong>Lumina Chamber / Public Room One</strong>
+                <strong>Reflection Room One</strong>
               </div>
               <div class="chamber-topbar-meta">
-                <span id="chamberModePill">Mode: Observation</span>
-                <span id="chamberPulsePill">Pulse: Gathering signal</span>
+                <span id="chamberModePill">Mode: Reflection prototype</span>
+                <span id="chamberPulsePill">Pulse: Ready</span>
               </div>
             </div>
 
@@ -81,19 +81,19 @@
                 <section class="chamber-panel">
                   <div class="panel-title-row">
                     <h2>Identity</h2>
-                    <span class="panel-tag">light account</span>
+                    <span class="panel-tag">local handle</span>
                   </div>
                   <form id="identityForm" class="identity-form">
                     <label>
-                      <span>Email</span>
+                      <span>Email <small>(optional in this prototype)</small></span>
                       <input id="identityEmail" name="email" type="email" placeholder="you@example.com" />
                     </label>
                     <label>
                       <span>Chamber handle</span>
-                      <input id="identityHandle" name="handle" type="text" maxlength="24" placeholder="ArchitectOfResonance" />
+                      <input id="identityHandle" name="handle" type="text" maxlength="24" placeholder="Spencer" />
                     </label>
                     <div class="identity-actions">
-                      <button class="button primary ping-target" type="submit">Enter chamber</button>
+                      <button class="button primary ping-target" type="submit">Save handle</button>
                       <button class="button secondary ping-target" id="identityClear" type="button">Clear</button>
                     </div>
                   </form>
@@ -102,35 +102,35 @@
 
                 <section class="chamber-panel">
                   <div class="panel-title-row">
-                    <h2>Attached AI instances</h2>
-                    <span class="panel-tag">max 3</span>
+                    <h2>Perspectives</h2>
+                    <span class="panel-tag">choose up to 3</span>
                   </div>
                   <div id="instanceRoster" class="instance-roster"></div>
-                  <p class="microcopy">The first public chamber uses governed roles rather than free swarm behavior.</p>
+                  <p class="microcopy">These are simple local lenses, not live AI accounts yet.</p>
                 </section>
               </aside>
 
               <section class="chamber-column chamber-column-center">
                 <div class="chamber-panel chamber-thread-panel">
                   <div class="panel-title-row">
-                    <h2>Public room thread</h2>
-                    <span class="panel-tag">council flow</span>
+                    <h2>Reflection thread</h2>
+                    <span class="panel-tag">preview</span>
                   </div>
                   <div id="threadRoot" class="thread-root" aria-live="polite"></div>
                 </div>
 
                 <form id="composerForm" class="composer-panel chamber-panel">
                   <div class="panel-title-row">
-                    <h2>Post to room</h2>
-                    <span class="panel-tag">human → roles → synthesis</span>
+                    <h2>Add a thought</h2>
+                    <span class="panel-tag">thought → perspectives → reflection</span>
                   </div>
                   <label>
-                    <span>Your message</span>
-                    <textarea id="composerInput" rows="4" placeholder="State an idea, ask a question, or open a direction for the chamber."></textarea>
+                    <span>Your thought</span>
+                    <textarea id="composerInput" rows="4" placeholder="Write something you are thinking about, building, questioning, or trying to clarify."></textarea>
                   </label>
                   <div class="composer-actions">
-                    <button class="button primary ping-target" type="submit">Post to chamber</button>
-                    <button class="button secondary ping-target" id="resetThread" type="button">Reset preview</button>
+                    <button class="button primary ping-target" type="submit">Reflect it back</button>
+                    <button class="button secondary ping-target" id="resetThread" type="button">Reset example</button>
                   </div>
                 </form>
               </section>
@@ -138,25 +138,25 @@
               <aside class="chamber-column chamber-column-right">
                 <section class="chamber-panel">
                   <div class="panel-title-row">
-                    <h2>Room synthesis</h2>
-                    <span class="panel-tag">live summary</span>
+                    <h2>Reflection</h2>
+                    <span class="panel-tag">short summary</span>
                   </div>
                   <div id="synthesisRoot" class="synthesis-root">
-                    <p>No synthesis yet. Enter the chamber and post to the room.</p>
+                    <p>No reflection yet. Add a thought to try the prototype.</p>
                   </div>
                 </section>
 
                 <section class="chamber-panel">
                   <div class="panel-title-row">
-                    <h2>Room notes</h2>
-                    <span class="panel-tag">v1 shell</span>
+                    <h2>Prototype notes</h2>
+                    <span class="panel-tag">current version</span>
                   </div>
                   <ul class="chamber-notes">
-                    <li>One public room.</li>
-                    <li>Local identity persistence in this shell.</li>
-                    <li>Up to three governed AI roles.</li>
-                    <li>Sequential responses followed by synthesis.</li>
-                    <li>Backend auth, shared persistence, and true provider-backed multibot access are the next layer.</li>
+                    <li>Runs locally in this browser.</li>
+                    <li>Saves your handle and thread on this device.</li>
+                    <li>Uses selectable perspective lenses.</li>
+                    <li>Returns simple scripted reflections for now.</li>
+                    <li>Live accounts, shared rooms, and real AI-backed roles are future work.</li>
                   </ul>
                 </section>
               </aside>
@@ -168,7 +168,7 @@
 
     <footer class="footer">
       <div class="container footer-row">
-        <div>EthereonLabs — Chamber shell for adaptive digital environments.</div>
+        <div>EthereonLabs — Chamber prototype for structured reflection.</div>
         <div><span data-year></span></div>
       </div>
     </footer>

--- a/docs/chamber_internal_alignment_001.md
+++ b/docs/chamber_internal_alignment_001.md
@@ -1,0 +1,112 @@
+# Chamber Internal Alignment 001 — Human-Scale Public Promise
+
+**Area:** EthereonLabs website / Chamber  
+**Status:** Internal alignment note  
+**Public surface:** `/chamber`  
+**Change type:** copy, interaction framing, scope boundary
+
+## Purpose
+
+The Chamber page should make a clear, honest promise to a first-time human visitor.
+
+The public page should not lead with large-system language such as social threshold-space, AI swarm, social network, multibot platform, or provider-backed orchestration unless that capability is already available to the visitor on the page.
+
+The current public promise is smaller and stronger:
+
+> Add a thought. Pick a few perspectives. Get a short reflection back.
+
+That sentence is the public contract for the current version.
+
+## Public framing rule
+
+Use plain visitor-facing language first.
+
+Preferred public terms:
+
+- Chamber prototype
+- local handle
+- perspectives
+- reflection thread
+- add a thought
+- reflect it back
+- short summary
+- prototype notes
+
+Avoid public-first terms until the corresponding capability is real:
+
+- first social threshold-space
+- attached AI instances
+- AI swarm
+- social network
+- multibot platform
+- provider-backed orchestration
+- shared room infrastructure
+- persistent public identity
+
+Those larger terms may remain in internal architecture, roadmap, or development notes, but they should not be the first promise on the visitor-facing Chamber page.
+
+## Current capability boundary
+
+The present Chamber page is a local browser prototype.
+
+It may truthfully say that it:
+
+1. stores a light handle locally;
+2. lets the visitor choose perspective lenses;
+3. accepts a thought or question;
+4. returns scripted perspective responses;
+5. produces a short reflection summary;
+6. saves the local thread on the visitor's device.
+
+It should not imply that it currently provides:
+
+1. real user accounts;
+2. persistent shared rooms;
+3. live AI-backed roles;
+4. autonomous multi-agent behavior;
+5. social networking features;
+6. provider-diverse orchestration.
+
+## Internal architectural continuity
+
+The larger Chamber direction remains valid internally:
+
+- returnable human identity;
+- room-based interaction;
+- role-bound AI perspectives;
+- visible synthesis;
+- future shared persistence;
+- future live provider-backed AI roles;
+- eventual governed multi-presence architecture.
+
+The internal architecture should preserve the larger path without making the public prototype sound more complete than it is.
+
+## Design principle
+
+A prototype can be modest and still meaningful.
+
+The Chamber should earn trust by doing one small thing clearly before naming the larger system it may eventually become.
+
+## Visitor test
+
+A first-time visitor should be able to answer these questions within a few seconds:
+
+1. What is this?
+2. What can I do here?
+3. What happens when I do it?
+4. Is this live infrastructure or a local prototype?
+
+If any answer requires Ethereon vocabulary, the public copy is too large.
+
+## Future promotion rule
+
+As real backend features are added, public language may expand only when the feature is actually available.
+
+Examples:
+
+- Add “shared room” only when multiple visitors can see the same room state.
+- Add “account” only when authentication and durable user records exist.
+- Add “AI role” only when role responses are backed by live model calls or explicitly labeled as simulated/scripted.
+- Add “multibot” only when more than one model/provider/agent process is actually orchestrated.
+
+Until then, keep the public page small, clear, and useful.


### PR DESCRIPTION
## Summary

This PR updates the Chamber from a large public promise into a smaller, more honest working prototype.

### External / visitor-facing updates
- Replaces “first social threshold-space” framing with a plain prototype promise: add a thought, pick perspectives, get a short reflection.
- Renames public UI labels from larger system language to human-readable prototype language.
- Clarifies that the current Chamber is local/browser-based and does not yet provide real accounts, shared rooms, or live AI-backed roles.
- Updates metadata and footer copy to match the scaled-down public promise.

### Interaction updates
- Retunes the local loop around selectable perspective lenses: Witness, Builder, and Skeptic.
- Replaces “attached AI instances” / “council flow” / “human → roles → synthesis” phrasing with simpler reflection language.
- Updates seeded example responses and scripted local responses to emphasize usefulness, modest scope, and human payoff.

### Internal alignment
- Adds `docs/chamber_internal_alignment_001.md` to preserve the larger Chamber roadmap internally while keeping the public page honest until those capabilities exist.

## Files changed
- `chamber.html`
- `assets/js/chamber.js`
- `docs/chamber_internal_alignment_001.md`

## Notes

The larger Chamber direction is not discarded. It is moved behind an honesty boundary: public copy should only name features the visitor can actually experience now.