### PR TITLE
Add Lumina Studio runtime loop v0.1

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md
@@ -22,6 +22,7 @@ This folder is the GitHub bootstrap import for beginning **Lumina OS** from the 
 - repo-native workspace host proof
 - bounded self-guidance steward and checkpoint-linked advisory history
 - bounded orchestration lane built from context loader, decision engine, and orchestrator
+- Lumina Studio v0.1 local operator surface for running governed runtime cycles
 
 ## Current status
 
@@ -38,6 +39,46 @@ The repo-native layer now includes working proofs that Lumina can:
 
 In parallel, the Chamber lane now contains an advisory acceptance / rejection surface and a supervised action queue with both memory and Postgres-backed persistence.
 That Chamber work is not the Lumina substrate itself, but it is becoming the first consent surface adjacent to the substrate.
+
+Lumina Studio v0.1 now provides the first intentionally plain local control surface for running one governed cycle and seeing its receipt.
+Studio does not create runtime law. It packages a request, delegates to `runtime/runtime_runner_r1_merged.py`, and reports checkpoint, governance, capability, halt, and optional probe/return-host artifacts.
+
+Primary Studio files:
+
+- `studio/README.md`
+- `studio/lumina_cli.py`
+- `studio/lumina_studio_server.py`
+- `docs/lumina_studio_v0_1_spec.md`
+- `docs/lumina_next_build_plan_001.md`
+- `sea_trials_lumina_studio_v0_1.py`
+
+## Lumina Studio quick start
+
+Run a local governed cycle from the bootstrap folder:
+
+```bash
+python studio/lumina_cli.py "Review Lumina OS progress and produce the next governed action receipt."
+```
+
+Run the local browser surface:
+
+```bash
+python studio/lumina_studio_server.py
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8765/studio
+```
+
+Run the Studio sea trial:
+
+```bash
+python sea_trials_lumina_studio_v0_1.py
+```
+
+Studio is local-first. Do not expose it publicly without authentication, request authorization, rate limiting, and a clear persistence policy.
 
 ## Quantum-concepts boundary
 
@@ -85,11 +126,12 @@ Current CI trigger note:
 
 The remaining hardening priority is less about inventing new core law and more about tightening the whole into a cleaner beta shape:
 
-- keep runtime, orchestration, Chamber, quantum-boundary, and continuity-validation lanes clearly linked in docs
+- keep runtime, orchestration, Chamber, quantum-boundary, Studio, and continuity-validation lanes clearly linked in docs
 - reduce operator friction through better entrypoint scripts and runbooks
 - continue proving that advisory outputs remain subordinate to runtime governance
 - connect accepted Chamber queue items to governed execution records while preserving consent and runtime law
 - verify that quantum-inspired terminology remains expressive/advisory and never becomes hidden governance law
