### PR TITLE
Add Lumina Studio state browser v0.2

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_state_browser_v0_2.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_state_browser_v0_2.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Sea trial for Lumina Studio State Browser v0.2.
+
+Validates that Studio can read recent runtime receipts and governance summaries
+without becoming a governance authority or writing state through the browser.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from argparse import Namespace
+from pathlib import Path
+from typing import Any, Dict, List
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parent
+STUDIO_ROOT = BOOTSTRAP_ROOT / "studio"
+if str(STUDIO_ROOT) not in sys.path:
+    sys.path.insert(0, str(STUDIO_ROOT))
+
+from lumina_cli import DEFAULT_FEATURE_FLAGS, compact_receipt, run_lumina_cycle  # noqa: E402
+from lumina_state_browser import state_snapshot  # noqa: E402
+
+
+def make_args(**overrides: Any) -> Namespace:
+    base: Dict[str, Any] = {
+        "prompt": ["Run Lumina Studio state browser verification cycle."],
+        "current_mode": "Continuity",
+        "target_mode": "Observation",
+        "action_type": "audit",
+        "action": "sea_trial_lumina_studio_state_browser_v0_2",
+        "project_id": "lumina-studio-state-browser",
+        "focus": "continuity",
+        "depth": "structural",
+        "intent": "verify",
+        "annotation": "Sea trial for Studio state browser v0.2",
+        "note": "Studio state browser verifier: read-only receipt inspection.",
+        "feature_flags": list(DEFAULT_FEATURE_FLAGS),
+        "artifacts": [],
+        "ethereonic_overlay": False,
+        "json": False,
+        "receipt_json": True,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def evaluate_snapshot(snapshot: Dict[str, Any], receipt: Dict[str, Any]) -> Dict[str, bool]:
+    latest_runs: List[Dict[str, Any]] = snapshot.get("latest_runs", []) or []
+    latest_run_ids = {run.get("run_id") for run in latest_runs}
+    governance = snapshot.get("governance", {}) or {}
+    return {
+        "snapshot_schema_matches": snapshot.get("schema_version") == "lumina-studio-state-browser-v0.2",
+        "snapshot_is_read_only": snapshot.get("read_only") is True,
+        "runtime_base_reported": bool(snapshot.get("runtime_base_dir")),
+        "receipt_count_positive": (snapshot.get("receipt_count_returned") or 0) >= 1,
+        "latest_receipt_found": receipt.get("run_id") in latest_run_ids,
+        "governance_summary_present": isinstance(governance, dict) and "event_count" in governance,
+        "governance_events_recorded": (governance.get("event_count") or 0) >= 1,
+        "canon_fields_present": "canon_record_count" in snapshot and "canon_head" in snapshot,
+    }
+
+
+def main() -> Dict[str, Any]:
+    result = run_lumina_cycle(make_args())
+    receipt = compact_receipt(result)
+    snapshot = state_snapshot(limit=12)
+    checks = evaluate_snapshot(snapshot, receipt)
+
+    summary = {
+        "suite": "Lumina Studio State Browser v0.2 sea trial",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "receipt": receipt,
+        "snapshot_summary": {
+            "schema_version": snapshot.get("schema_version"),
+            "read_only": snapshot.get("read_only"),
+            "receipt_count_returned": snapshot.get("receipt_count_returned"),
+            "governance": snapshot.get("governance"),
+            "canon_record_count": snapshot.get("canon_record_count"),
+            "canon_head": snapshot.get("canon_head"),
+        },
+        "authority_boundary": "State browser reads emitted runtime files only; it does not write checkpoints, governance logs, or canon lineage.",
+    }
+
+    report_dir = BOOTSTRAP_ROOT / ".studio_sea_trials"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / "lumina_studio_state_browser_v0_2_report.json"
+    with report_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    summary["report_path"] = str(report_path)
+    return summary
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/README.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/README.md
@@ -1,4 +1,4 @@
-# Lumina Studio v0.1
+# Lumina Studio v0.2
 
 Lumina Studio is the first deliberately plain operator surface for the Lumina OS governed runtime substrate.
 
@@ -6,7 +6,7 @@ It is not Chamber.
 It is not a public social surface.  
 It is not a new governance authority.
 
-It is a local control surface that packages a request, invokes the existing runtime runner, and shows the receipt.
+It is a local control surface that packages a request, invokes the existing runtime runner, shows the receipt, and now reads recent emitted runtime state.
 
 ## What Studio does
 
@@ -16,6 +16,7 @@ It is a local control surface that packages a request, invokes the existing runt
 - calls `runtime/runtime_runner_r1_merged.py`
 - lets the runtime own input integrity, mode legality, mutation gates, capability exposure, checkpoints, governance logs, canon metadata, and optional probe execution
 - returns a compact receipt with checkpoint, governance, exposed capabilities, and halt status
+- reads recent runtime receipts and governance summaries through a read-only state browser
 
 ## What Studio must not do
 
@@ -24,6 +25,7 @@ It is a local control surface that packages a request, invokes the existing runt
 - mutate canon directly
 - treat poetic or Ethereonic language as structural authority
 - replace Chamber or the public website
+- write to governance/canon/checkpoint files through the state browser
 - expose this local server publicly without authentication and persistence policy
 
 ## CLI usage
@@ -55,6 +57,30 @@ python lumina_cli.py "Draft the next Studio build step" \
   --ethereonic-overlay
 ```
 
+## State browser usage
+
+Read recent emitted runtime receipts from the command line:
+
+```bash
+python lumina_state_browser.py --limit 12
+```
+
+The state browser is read-only. It summarizes files under:
+
+```text
+.lumina_state/ship_of_ethereon_v2/runtime_runner_r1_actiontype_logging/
+```
+
+It returns:
+
+- recent run receipts
+- checkpoint paths
+- governance log path
+- governance event counts
+- latest governance event type/hash
+- canon lineage count/head when present
+- exposed capability ids for recent runs
+
 ## Local server usage
 
 ```bash
@@ -65,6 +91,14 @@ Then open:
 
 ```text
 http://127.0.0.1:8765/studio
+```
+
+Useful local endpoints:
+
+```text
+/health
+/api/state?limit=12
+/run
 ```
 
 The server is intentionally local-first and standard-library only. It should not be deployed as a public endpoint without authentication, rate limiting, and a clear persistence boundary.
@@ -80,10 +114,11 @@ That is intentional. It gives us a safe first proof:
 3. expose lawful Observation capabilities
 4. write a checkpoint
 5. return a receipt
+6. refresh emitted runtime state
 
 ## Authority boundary
 
-Studio is a launcher and receipt viewer.
+Studio is a launcher, receipt viewer, and read-only state browser.
 
 Runtime law remains owned by the runtime substrate:
 
@@ -96,7 +131,7 @@ Runtime law remains owned by the runtime substrate:
 
 ## First-pass success criteria
 
-Studio v0.1 succeeds if it can:
+Studio v0.1 succeeded if it could:
 
 - run one governed cycle from CLI
 - run one governed cycle from local browser UI
@@ -105,10 +140,18 @@ Studio v0.1 succeeds if it can:
 - show exposed capability IDs
 - preserve orientation as supplemental stance, not governance law
 
+Studio v0.2 succeeds if it can additionally:
+
+- summarize recent emitted run receipts
+- summarize governance event counts
+- report canon head/count if present
+- expose the same read-only snapshot through `/api/state`
+- keep state inspection read-only and non-authoritative
+
 ## Next hardening steps
 
 1. Add a richer result viewer for governance decisions.
-2. Add a saved-cycle browser over `.lumina_state`.
-3. Add a mode/action preset library.
+2. Add mode/action preset library.
+3. Add diffable receipt comparison between runs.
 4. Wire accepted Chamber queue items into Studio/runtime cycles while preserving consent.
 5. Add authentication before any remote deployment.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_state_browser.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_state_browser.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Lumina Studio State Browser v0.2.
+
+Read-only helpers for inspecting Lumina runtime receipts and governance events.
+This module does not write state and does not own governance truth. It only
+summarizes files already emitted by the governed runtime runner.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+STATE_ROOT = REPO_ROOT / ".lumina_state" / "ship_of_ethereon_v2"
+DEFAULT_RUNTIME_BASE = STATE_ROOT / "runtime_runner_r1_actiontype_logging"
+
+
+def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else None
+    except Exception:
+        return None
+
+
+def _read_jsonl(path: Path, *, limit: int = 50) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: List[Dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except Exception:
+                    continue
+                if isinstance(payload, dict):
+                    rows.append(payload)
+    except Exception:
+        return []
+    return rows[-limit:]
+
+
+def _safe_stat_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except Exception:
+        return 0.0
+
+
+def _capability_ids(payload: Dict[str, Any]) -> List[str]:
+    exposed = payload.get("exposed_capabilities", []) or []
+    if not isinstance(exposed, list):
+        return []
+    out: List[str] = []
+    for item in exposed:
+        if isinstance(item, dict) and item.get("capability_id"):
+            out.append(str(item["capability_id"]))
+    return out
+
+
+def compact_run_summary(payload: Dict[str, Any], *, path: Optional[Path] = None) -> Dict[str, Any]:
+    governance = payload.get("governance", {}) or {}
+    if not isinstance(governance, dict):
+        governance = {}
+    input_integrity = governance.get("input_integrity", {}) or {}
+    if not isinstance(input_integrity, dict):
+        input_integrity = {}
+    return {
+        "run_id": payload.get("run_id"),
+        "created_at": payload.get("created_at"),
+        "requested_action": payload.get("requested_action"),
+        "action_type": payload.get("action_type"),
+        "requested_mode": payload.get("requested_mode"),
+        "target_mode": payload.get("target_mode"),
+        "halted": payload.get("halted"),
+        "halt_reason": payload.get("halt_reason"),
+        "session_id": payload.get("session_id"),
+        "context_bundle_id": payload.get("context_bundle_id"),
+        "checkpoint_path": payload.get("checkpoint_path"),
+        "log_path": payload.get("log_path") or (str(path) if path else None),
+        "governance_log_path": payload.get("governance_log_path"),
+        "governance_chain_valid": (payload.get("governance_chain_status") or {}).get("valid"),
+        "canon_head": (payload.get("canon_lineage") or {}).get("current_head"),
+        "exposed_capability_ids": _capability_ids(payload),
+        "governance_keys": sorted(governance.keys()),
+        "input_confidence": input_integrity.get("confidence_label"),
+        "input_behavior": input_integrity.get("recommended_behavior"),
+        "probe_run_id": (payload.get("probe_artifacts") or {}).get("run_id"),
+        "lumina_project_id": (payload.get("lumina_return_host_artifacts") or {}).get("project_id"),
+        "source_path": str(path) if path else None,
+    }
+
+
+def iter_result_logs(base_dir: Path = DEFAULT_RUNTIME_BASE) -> Iterable[Path]:
+    logs_dir = base_dir / "logs"
+    if not logs_dir.exists():
+        return []
+    return sorted(logs_dir.glob("*.json"), key=_safe_stat_mtime, reverse=True)
+
+
+def list_run_receipts(*, base_dir: Path = DEFAULT_RUNTIME_BASE, limit: int = 20) -> List[Dict[str, Any]]:
+    receipts: List[Dict[str, Any]] = []
+    for path in iter_result_logs(base_dir):
+        payload = _read_json(path)
+        if payload is None:
+            continue
+        receipts.append(compact_run_summary(payload, path=path))
+        if len(receipts) >= limit:
+            break
+    return receipts
+
+
+def governance_event_summary(events: List[Dict[str, Any]]) -> Dict[str, Any]:
+    event_types: Dict[str, int] = {}
+    action_types: Dict[str, int] = {}
+    for event in events:
+        event_type = str(event.get("event_type") or "unknown")
+        event_types[event_type] = event_types.get(event_type, 0) + 1
+        metadata = event.get("metadata", {}) or {}
+        if isinstance(metadata, dict) and metadata.get("action_type"):
+            action_type = str(metadata["action_type"])
+            action_types[action_type] = action_types.get(action_type, 0) + 1
+    return {
+        "event_count": len(events),
+        "event_types": dict(sorted(event_types.items())),
+        "action_types": dict(sorted(action_types.items())),
+        "latest_event_type": events[-1].get("event_type") if events else None,
+        "latest_event_hash": events[-1].get("record_hash") if events else None,
+    }
+
+
+def state_snapshot(*, base_dir: Path = DEFAULT_RUNTIME_BASE, limit: int = 20) -> Dict[str, Any]:
+    governance_log_path = base_dir / "governance_log_r1.jsonl"
+    canon_lineage_path = base_dir / "canon_lineage_r1.jsonl"
+    receipts = list_run_receipts(base_dir=base_dir, limit=limit)
+    governance_events = _read_jsonl(governance_log_path, limit=500)
+    canon_records = _read_jsonl(canon_lineage_path, limit=50)
+    return {
+        "schema_version": "lumina-studio-state-browser-v0.2",
+        "read_only": True,
+        "state_root": str(STATE_ROOT),
+        "runtime_base_dir": str(base_dir),
+        "runtime_base_exists": base_dir.exists(),
+        "logs_dir": str(base_dir / "logs"),
+        "receipt_count_returned": len(receipts),
+        "latest_runs": receipts,
+        "governance_log_path": str(governance_log_path),
+        "governance": governance_event_summary(governance_events),
+        "canon_lineage_path": str(canon_lineage_path),
+        "canon_record_count": len(canon_records),
+        "canon_head": canon_records[-1].get("canon_version") if canon_records else None,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Read Lumina Studio runtime receipts without mutating state.")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--base-dir", default=None, help="Override runtime base dir. Defaults to .lumina_state/ship_of_ethereon_v2/runtime_runner_r1_actiontype_logging")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    base_dir = Path(args.base_dir).expanduser().resolve() if args.base_dir else DEFAULT_RUNTIME_BASE
+    print(json.dumps(state_snapshot(base_dir=base_dir, limit=args.limit), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_studio_server.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_studio_server.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
-"""Lumina Studio Server v0.1.
+"""Lumina Studio Server v0.2.
 
 Tiny local HTTP control surface for the governed Lumina runtime.
 This is deliberately plain: standard library only, local-first, and subordinate
 to RuntimeRunner. It is not a public Chamber surface and not a governance owner.
+
+v0.2 adds read-only state inspection over runtime receipts and governance event
+summaries emitted by the governed runtime.
 """
 from __future__ import annotations
 
@@ -19,6 +22,7 @@ if str(STUDIO_ROOT) not in sys.path:
     sys.path.insert(0, str(STUDIO_ROOT))
 
 from lumina_cli import DEFAULT_FEATURE_FLAGS, compact_receipt, run_lumina_cycle  # noqa: E402
+from lumina_state_browser import state_snapshot  # noqa: E402
 
 
 HTML = """<!doctype html>
@@ -26,32 +30,39 @@ HTML = """<!doctype html>
 <head>
   <meta charset=\"utf-8\" />
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
-  <title>Lumina Studio v0.1</title>
+  <title>Lumina Studio v0.2</title>
   <style>
     :root { color-scheme: dark; }
     body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; background: #07111f; color: #eaf2ff; }
-    main { max-width: 980px; margin: 0 auto; padding: 32px 20px 48px; }
+    main { max-width: 1080px; margin: 0 auto; padding: 32px 20px 48px; }
     h1 { margin: 0 0 6px; font-size: clamp(2rem, 5vw, 4rem); letter-spacing: -0.06em; }
+    h2 { margin-top: 0; }
     .kicker { color: #f6c96b; text-transform: uppercase; letter-spacing: 0.18em; font-size: 0.78rem; }
-    .sub { max-width: 780px; color: #b9c7dc; line-height: 1.55; }
-    form { display: grid; gap: 16px; margin-top: 28px; background: rgba(255,255,255,0.045); border: 1px solid rgba(255,255,255,0.12); border-radius: 22px; padding: 22px; box-shadow: 0 24px 80px rgba(0,0,0,0.35); }
+    .sub { max-width: 820px; color: #b9c7dc; line-height: 1.55; }
+    form, .panel { display: grid; gap: 16px; margin-top: 28px; background: rgba(255,255,255,0.045); border: 1px solid rgba(255,255,255,0.12); border-radius: 22px; padding: 22px; box-shadow: 0 24px 80px rgba(0,0,0,0.35); }
     label { display: grid; gap: 6px; color: #cbd8ec; font-size: 0.92rem; }
     input, textarea, select { width: 100%; box-sizing: border-box; border-radius: 12px; border: 1px solid rgba(255,255,255,0.16); background: rgba(0,0,0,0.25); color: #f7fbff; padding: 11px 12px; font: inherit; }
     textarea { min-height: 130px; resize: vertical; }
     .grid { display: grid; gap: 14px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .actions { display: flex; gap: 10px; flex-wrap: wrap; }
     button { justify-self: start; border: 0; border-radius: 999px; padding: 12px 18px; font-weight: 700; background: linear-gradient(135deg, #f6c96b, #fff1b5); color: #111522; cursor: pointer; }
+    button.secondary { background: rgba(255,255,255,0.12); color: #eaf2ff; border: 1px solid rgba(255,255,255,0.16); }
     pre { white-space: pre-wrap; overflow-wrap: anywhere; background: rgba(0,0,0,0.35); border: 1px solid rgba(255,255,255,0.12); border-radius: 18px; padding: 18px; margin-top: 20px; color: #dbe8ff; }
     .receipt { margin-top: 24px; }
     .note { color: #8fa4c3; font-size: 0.9rem; }
+    .cards { display: grid; gap: 12px; }
+    .card { border: 1px solid rgba(255,255,255,0.12); border-radius: 16px; padding: 14px; background: rgba(0,0,0,0.18); }
+    .card strong { color: #fff3bd; }
+    .muted { color: #90a4c4; }
     @media (max-width: 760px) { .grid, .grid.two { grid-template-columns: 1fr; } }
   </style>
 </head>
 <body>
   <main>
-    <div class=\"kicker\">Local control surface · governed runtime</div>
-    <h1>Lumina Studio v0.1</h1>
-    <p class=\"sub\">Run one Lumina cycle through the existing runtime spine. Studio only packages the request and displays the receipt; mode legality, mutation gates, input integrity, capability exposure, checkpoints, and governance history remain owned by the runtime.</p>
+    <div class=\"kicker\">Local control surface · governed runtime · read-only state browser</div>
+    <h1>Lumina Studio v0.2</h1>
+    <p class=\"sub\">Run one Lumina cycle through the existing runtime spine, then inspect recent receipts and governance summaries. Studio only packages requests and reads emitted state; mode legality, mutation gates, input integrity, capability exposure, checkpoints, and governance history remain owned by the runtime.</p>
     <form method=\"post\" action=\"/run\">
       <label>Operator request
         <textarea name=\"prompt\" required>Review Lumina OS progress and produce the next governed action receipt.</textarea>
@@ -83,24 +94,61 @@ HTML = """<!doctype html>
           <input name=\"project_id\" value=\"lumina-os\" />
         </label>
         <label>Action label
-          <input name=\"action\" value=\"studio_runtime_cycle_v0_1\" />
+          <input name=\"action\" value=\"studio_runtime_cycle_v0_2\" />
         </label>
       </div>
       <label>Annotation
-        <input name=\"annotation\" value=\"Studio v0.1 local governed runtime loop\" />
+        <input name=\"annotation\" value=\"Studio v0.2 local governed runtime loop with state browser\" />
       </label>
       <label><input type=\"checkbox\" name=\"ethereonic_overlay\" value=\"1\" /> Attach optional expressive overlay</label>
-      <button type=\"submit\">Run Lumina cycle</button>
+      <div class=\"actions\">
+        <button type=\"submit\">Run Lumina cycle</button>
+        <button type=\"button\" class=\"secondary\" id=\"refresh-state\">Refresh state</button>
+      </div>
       <div class=\"note\">For local use only. Do not expose this server publicly without adding authentication and persistence policy.</div>
     </form>
     <section class=\"receipt\">
       <h2>Last receipt</h2>
       <pre id=\"receipt\">No cycle has run in this page yet.</pre>
     </section>
+    <section class=\"panel\">
+      <h2>Runtime state</h2>
+      <div id=\"state-cards\" class=\"cards\"><div class=\"muted\">State not loaded yet.</div></div>
+      <pre id=\"state-json\">Click Refresh state to inspect recent runtime receipts.</pre>
+    </section>
   </main>
   <script>
     const form = document.querySelector('form');
     const receipt = document.querySelector('#receipt');
+    const stateJson = document.querySelector('#state-json');
+    const stateCards = document.querySelector('#state-cards');
+    const refreshButton = document.querySelector('#refresh-state');
+
+    function renderStateCards(data) {
+      const runs = data.latest_runs || [];
+      const governance = data.governance || {};
+      const cards = [];
+      cards.push(`<div class=\"card\"><strong>Receipts:</strong> ${data.receipt_count_returned || 0}<br><span class=\"muted\">State root: ${data.state_root || 'unknown'}</span></div>`);
+      cards.push(`<div class=\"card\"><strong>Governance events:</strong> ${governance.event_count || 0}<br><span class=\"muted\">Latest: ${governance.latest_event_type || 'none'}</span></div>`);
+      cards.push(`<div class=\"card\"><strong>Canon head:</strong> ${data.canon_head || 'none'}<br><span class=\"muted\">Records: ${data.canon_record_count || 0}</span></div>`);
+      for (const run of runs.slice(0, 5)) {
+        cards.push(`<div class=\"card\"><strong>${run.run_id || 'unknown run'}</strong><br>${run.requested_mode || '?'} → ${run.target_mode || '?'} · ${run.action_type || '?'} · halted: ${run.halted}<br><span class=\"muted\">${run.requested_action || ''}</span></div>`);
+      }
+      stateCards.innerHTML = cards.join('');
+    }
+
+    async function refreshState() {
+      stateJson.textContent = 'Reading emitted runtime state…';
+      try {
+        const response = await fetch('/api/state?limit=12');
+        const data = await response.json();
+        renderStateCards(data);
+        stateJson.textContent = JSON.stringify(data, null, 2);
+      } catch (err) {
+        stateJson.textContent = 'State refresh failed: ' + err;
+      }
+    }
+
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
       receipt.textContent = 'Running Lumina cycle…';
@@ -109,10 +157,14 @@ HTML = """<!doctype html>
         const response = await fetch('/run', { method: 'POST', body });
         const data = await response.json();
         receipt.textContent = JSON.stringify(data, null, 2);
+        await refreshState();
       } catch (err) {
         receipt.textContent = 'Lumina Studio request failed: ' + err;
       }
     });
+
+    refreshButton.addEventListener('click', refreshState);
+    refreshState();
   </script>
 </body>
 </html>"""
@@ -154,8 +206,16 @@ def _payload_from_body(raw_body: bytes, content_type: str) -> Dict[str, Any]:
     return payload
 
 
+def _query_limit(path: str, default: int = 20) -> int:
+    query = parse_qs(urlparse(path).query)
+    try:
+        return max(1, min(int(_single(query, "limit", str(default))), 100))
+    except Exception:
+        return default
+
+
 class LuminaStudioHandler(BaseHTTPRequestHandler):
-    server_version = "LuminaStudio/0.1"
+    server_version = "LuminaStudio/0.2"
 
     def _send(self, status: int, body: bytes, content_type: str) -> None:
         self.send_response(status)
@@ -170,7 +230,11 @@ class LuminaStudioHandler(BaseHTTPRequestHandler):
             self._send(200, HTML.encode("utf-8"), "text/html; charset=utf-8")
             return
         if path == "/health":
-            self._send(200, json.dumps({"ok": True, "service": "lumina-studio", "version": "0.1"}).encode("utf-8"), "application/json")
+            self._send(200, json.dumps({"ok": True, "service": "lumina-studio", "version": "0.2"}).encode("utf-8"), "application/json")
+            return
+        if path == "/api/state":
+            payload = state_snapshot(limit=_query_limit(self.path, 20))
+            self._send(200, json.dumps(payload, indent=2).encode("utf-8"), "application/json")
             return
         self._send(404, b"not found", "text/plain; charset=utf-8")
 
@@ -195,7 +259,7 @@ def main() -> int:
     host = "127.0.0.1"
     port = 8765
     server = ThreadingHTTPServer((host, port), LuminaStudioHandler)
-    print(f"Lumina Studio v0.1 running at http://{host}:{port}/studio")
+    print(f"Lumina Studio v0.2 running at http://{host}:{port}/studio")
     print("Use Ctrl-C to stop.")
     try:
         server.serve_forever()


### PR DESCRIPTION
## Purpose

Adds a read-only state browser to Lumina Studio so the local operator surface can inspect recent emitted runtime receipts instead of only launching new cycles.

Studio v0.1 made Lumina runnable. This PR makes Studio more inspectable.

## Changes

- Adds `studio/lumina_state_browser.py`
- Updates `studio/lumina_studio_server.py` from v0.1 to v0.2
- Updates `studio/README.md` with state browser usage
- Adds `sea_trials_lumina_studio_state_browser_v0_2.py`

## What the state browser reads

Default path:

```text
.lumina_state/ship_of_ethereon_v2/runtime_runner_r1_actiontype_logging/
```

It summarizes:

- recent run result JSON files
- governance event counts from the runtime log
- canon record count/head when present
- checkpoint/log paths
- exposed capability ids for recent runs

## Local usage

```bash
cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
python studio/lumina_state_browser.py --limit 12
```

Local server:

```bash
python studio/lumina_studio_server.py
```

Then open:

```text
http://127.0.0.1:8765/studio
```

State endpoint:

```text
http://127.0.0.1:8765/api/state?limit=12
```

Sea trial:

```bash
python sea_trials_lumina_studio_state_browser_v0_2.py
```

## Boundary

The state browser is read-only. It does not write checkpoints, governance logs, canon lineage, sessions, or capability state. It only summarizes emitted runtime files.

## Notes

Two attempted doc-only writes to the broader bootstrap docs were blocked by the connector safety checks, so this PR keeps the scope to the Studio README, server, browser utility, and verifier.