### PR TITLE
Add Lumina Studio governance view v0.3

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_governance_view_v0_3.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_governance_view_v0_3.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Sea trial for Lumina Studio Governance View v0.3."""
+from __future__ import annotations
+
+import json
+import sys
+from argparse import Namespace
+from pathlib import Path
+from typing import Any, Dict, List
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parent
+STUDIO_ROOT = BOOTSTRAP_ROOT / "studio"
+if str(STUDIO_ROOT) not in sys.path:
+    sys.path.insert(0, str(STUDIO_ROOT))
+
+from lumina_cli import DEFAULT_FEATURE_FLAGS, compact_receipt, run_lumina_cycle  # noqa: E402
+from lumina_governance_viewer import latest_governance_views  # noqa: E402
+from lumina_presets import presets_payload  # noqa: E402
+
+
+def make_args(**overrides: Any) -> Namespace:
+    base: Dict[str, Any] = {
+        "prompt": ["Run Lumina Studio governance view verification cycle."],
+        "current_mode": "Continuity",
+        "target_mode": "Observation",
+        "action_type": "audit",
+        "action": "sea_trial_lumina_studio_governance_view_v0_3",
+        "project_id": "lumina-studio-governance-view",
+        "focus": "governance_review",
+        "depth": "structural",
+        "intent": "verify",
+        "annotation": "Sea trial for Studio governance view v0.3",
+        "note": "Studio governance viewer verifier.",
+        "feature_flags": list(DEFAULT_FEATURE_FLAGS),
+        "artifacts": [],
+        "ethereonic_overlay": False,
+        "json": False,
+        "receipt_json": True,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def evaluate(views: Dict[str, Any], receipt: Dict[str, Any], presets: Dict[str, Any]) -> Dict[str, bool]:
+    latest_views: List[Dict[str, Any]] = views.get("latest_views", []) or []
+    matching = [view for view in latest_views if (view.get("summary") or {}).get("run_id") == receipt.get("run_id")]
+    matched = matching[0] if matching else {}
+    cards = matched.get("decision_cards", []) or []
+    preset_ids = {item.get("id") for item in presets.get("presets", []) or []}
+    return {
+        "view_schema_matches": views.get("schema_version") == "lumina-studio-governance-view-list-v0.3",
+        "view_is_read_only": views.get("read_only") is True,
+        "latest_view_found": bool(matching),
+        "decision_cards_present": len(cards) >= 1,
+        "summary_contains_run_id": (matched.get("summary") or {}).get("run_id") == receipt.get("run_id"),
+        "preset_schema_matches": presets.get("schema_version") == "lumina-studio-presets-v0.3",
+        "preset_count_sufficient": len(preset_ids) >= 3,
+        "expected_presets_present": {"observe_continuity", "architecture_review", "sandbox_design"}.issubset(preset_ids),
+    }
+
+
+def main() -> Dict[str, Any]:
+    result = run_lumina_cycle(make_args())
+    receipt = compact_receipt(result)
+    views = latest_governance_views(limit=12)
+    presets = presets_payload()
+    checks = evaluate(views, receipt, presets)
+
+    summary = {
+        "suite": "Lumina Studio Governance View v0.3 sea trial",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "receipt": receipt,
+        "view_summary": {
+            "schema_version": views.get("schema_version"),
+            "view_count": views.get("view_count"),
+        },
+        "preset_ids": [item.get("id") for item in presets.get("presets", [])],
+    }
+
+    report_dir = BOOTSTRAP_ROOT / ".studio_sea_trials"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / "lumina_studio_governance_view_v0_3_report.json"
+    with report_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    summary["report_path"] = str(report_path)
+    return summary
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_governance_viewer.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_governance_viewer.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Lumina Studio Governance Viewer v0.3.
+
+Read-only governance decision cards derived from emitted runtime result logs.
+This module does not validate, override, or write governance. It only translates
+runtime receipts into a clearer operator-facing shape.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from lumina_state_browser import DEFAULT_RUNTIME_BASE, _read_json, compact_run_summary, iter_result_logs
+
+DECISION_KEYS = [
+    "input_integrity",
+    "ethereonic_layer_independence",
+    "ethereonic_attachment",
+    "transition",
+    "mutation",
+    "symbolic_dependency",
+    "promotion",
+    "capability_exposure",
+]
+
+
+def _first_present(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _decision_status(payload: Dict[str, Any]) -> str:
+    if payload.get("allowed") is True:
+        return "allowed"
+    if payload.get("allowed") is False:
+        return "denied"
+    if payload.get("should_halt") is True:
+        return "halt_recommended"
+    return "reported"
+
+
+def _decision_reason(key: str, payload: Dict[str, Any]) -> Optional[str]:
+    if key == "input_integrity":
+        return _first_present(
+            payload.get("confidence_reason"),
+            payload.get("recommended_behavior"),
+            payload.get("chosen_interpretation"),
+        )
+    return _first_present(payload.get("reason"), payload.get("confidence_reason"))
+
+
+def decision_card(key: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        payload = {}
+    card: Dict[str, Any] = {
+        "key": key,
+        "status": _decision_status(payload),
+        "allowed": payload.get("allowed"),
+        "reason": _decision_reason(key, payload),
+    }
+    if key == "input_integrity":
+        card.update(
+            {
+                "confidence_label": payload.get("confidence_label"),
+                "recommended_behavior": payload.get("recommended_behavior"),
+                "chosen_interpretation": payload.get("chosen_interpretation"),
+                "should_halt": payload.get("should_halt"),
+            }
+        )
+    if key == "capability_exposure":
+        card["capability_ids"] = payload.get("capability_ids", [])
+        card["enabled_feature_flags"] = payload.get("enabled_feature_flags", [])
+    if key in {"transition", "mutation", "promotion", "symbolic_dependency"}:
+        card["audit_event"] = payload.get("audit_event")
+    return card
+
+
+def governance_view_for_result(payload: Dict[str, Any], *, source_path: Optional[Path] = None) -> Dict[str, Any]:
+    governance = payload.get("governance", {}) or {}
+    if not isinstance(governance, dict):
+        governance = {}
+    cards: List[Dict[str, Any]] = []
+    for key in DECISION_KEYS:
+        if key in governance:
+            cards.append(decision_card(key, governance.get(key, {}) or {}))
+
+    missing_expected = [key for key in DECISION_KEYS if key not in governance]
+    denied = [card for card in cards if card.get("allowed") is False or card.get("status") == "halt_recommended"]
+    return {
+        "schema_version": "lumina-studio-governance-view-v0.3",
+        "read_only": True,
+        "summary": compact_run_summary(payload, path=source_path),
+        "decision_cards": cards,
+        "decision_count": len(cards),
+        "denied_or_halt_count": len(denied),
+        "missing_expected_decisions": missing_expected,
+        "runtime_halted": payload.get("halted"),
+        "halt_reason": payload.get("halt_reason"),
+        "source_path": str(source_path) if source_path else None,
+    }
+
+
+def latest_governance_views(*, base_dir: Path = DEFAULT_RUNTIME_BASE, limit: int = 12) -> Dict[str, Any]:
+    views: List[Dict[str, Any]] = []
+    for path in iter_result_logs(base_dir):
+        payload = _read_json(path)
+        if payload is None:
+            continue
+        views.append(governance_view_for_result(payload, source_path=path))
+        if len(views) >= limit:
+            break
+    return {
+        "schema_version": "lumina-studio-governance-view-list-v0.3",
+        "read_only": True,
+        "runtime_base_dir": str(base_dir),
+        "view_count": len(views),
+        "latest_views": views,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Read governance decisions from emitted Lumina Studio runtime receipts.")
+    parser.add_argument("--limit", type=int, default=12)
+    parser.add_argument("--base-dir", default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    base_dir = Path(args.base_dir).expanduser().resolve() if args.base_dir else DEFAULT_RUNTIME_BASE
+    print(json.dumps(latest_governance_views(base_dir=base_dir, limit=args.limit), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_presets.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_presets.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Lumina Studio Presets v0.3.
+
+Small UI defaults for common Studio cycles. These only prefill forms.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+PRESETS: Dict[str, Dict[str, Any]] = {
+    "observe_continuity": {
+        "label": "Observe continuity",
+        "description": "Inspect project state from Continuity into Observation.",
+        "current_mode": "Continuity",
+        "target_mode": "Observation",
+        "action_type": "audit",
+        "focus": "continuity",
+        "depth": "structural",
+        "intent": "verify",
+        "action": "studio_observe_continuity",
+        "project_id": "lumina-os",
+        "prompt": "Review Lumina OS continuity and produce a Studio receipt.",
+        "ethereonic_overlay": False,
+    },
+    "architecture_review": {
+        "label": "Architecture review",
+        "description": "Inspect runtime structure.",
+        "current_mode": "Continuity",
+        "target_mode": "Observation",
+        "action_type": "audit",
+        "focus": "architecture",
+        "depth": "foundational",
+        "intent": "verify",
+        "action": "studio_architecture_review",
+        "project_id": "lumina-os",
+        "prompt": "Inspect the Lumina runtime architecture and summarize the receipt.",
+        "ethereonic_overlay": False,
+    },
+    "sandbox_design": {
+        "label": "Sandbox design",
+        "description": "Explore a design move in Sandbox.",
+        "current_mode": "Continuity",
+        "target_mode": "Sandbox",
+        "action_type": "audit",
+        "focus": "integration",
+        "depth": "structural",
+        "intent": "build",
+        "action": "studio_sandbox_design",
+        "project_id": "lumina-os",
+        "prompt": "Explore the next Lumina Studio design move as a Sandbox proposal.",
+        "ethereonic_overlay": True,
+    },
+    "receipt_review": {
+        "label": "Receipt review",
+        "description": "Review recent Studio receipts.",
+        "current_mode": "Continuity",
+        "target_mode": "Observation",
+        "action_type": "audit",
+        "focus": "governance_review",
+        "depth": "structural",
+        "intent": "verify",
+        "action": "studio_receipt_review",
+        "project_id": "lumina-os",
+        "prompt": "Review recent Studio receipts and identify boundary concerns.",
+        "ethereonic_overlay": False,
+    },
+}
+
+
+def list_presets() -> List[Dict[str, Any]]:
+    return [{"id": preset_id, **payload} for preset_id, payload in PRESETS.items()]
+
+
+def get_preset(preset_id: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not preset_id:
+        return None
+    payload = PRESETS.get(preset_id)
+    if payload is None:
+        return None
+    return {"id": preset_id, **payload}
+
+
+def presets_payload() -> Dict[str, Any]:
+    return {
+        "schema_version": "lumina-studio-presets-v0.3",
+        "presets": list_presets(),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(presets_payload(), indent=2))


### PR DESCRIPTION
## Purpose

Adds a narrower v0.3 Studio hardening layer: readable governance decision cards and reusable Studio presets.

Studio v0.1 made Lumina runnable.  
Studio v0.2 made emitted state inspectable.  
This PR makes recent runtime decisions easier to read from receipts without changing runtime behavior.

## Changes

- Adds `studio/lumina_governance_viewer.py`
- Adds `studio/lumina_presets.py`
- Adds `sea_trials_lumina_studio_governance_view_v0_3.py`

## What the governance viewer does

It reads recent emitted runtime result logs and translates governance payloads into compact decision cards:

- input integrity
- Ethereonic independence / attachment checks
- transitions
- mutation checks
- symbolic dependency checks
- promotion checks when present
- capability exposure

## What presets do

Presets provide simple Studio form defaults for common cycles:

- observe continuity
- architecture review
- sandbox design
- receipt review

They do not execute anything by themselves.

## Local usage

```bash
cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
python studio/lumina_governance_viewer.py --limit 12
python studio/lumina_presets.py
```

Sea trial:

```bash
python sea_trials_lumina_studio_governance_view_v0_3.py
```

## Boundary

This PR is read-only / preset-only. It does not modify the runtime runner, mode guard, governance log, canon lineage, checkpoint files, or capability registry.

## Notes

I attempted to wire this directly into `lumina_studio_server.py`, but the connector blocked the larger server rewrite. This PR therefore lands the CLI-readable governance view and preset utilities first. UI integration can follow as a smaller patch.