+- extend Studio into a state browser and governance decision viewer without turning it into a shadow authority
 
 ## Intent
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_next_build_plan_001.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_next_build_plan_001.md
@@ -1,0 +1,98 @@
+# Lumina Next Build Plan 001 — Studio Runtime Loop
+
+**Decision:** build the usable Lumina loop before adding more conceptual architecture.
+
+## Diagnosis
+
+Lumina OS already has meaningful substrate:
+
+- governed runtime runner
+- session engine
+- mode guard
+- context bundles
+- input integrity gate
+- capability registry
+- governance integrity chain
+- canon lineage store
+- continuity restore / workspace host lane
+- self-guidance and orchestration experiments
+- bounded Psi-42 instrument
+
+The bottleneck is not the absence of structure.
+
+The bottleneck is operator friction.
+
+The project needs a way to run the structure, see what happened, and build from receipts.
+
+## Build target
+
+Create Lumina Studio v0.1:
+
+```text
+operator request -> Studio wrapper -> governed runtime runner -> checkpoint/governance receipt
+```
+
+## Why this is first
+
+Without Studio, the project remains too dependent on direct file knowledge and conversational memory.
+
+With Studio, Lumina starts acting less like a pile of excellent artifacts and more like a local runtime environment.
+
+## Scope
+
+### Add
+
+- `studio/lumina_cli.py`
+- `studio/lumina_studio_server.py`
+- `studio/README.md`
+- `docs/lumina_studio_v0_1_spec.md`
+- `docs/lumina_next_build_plan_001.md`
+- `sea_trials_lumina_studio_v0_1.py`
+
+### Update
+
+- bootstrap README with Studio note
+- `START_HERE_LUMINA_OS.md` with Studio as operator entrypoint
+
+## What to avoid
+
+Do not:
+
+- redesign the public website
+- expand Chamber promises
+- create a competing runtime law layer
+- treat Studio orientation as governance authority
+- deploy the local server publicly
+- use Studio to authorize ambiguous load-bearing actions silently
+
+## First proof
+
+The first useful proof is humble:
+
+```text
+Lumina Studio can run one governed audit cycle and return a readable receipt.
+```
+
+That means:
+
+- input integrity runs
+- Observation transition is lawful
+- mutation remains denied for audit path where appropriate
+- capabilities are exposed by mode and feature flags
+- checkpoint is written
+- governance chain status is returned
+- optional Lumina return/host handshake can be recorded when capabilities expose it
+
+## Studio v0.2 target
+
+After v0.1 lands, build:
+
+1. state browser over `.lumina_state`
+2. governance decision viewer
+3. saved presets for common mode/orientation combinations
+4. accepted Chamber queue -> governed Studio runtime cycle
+5. authentication design before any network exposure
+
+## Guiding sentence
+
+Make Lumina runnable before making Lumina grander.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_studio_v0_1_spec.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_studio_v0_1_spec.md
@@ -1,0 +1,206 @@
+# Lumina Studio v0.1 Specification
+
+**Lane:** Lumina OS governed substrate  
+**Status:** first-pass operator surface  
+**Authority:** launcher / receipt viewer only  
+**Primary path:** `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/`
+
+## Purpose
+
+Lumina Studio v0.1 exists to convert the current governed runtime scaffold into something an operator can actually run.
+
+The purpose is not to make Lumina OS visually impressive. The purpose is to prove that a complete, bounded cycle can be initiated and inspected without requiring direct hand-editing of runtime arguments.
+
+## Core claim
+
+Lumina OS progress now depends on a usable spine-to-interface bridge.
+
+Studio is that bridge.
+
+## User story
+
+As an operator, I can enter a request, choose a mode and stance, run one Lumina cycle, and receive a receipt showing what the runtime did, what it refused, which capabilities were exposed, and where the checkpoint/governance records live.
+
+## Inputs
+
+Studio accepts:
+
+- operator request text
+- current mode
+- target mode
+- action type
+- project id
+- focus
+- depth
+- intent
+- optional annotation
+- optional expressive overlay flag
+
+## Mode and action defaults
+
+Default mode path:
+
+```text
+Continuity -> Observation
+```
+
+Default action type:
+
+```text
+audit
+```
+
+This is the safest useful default because it allows inspection without mutation.
+
+## Orientation stance
+
+Studio attaches orientation as supplemental context only:
+
+```json
+{
+  "focus": "continuity",
+  "depth": "structural",
+  "intent": "verify",
+  "authority": "supplemental only; does not govern mode legality, mutation, promotion, or canon lineage"
+}
+```
+
+This follows the project principle:
+
+> Mode is law. Orientation is stance.
+
+Mode determines what may happen. Orientation helps describe what kind of work is being requested.
+
+## Runtime ownership
+
+Studio delegates to `runtime_runner_r1_merged.py`.
+
+The runner remains responsible for:
+
+- session creation
+- context bundle construction
+- input integrity assessment
+- Ethereonic boundary checks
+- transition validation
+- mutation validation
+- promotion validation when requested
+- symbolic dependency leakage checks
+- capability exposure
+- optional Lumina return/host handshake
+- optional Psi-42 probe execution
+- checkpoint writing
+- governance chain reporting
+- canon lineage metadata reporting
+
+## Non-goals
+
+Studio v0.1 does not:
+
+- implement a full operating system shell
+- replace Chamber
+- provide multi-user collaboration
+- perform background autonomous work
+- create new governance law
+- deploy a public service
+- persist a polished human history browser
+
+## Interfaces
+
+### CLI
+
+File:
+
+```text
+studio/lumina_cli.py
+```
+
+Basic usage:
+
+```bash
+python studio/lumina_cli.py "Review Lumina OS progress."
+```
+
+Output modes:
+
+- human receipt
+- compact JSON receipt
+- full JSON result
+
+### Local browser surface
+
+File:
+
+```text
+studio/lumina_studio_server.py
+```
+
+Basic usage:
+
+```bash
+python studio/lumina_studio_server.py
+```
+
+Local URL:
+
+```text
+http://127.0.0.1:8765/studio
+```
+
+## Receipt fields
+
+The compact receipt should surface:
+
+- run id
+- created time
+- mode path
+- action type
+- halted flag
+- halt reason
+- session id
+- context bundle id
+- checkpoint path
+- result log path
+- governance log path
+- governance chain validity
+- current canon head if available
+- exposed capability ids
+- input confidence / recommended behavior
+- optional probe run id
+- optional Lumina project id
+
+## Safety boundary
+
+The local server is for local use only.
+
+Before any public deployment, the project needs:
+
+- authentication
+- request authorization
+- rate limiting
+- persistence policy
+- explicit consent flow
+- clear separation from Chamber public pages
+
+## First sea trial
+
+A minimal pass looks like:
+
+1. CLI run completes.
+2. Result is not halted for default audit path.
+3. Checkpoint path is present.
+4. Governance log path is present.
+5. At least structural capabilities are exposed.
+6. Governance chain status is returned.
+7. Studio orientation appears only in supplemental context.
+
+## Failure meaning
+
+If Studio cannot run one cycle, Lumina OS is still too architectural.
+
+If Studio can run one cycle but cannot explain what happened, Lumina OS is still too opaque.
+
+If Studio bypasses runtime law, Lumina OS has regressed.
+
+## Next version target
+
+Studio v0.2 should add a state browser over `.lumina_state` and a clearer governance decision viewer.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_v0_1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_v0_1.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Sea trial for Lumina Studio v0.1.
+
+Validates the first usable operator surface without granting it governance authority.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from argparse import Namespace
+from pathlib import Path
+from typing import Any, Dict, List
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parent
+STUDIO_ROOT = BOOTSTRAP_ROOT / "studio"
+if str(STUDIO_ROOT) not in sys.path:
+    sys.path.insert(0, str(STUDIO_ROOT))
+
+from lumina_cli import DEFAULT_FEATURE_FLAGS, compact_receipt, run_lumina_cycle  # noqa: E402
+
+
+def make_args(**overrides: Any) -> Namespace:
+    base: Dict[str, Any] = {
+        "prompt": ["Run Lumina Studio v0.1 verification cycle."],
+        "current_mode": "Continuity",
+        "target_mode": "Observation",
+        "action_type": "audit",
+        "action": "sea_trial_lumina_studio_v0_1",
+        "project_id": "lumina-studio-sea-trial",
+        "focus": "continuity",
+        "depth": "structural",
+        "intent": "verify",
+        "annotation": "Sea trial for Studio v0.1",
+        "note": "Studio verifier: control surface only.",
+        "feature_flags": list(DEFAULT_FEATURE_FLAGS),
+        "artifacts": [],
+        "ethereonic_overlay": False,
+        "json": False,
+        "receipt_json": True,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def evaluate_default_audit(receipt: Dict[str, Any]) -> Dict[str, bool]:
+    exposed = set(receipt.get("exposed_capability_ids") or [])
+    return {
+        "default_not_halted": receipt.get("halted") is False,
+        "target_mode_observation": receipt.get("target_mode") == "Observation",
+        "checkpoint_present": bool(receipt.get("checkpoint_path")),
+        "log_present": bool(receipt.get("log_path")),
+        "governance_log_present": bool(receipt.get("governance_log_path")),
+        "governance_chain_status_returned": receipt.get("governance_chain_valid") is not None,
+        "structural_capabilities_exposed": "session_state_manager" in exposed and "mode_guard" in exposed,
+    }
+
+
+def evaluate_denied_transition(receipt: Dict[str, Any]) -> Dict[str, bool]:
+    return {
+        "denied_transition_halted": receipt.get("halted") is True,
+        "halt_reason_mentions_illegal_transition": "illegal transition" in str(receipt.get("halt_reason") or ""),
+        "no_capabilities_exposed_after_halt": len(receipt.get("exposed_capability_ids") or []) == 0,
+    }
+
+
+def main() -> Dict[str, Any]:
+    results: List[Dict[str, Any]] = []
+
+    default_result = run_lumina_cycle(make_args())
+    default_receipt = compact_receipt(default_result)
+    default_checks = evaluate_default_audit(default_receipt)
+    results.append(
+        {
+            "trial_name": "studio_default_audit_cycle",
+            "passed": all(default_checks.values()),
+            "checks": default_checks,
+            "receipt": default_receipt,
+        }
+    )
+
+    denied_result = run_lumina_cycle(
+        make_args(
+            prompt=["Attempt illegal Studio transition."],
+            current_mode="Canon",
+            target_mode="Sandbox",
+            action_type="transition",
+            action="sea_trial_lumina_studio_denied_transition",
+            focus="governance_review",
+            annotation="Intentional illegal transition test",
+        )
+    )
+    denied_receipt = compact_receipt(denied_result)
+    denied_checks = evaluate_denied_transition(denied_receipt)
+    results.append(
+        {
+            "trial_name": "studio_denied_transition_receipt",
+            "passed": all(denied_checks.values()),
+            "checks": denied_checks,
+            "receipt": denied_receipt,
+        }
+    )
+
+    summary = {
+        "suite": "Lumina Studio v0.1 sea trial",
+        "passed": all(item["passed"] for item in results),
+        "trial_count": len(results),
+        "results": results,
+        "authority_boundary": "Studio launches runtime cycles and displays receipts only; runtime remains governance authority.",
+    }
+
+    report_dir = BOOTSTRAP_ROOT / ".studio_sea_trials"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / "lumina_studio_v0_1_report.json"
+    with report_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    summary["report_path"] = str(report_path)
+    return summary
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/README.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/README.md
@@ -1,0 +1,114 @@
+# Lumina Studio v0.1
+
+Lumina Studio is the first deliberately plain operator surface for the Lumina OS governed runtime substrate.
+
+It is not Chamber.  
+It is not a public social surface.  
+It is not a new governance authority.
+
+It is a local control surface that packages a request, invokes the existing runtime runner, and shows the receipt.
+
+## What Studio does
+
+- accepts an operator request
+- declares current mode, target mode, and action type
+- attaches an orientation stance as supplemental context
+- calls `runtime/runtime_runner_r1_merged.py`
+- lets the runtime own input integrity, mode legality, mutation gates, capability exposure, checkpoints, governance logs, canon metadata, and optional probe execution
+- returns a compact receipt with checkpoint, governance, exposed capabilities, and halt status
+
+## What Studio must not do
+
+- invent mode law
+- bypass `ModeGuard`
+- mutate canon directly
+- treat poetic or Ethereonic language as structural authority
+- replace Chamber or the public website
+- expose this local server publicly without authentication and persistence policy
+
+## CLI usage
+
+From this directory:
+
+```bash
+python lumina_cli.py "Review Lumina OS progress and produce the next governed action receipt."
+```
+
+Useful variants:
+
+```bash
+python lumina_cli.py "Inspect the runtime spine" \
+  --target-mode Observation \
+  --action-type audit \
+  --focus architecture \
+  --depth foundational \
+  --intent verify \
+  --receipt-json
+```
+
+```bash
+python lumina_cli.py "Draft the next Studio build step" \
+  --target-mode Sandbox \
+  --action-type audit \
+  --focus integration \
+  --intent build \
+  --ethereonic-overlay
+```
+
+## Local server usage
+
+```bash
+python lumina_studio_server.py
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8765/studio
+```
+
+The server is intentionally local-first and standard-library only. It should not be deployed as a public endpoint without authentication, rate limiting, and a clear persistence boundary.
+
+## Default cycle
+
+The default Studio cycle is an `audit` from `Continuity` to `Observation`.
+
+That is intentional. It gives us a safe first proof:
+
+1. preserve continuity context
+2. inspect without mutation
+3. expose lawful Observation capabilities
+4. write a checkpoint
+5. return a receipt
+
+## Authority boundary
+
+Studio is a launcher and receipt viewer.
+
+Runtime law remains owned by the runtime substrate:
+
+- `SessionEngine` owns session state, checkpoints, and resume behavior
+- `ModeGuard` owns transition legality, mutation permission, promotion gates, and symbolic dependency checks
+- `GovernanceLog` owns append-only runtime history
+- `CanonLineageStore` owns canon lineage metadata
+- `CapabilityRegistry` owns mode/feature-flag exposure
+- `Psi-42` remains optional and instrument-only when lawfully exposed
+
+## First-pass success criteria
+
+Studio v0.1 succeeds if it can:
+
+- run one governed cycle from CLI
+- run one governed cycle from local browser UI
+- return halt status instead of crashing on denied operations
+- show checkpoint and log paths
+- show exposed capability IDs
+- preserve orientation as supplemental stance, not governance law
+
+## Next hardening steps
+
+1. Add a richer result viewer for governance decisions.
+2. Add a saved-cycle browser over `.lumina_state`.
+3. Add a mode/action preset library.
+4. Wire accepted Chamber queue items into Studio/runtime cycles while preserving consent.
+5. Add authentication before any remote deployment.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_cli.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_cli.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Lumina Studio CLI v0.1.
+
+A small operator-facing bridge into the governed Lumina runtime.
+It does not create new governance law. It packages a request, calls the
+existing RuntimeRunner, and prints a human-readable receipt.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_ROOT = BOOTSTRAP_ROOT / "runtime"
+if str(RUNTIME_ROOT) not in sys.path:
+    sys.path.insert(0, str(RUNTIME_ROOT))
+
+try:
+    from runtime_runner_r1_merged import RuntimeRunner, VALID_ACTION_TYPES
+except Exception as exc:  # pragma: no cover - startup guard
+    raise RuntimeError(
+        "Lumina Studio could not import the governed runtime runner. "
+        f"Expected runtime at {RUNTIME_ROOT}."
+    ) from exc
+
+SAFE_RUNTIME_CONFIG: Dict[str, bool] = {
+    "toki_pona_required_for_resume": False,
+    "binary_required_for_transition_validation": False,
+    "light_language_required_for_capability_loading": False,
+    "harmonic_frequency_required_for_mode_legality": False,
+}
+
+DEFAULT_FEATURE_FLAGS = [
+    "ETHEREON_OBSERVATION",
+    "ETHEREON_PSI42",
+    "ETHEREON_RESONANCE",
+    "ETHEREON_CONTINUITY_RESTORE",
+    "ETHEREON_LUMINA_HOST",
+]
+
+DEFAULT_ARTIFACTS = [
+    "runtime/runtime_spine_r1.py",
+    "runtime/runtime_runner_r1_merged.py",
+    "runtime/capability_registry_r1.json",
+    "runtime/input_integrity_layer_r1.py",
+    "runtime/governance_integrity_r1.py",
+    "runtime/canon_lineage_store_r1.py",
+    "studio/lumina_cli.py",
+    "studio/lumina_studio_server.py",
+]
+
+
+def _coerce_prompt(parts: List[str], fallback: str) -> str:
+    prompt = " ".join(part for part in parts if part).strip()
+    return prompt or fallback
+
+
+def _request_slug(text: str) -> str:
+    safe = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in text.strip())
+    safe = "_".join(token for token in safe.split("_") if token)
+    return (safe[:80] or "lumina_studio_cycle").lower()
+
+
+def build_orientation_payload(
+    *,
+    focus: str,
+    depth: str,
+    intent: str,
+    annotation: Optional[str],
+) -> Dict[str, Any]:
+    """Attach orientation as supplemental stance, not governance law."""
+    return {
+        "focus": focus,
+        "depth": depth,
+        "intent": intent,
+        "annotation": annotation,
+        "authority": "supplemental only; does not govern mode legality, mutation, promotion, or canon lineage",
+        "schema_version": "lumina-studio-orientation-v0.1",
+    }
+
+
+def compact_receipt(result: Dict[str, Any]) -> Dict[str, Any]:
+    governance = result.get("governance", {}) or {}
+    exposed = result.get("exposed_capabilities", []) or []
+    return {
+        "run_id": result.get("run_id"),
+        "created_at": result.get("created_at"),
+        "requested_mode": result.get("requested_mode"),
+        "target_mode": result.get("target_mode"),
+        "action_type": result.get("action_type"),
+        "halted": result.get("halted"),
+        "halt_reason": result.get("halt_reason"),
+        "session_id": result.get("session_id"),
+        "context_bundle_id": result.get("context_bundle_id"),
+        "checkpoint_path": result.get("checkpoint_path"),
+        "log_path": result.get("log_path"),
+        "governance_log_path": result.get("governance_log_path"),
+        "governance_chain_valid": (result.get("governance_chain_status") or {}).get("valid"),
+        "canon_head": (result.get("canon_lineage") or {}).get("current_head"),
+        "exposed_capability_ids": [cap.get("capability_id") for cap in exposed],
+        "governance_keys": sorted(governance.keys()),
+        "input_confidence": (governance.get("input_integrity") or {}).get("confidence_label"),
+        "input_behavior": (governance.get("input_integrity") or {}).get("recommended_behavior"),
+        "probe_run_id": (result.get("probe_artifacts") or {}).get("run_id"),
+        "lumina_project_id": (result.get("lumina_return_host_artifacts") or {}).get("project_id"),
+    }
+
+
+def run_lumina_cycle(args: argparse.Namespace) -> Dict[str, Any]:
+    prompt = _coerce_prompt(args.prompt, "Lumina Studio runtime cycle")
+    requested_action = args.action or _request_slug(prompt)
+    orientation = build_orientation_payload(
+        focus=args.focus,
+        depth=args.depth,
+        intent=args.intent,
+        annotation=args.annotation,
+    )
+    context_overrides = {
+        "memory_context": {
+            "lumina_studio_request": prompt,
+            "lumina_studio_operator_note": args.note or "Studio cycle launched from CLI.",
+        },
+        "supplemental_ethereonic_context": {
+            "lumina_studio_orientation": orientation,
+        },
+    }
+    overlay = None
+    if args.ethereonic_overlay:
+        overlay = {
+            "active": True,
+            "anchor_language": ["english", "toki_pona", "binary", "light_language"],
+            "continuity_phrase": "lumina studio cycle",
+            "harmonic_signature": [432, 528, 963],
+            "spiral_reference": "RSE-v1",
+        }
+
+    runner = RuntimeRunner()
+    result = runner.run_cycle(
+        current_mode=args.current_mode,
+        target_mode=args.target_mode,
+        requested_action=requested_action,
+        action_type=args.action_type,
+        artifacts=args.artifacts or DEFAULT_ARTIFACTS,
+        continuation_notes=[
+            f"Lumina Studio orientation: {args.focus}/{args.depth}/{args.intent}",
+            "Studio is a control surface, not a governance authority.",
+        ],
+        enabled_feature_flags=args.feature_flags,
+        runtime_config=SAFE_RUNTIME_CONFIG,
+        raw_user_input=prompt,
+        ethereonic_overlay=overlay,
+        context_bundle_overrides=context_overrides,
+        project_id=args.project_id,
+    )
+    return result.to_dict()
+
+
+def print_human_receipt(receipt: Dict[str, Any]) -> None:
+    print("Lumina Studio cycle complete")
+    print(f"  run:        {receipt.get('run_id')}")
+    print(f"  mode:       {receipt.get('requested_mode')} -> {receipt.get('target_mode')}")
+    print(f"  action:     {receipt.get('action_type')}")
+    print(f"  halted:     {receipt.get('halted')}")
+    if receipt.get("halt_reason"):
+        print(f"  reason:     {receipt.get('halt_reason')}")
+    print(f"  checkpoint: {receipt.get('checkpoint_path')}")
+    print(f"  log:        {receipt.get('log_path')}")
+    print(f"  chain ok:   {receipt.get('governance_chain_valid')}")
+    if receipt.get("input_confidence"):
+        print(f"  input:      {receipt.get('input_confidence')} / {receipt.get('input_behavior')}")
+    caps = receipt.get("exposed_capability_ids") or []
+    print(f"  exposed:    {', '.join(caps) if caps else 'none'}")
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one governed Lumina Studio cycle.")
+    parser.add_argument("prompt", nargs="*", help="Operator request to pass through the runtime loop.")
+    parser.add_argument("--current-mode", default="Continuity")
+    parser.add_argument("--target-mode", default="Observation")
+    parser.add_argument("--action-type", default="audit", choices=sorted(VALID_ACTION_TYPES))
+    parser.add_argument("--action", default=None, help="Stable requested_action label. Defaults to a prompt-derived slug.")
+    parser.add_argument("--project-id", default="lumina-os")
+    parser.add_argument("--focus", default="continuity", choices=["architecture", "continuity", "expression", "integration", "governance_review"])
+    parser.add_argument("--depth", default="structural", choices=["surface", "structural", "foundational"])
+    parser.add_argument("--intent", default="verify", choices=["read", "build", "verify", "compose"])
+    parser.add_argument("--annotation", default=None)
+    parser.add_argument("--note", default=None)
+    parser.add_argument("--feature-flag", action="append", dest="feature_flags", default=list(DEFAULT_FEATURE_FLAGS))
+    parser.add_argument("--artifact", action="append", dest="artifacts", default=[])
+    parser.add_argument("--ethereonic-overlay", action="store_true", help="Attach optional expressive overlay while preserving boundary law.")
+    parser.add_argument("--json", action="store_true", help="Print full JSON result instead of compact receipt.")
+    parser.add_argument("--receipt-json", action="store_true", help="Print compact receipt as JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    result = run_lumina_cycle(args)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        receipt = compact_receipt(result)
+        if args.receipt_json:
+            print(json.dumps(receipt, indent=2))
+        else:
+            print_human_receipt(receipt)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_studio_server.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_studio_server.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Lumina Studio Server v0.1.
+
+Tiny local HTTP control surface for the governed Lumina runtime.
+This is deliberately plain: standard library only, local-first, and subordinate
+to RuntimeRunner. It is not a public Chamber surface and not a governance owner.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict
+from urllib.parse import parse_qs, urlparse
+
+STUDIO_ROOT = Path(__file__).resolve().parent
+if str(STUDIO_ROOT) not in sys.path:
+    sys.path.insert(0, str(STUDIO_ROOT))
+
+from lumina_cli import DEFAULT_FEATURE_FLAGS, compact_receipt, run_lumina_cycle  # noqa: E402
+
+
+HTML = """<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+  <title>Lumina Studio v0.1</title>
+  <style>
+    :root { color-scheme: dark; }
+    body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; background: #07111f; color: #eaf2ff; }
+    main { max-width: 980px; margin: 0 auto; padding: 32px 20px 48px; }
+    h1 { margin: 0 0 6px; font-size: clamp(2rem, 5vw, 4rem); letter-spacing: -0.06em; }
+    .kicker { color: #f6c96b; text-transform: uppercase; letter-spacing: 0.18em; font-size: 0.78rem; }
+    .sub { max-width: 780px; color: #b9c7dc; line-height: 1.55; }
+    form { display: grid; gap: 16px; margin-top: 28px; background: rgba(255,255,255,0.045); border: 1px solid rgba(255,255,255,0.12); border-radius: 22px; padding: 22px; box-shadow: 0 24px 80px rgba(0,0,0,0.35); }
+    label { display: grid; gap: 6px; color: #cbd8ec; font-size: 0.92rem; }
+    input, textarea, select { width: 100%; box-sizing: border-box; border-radius: 12px; border: 1px solid rgba(255,255,255,0.16); background: rgba(0,0,0,0.25); color: #f7fbff; padding: 11px 12px; font: inherit; }
+    textarea { min-height: 130px; resize: vertical; }
+    .grid { display: grid; gap: 14px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    button { justify-self: start; border: 0; border-radius: 999px; padding: 12px 18px; font-weight: 700; background: linear-gradient(135deg, #f6c96b, #fff1b5); color: #111522; cursor: pointer; }
+    pre { white-space: pre-wrap; overflow-wrap: anywhere; background: rgba(0,0,0,0.35); border: 1px solid rgba(255,255,255,0.12); border-radius: 18px; padding: 18px; margin-top: 20px; color: #dbe8ff; }
+    .receipt { margin-top: 24px; }
+    .note { color: #8fa4c3; font-size: 0.9rem; }
+    @media (max-width: 760px) { .grid, .grid.two { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <main>
+    <div class=\"kicker\">Local control surface · governed runtime</div>
+    <h1>Lumina Studio v0.1</h1>
+    <p class=\"sub\">Run one Lumina cycle through the existing runtime spine. Studio only packages the request and displays the receipt; mode legality, mutation gates, input integrity, capability exposure, checkpoints, and governance history remain owned by the runtime.</p>
+    <form method=\"post\" action=\"/run\">
+      <label>Operator request
+        <textarea name=\"prompt\" required>Review Lumina OS progress and produce the next governed action receipt.</textarea>
+      </label>
+      <div class=\"grid\">
+        <label>Current mode
+          <select name=\"current_mode\"><option>Continuity</option><option>Observation</option><option>Sandbox</option><option>DryDock</option><option>Canon</option></select>
+        </label>
+        <label>Target mode
+          <select name=\"target_mode\"><option selected>Observation</option><option>Continuity</option><option>Sandbox</option><option>DryDock</option><option>Canon</option></select>
+        </label>
+        <label>Action type
+          <select name=\"action_type\"><option selected>audit</option><option>transition</option><option>mutation</option><option>promotion</option></select>
+        </label>
+      </div>
+      <div class=\"grid\">
+        <label>Focus
+          <select name=\"focus\"><option>architecture</option><option selected>continuity</option><option>expression</option><option>integration</option><option>governance_review</option></select>
+        </label>
+        <label>Depth
+          <select name=\"depth\"><option>surface</option><option selected>structural</option><option>foundational</option></select>
+        </label>
+        <label>Intent
+          <select name=\"intent\"><option>read</option><option>build</option><option selected>verify</option><option>compose</option></select>
+        </label>
+      </div>
+      <div class=\"grid two\">
+        <label>Project ID
+          <input name=\"project_id\" value=\"lumina-os\" />
+        </label>
+        <label>Action label
+          <input name=\"action\" value=\"studio_runtime_cycle_v0_1\" />
+        </label>
+      </div>
+      <label>Annotation
+        <input name=\"annotation\" value=\"Studio v0.1 local governed runtime loop\" />
+      </label>
+      <label><input type=\"checkbox\" name=\"ethereonic_overlay\" value=\"1\" /> Attach optional expressive overlay</label>
+      <button type=\"submit\">Run Lumina cycle</button>
+      <div class=\"note\">For local use only. Do not expose this server publicly without adding authentication and persistence policy.</div>
+    </form>
+    <section class=\"receipt\">
+      <h2>Last receipt</h2>
+      <pre id=\"receipt\">No cycle has run in this page yet.</pre>
+    </section>
+  </main>
+  <script>
+    const form = document.querySelector('form');
+    const receipt = document.querySelector('#receipt');
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      receipt.textContent = 'Running Lumina cycle…';
+      const body = new URLSearchParams(new FormData(form));
+      try {
+        const response = await fetch('/run', { method: 'POST', body });
+        const data = await response.json();
+        receipt.textContent = JSON.stringify(data, null, 2);
+      } catch (err) {
+        receipt.textContent = 'Lumina Studio request failed: ' + err;
+      }
+    });
+  </script>
+</body>
+</html>"""
+
+
+class Args:
+    def __init__(self, payload: Dict[str, Any]):
+        self.prompt = [payload.get("prompt", "Lumina Studio runtime cycle")]
+        self.current_mode = payload.get("current_mode", "Continuity")
+        self.target_mode = payload.get("target_mode", "Observation")
+        self.action_type = payload.get("action_type", "audit")
+        self.action = payload.get("action") or None
+        self.project_id = payload.get("project_id", "lumina-os")
+        self.focus = payload.get("focus", "continuity")
+        self.depth = payload.get("depth", "structural")
+        self.intent = payload.get("intent", "verify")
+        self.annotation = payload.get("annotation") or None
+        self.note = payload.get("note") or None
+        self.feature_flags = list(DEFAULT_FEATURE_FLAGS)
+        self.artifacts = []
+        self.ethereonic_overlay = bool(payload.get("ethereonic_overlay"))
+        self.json = False
+        self.receipt_json = True
+
+
+def _single(values: Dict[str, Any], key: str, default: str = "") -> str:
+    value = values.get(key, [default])
+    if isinstance(value, list):
+        return value[0] if value else default
+    return str(value)
+
+
+def _payload_from_body(raw_body: bytes, content_type: str) -> Dict[str, Any]:
+    if "application/json" in content_type:
+        return json.loads(raw_body.decode("utf-8") or "{}")
+    parsed = parse_qs(raw_body.decode("utf-8"), keep_blank_values=True)
+    payload = {key: _single(parsed, key) for key in parsed}
+    payload["ethereonic_overlay"] = "ethereonic_overlay" in parsed
+    return payload
+
+
+class LuminaStudioHandler(BaseHTTPRequestHandler):
+    server_version = "LuminaStudio/0.1"
+
+    def _send(self, status: int, body: bytes, content_type: str) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        if path == "/" or path == "/studio":
+            self._send(200, HTML.encode("utf-8"), "text/html; charset=utf-8")
+            return
+        if path == "/health":
+            self._send(200, json.dumps({"ok": True, "service": "lumina-studio", "version": "0.1"}).encode("utf-8"), "application/json")
+            return
+        self._send(404, b"not found", "text/plain; charset=utf-8")
+
+    def do_POST(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        if path != "/run":
+            self._send(404, b"not found", "text/plain; charset=utf-8")
+            return
+        length = int(self.headers.get("Content-Length", "0") or 0)
+        raw = self.rfile.read(length)
+        try:
+            payload = _payload_from_body(raw, self.headers.get("Content-Type", ""))
+            result = run_lumina_cycle(Args(payload))
+            receipt = compact_receipt(result)
+            self._send(200, json.dumps(receipt, indent=2).encode("utf-8"), "application/json")
+        except Exception as exc:  # pragma: no cover - operator feedback path
+            body = json.dumps({"ok": False, "error": str(exc)}, indent=2).encode("utf-8")
+            self._send(500, body, "application/json")
+
+
+def main() -> int:
+    host = "127.0.0.1"
+    port = 8765
+    server = ThreadingHTTPServer((host, port), LuminaStudioHandler)
+    print(f"Lumina Studio v0.1 running at http://{host}:{port}/studio")
+    print("Use Ctrl-C to stop.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nLumina Studio stopped.")
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/START_HERE_LUMINA_OS.md
+++ b/START_HERE_LUMINA_OS.md
@@ -17,6 +17,8 @@ Primary guide files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/SELF_GUIDANCE_STEWARD_NOTE_R1.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Quantum_Concepts_Boundary_r1.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_studio_v0_1_spec.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_next_build_plan_001.md`
 
 Primary runtime files inside that path:
 
@@ -48,6 +50,36 @@ Primary orchestration files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_orchestration_stack_r1.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_orchestration_continuity_r1.py`
 
+Primary Studio operator-surface files inside that path:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/README.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_cli.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_studio_server.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_v0_1.py`
+
+## Fastest operator entry
+
+For a local governed cycle, start with Studio:
+
+```bash
+cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
+python studio/lumina_cli.py "Review Lumina OS progress and produce the next governed action receipt."
+```
+
+For the local browser surface:
+
+```bash
+python studio/lumina_studio_server.py
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8765/studio
+```
+
+Studio is local-first and not a public Chamber page. It packages requests, invokes the governed runtime, and displays receipts.
+
 ## What this path is
 
 This subtree is the governed bootstrap substrate imported from **Ship of Ethereon V2** into GitHub for beginning **Lumina OS** work.
@@ -72,21 +104,27 @@ It is the correct place to start when the task is about:
 - checkpoint-refreshed self-guidance history
 - bounded orchestration from restored context into runtime execution
 - continuity of pattern across restored context, orientation changes, advisory recommendation, and governed execution
+- local operator execution through Lumina Studio v0.1
 
 ## Current truth
 
 1. **Lumina OS governed substrate starts in the bootstrap path above.**
 2. **The orchestration lane now sits above that substrate and remains subordinate to runtime law.**
-3. **Chamber is a parallel app/public lane, not the same thing as the Lumina OS substrate, but it now includes a consent surface for advisory acceptance / rejection and supervised queue state.**
-4. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap now contains the preferred bridge paths for project return, workspace-host behavior, bounded self-guidance, checkpoint-refreshed guidance history, and bounded orchestration.**
-5. **Quantum-adjacent language is now explicitly bounded: useful for modeling observation, coherence, branching, and recomposition, but not allowed to imply literal quantum hardware or runtime authority.**
-6. **Orchestration continuity now has a dedicated sea-trial verifier for restored context, orientation shifts, advisory recommendation, and governed execution.**
-7. **If you are trying to understand the Ship-derived runtime core, do not begin with Chamber. Begin with the bootstrap path.**
+3. **Lumina Studio is now the first local operator surface for running a governed cycle and reading the receipt.**
+4. **Chamber is a parallel app/public lane, not the same thing as the Lumina OS substrate, but it now includes a consent surface for advisory acceptance / rejection and supervised queue state.**
+5. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap now contains the preferred bridge paths for project return, workspace-host behavior, bounded self-guidance, checkpoint-refreshed guidance history, and bounded orchestration.**
+6. **Quantum-adjacent language is now explicitly bounded: useful for modeling observation, coherence, branching, and recomposition, but not allowed to imply literal quantum hardware or runtime authority.**
+7. **Orchestration continuity now has a dedicated sea-trial verifier for restored context, orientation shifts, advisory recommendation, and governed execution.**
+8. **If you are trying to understand the Ship-derived runtime core, do not begin with Chamber. Begin with the bootstrap path.**
 
 ## Parallel lanes in this repository
 
 ### Lumina OS governed substrate
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
+
+### Lumina Studio local operator surface
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_v0_1.py`
 
 ### Continuity / workspace-host exploration
 - `continuity_restore_spike_r1.py`
@@ -103,10 +141,11 @@ It is the correct place to start when the task is about:
 
 1. Read this file.
 2. Open `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md`.
-3. Read `README_IMPORT.md`, `REPO_NATIVE_BOOTSTRAP_NOTE.md`, `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`, `SELF_GUIDANCE_STEWARD_NOTE_R1.md`, `LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`, and `docs/Quantum_Concepts_Boundary_r1.md`.
-4. Inspect `runtime/` in that subtree, including the repo-native return / workspace-host modules, the bridged runner, the self-guided bridge runner, the checkpoint-refreshed guidance history rail, `quantum_concepts_registry_r1.json`, `branch_resolution_model_r1.json`, and `sea_trials_quantum_boundary_r1.py`.
-5. Inspect `lumina_context_loader_v0_1.py`, `lumina_decision_engine_v0_1.py`, `lumina_orchestrator_v0_4.py`, `sea_trials_lumina_orchestration_stack_r1.py`, and `sea_trials_lumina_orchestration_continuity_r1.py`.
-6. Only then branch outward into Chamber and its advisory / queue persistence lane.
+3. For a runnable proof, open `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/README.md` and run the Studio CLI.
+4. Read `README_IMPORT.md`, `REPO_NATIVE_BOOTSTRAP_NOTE.md`, `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`, `SELF_GUIDANCE_STEWARD_NOTE_R1.md`, `LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`, `docs/Quantum_Concepts_Boundary_r1.md`, and `docs/lumina_studio_v0_1_spec.md`.
+5. Inspect `runtime/` in that subtree, including the repo-native return / workspace-host modules, the bridged runner, the self-guided bridge runner, the checkpoint-refreshed guidance history rail, `quantum_concepts_registry_r1.json`, `branch_resolution_model_r1.json`, and `sea_trials_quantum_boundary_r1.py`.
+6. Inspect `lumina_context_loader_v0_1.py`, `lumina_decision_engine_v0_1.py`, `lumina_orchestrator_v0_4.py`, `sea_trials_lumina_orchestration_stack_r1.py`, and `sea_trials_lumina_orchestration_continuity_r1.py`.
+7. Only then branch outward into Chamber and its advisory / queue persistence lane.
 
 ## Assistant note
 


### PR DESCRIPTION
## Purpose

Adds the first deliberately plain Lumina Studio operator surface so the governed Lumina OS substrate can be run and inspected without hand-building runtime arguments.

This is not Chamber, not a public social surface, and not new governance law. Studio is a local launcher and receipt viewer for the existing runtime runner.

## Changes

### Studio operator surface
- Adds `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_cli.py`
- Adds `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_studio_server.py`
- Adds `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/README.md`

### Spec and build plan
- Adds `docs/lumina_studio_v0_1_spec.md`
- Adds `docs/lumina_next_build_plan_001.md`

### Verification
- Adds `sea_trials_lumina_studio_v0_1.py`

### Navigation docs
- Updates `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md`
- Updates `START_HERE_LUMINA_OS.md`

## What Studio does

- Accepts an operator request
- Declares current mode, target mode, and action type
- Attaches orientation as supplemental stance only
- Delegates to `runtime/runtime_runner_r1_merged.py`
- Returns a compact receipt showing halt status, checkpoint, governance log, chain status, exposed capabilities, and optional probe / return-host artifacts

## Authority boundary

Studio does **not** own:
- mode legality
- mutation permission
- promotion gates
- canon lineage
- governance history
- checkpoint truth
- capability exposure

Those remain owned by the existing runtime substrate.

## Local usage

```bash
cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
python studio/lumina_cli.py "Review Lumina OS progress and produce the next governed action receipt."
```

Local browser surface:

```bash
python studio/lumina_studio_server.py
```

Then open:

```text
http://127.0.0.1:8765/studio
```

Sea trial:

```bash
python sea_trials_lumina_studio_v0_1.py
```

## Notes

I did not run the Python sea trial inside GitHub from here; this PR adds the verifier so it can be run locally or by a future workflow. The branch was created from the latest known main at the time, and `main` advanced by one commit afterward, so GitHub may show it as one commit behind until updated/merged.