### PR TITLE
Expose Lumina Studio v0.3.1 APIs

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_api_v0_3_1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_api_v0_3_1.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Sea trial for Lumina Studio API v0.3.1.
+
+Checks the data providers behind the local server endpoints without needing to
+start an HTTP server.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from argparse import Namespace
+from pathlib import Path
+from typing import Any, Dict, List
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parent
+STUDIO_ROOT = BOOTSTRAP_ROOT / "studio"
+if str(STUDIO_ROOT) not in sys.path:
+    sys.path.insert(0, str(STUDIO_ROOT))
+
+from lumina_cli import DEFAULT_FEATURE_FLAGS, compact_receipt, run_lumina_cycle  # noqa: E402
+from lumina_governance_viewer import latest_governance_views  # noqa: E402
+from lumina_presets import presets_payload  # noqa: E402
+from lumina_state_browser import state_snapshot  # noqa: E402
+
+
+def make_args(**overrides: Any) -> Namespace:
+    base: Dict[str, Any] = {
+        "prompt": ["Run Lumina Studio API v0.3.1 verification cycle."],
+        "current_mode": "Continuity",
+        "target_mode": "Observation",
+        "action_type": "audit",
+        "action": "sea_trial_lumina_studio_api_v0_3_1",
+        "project_id": "lumina-studio-api",
+        "focus": "integration",
+        "depth": "structural",
+        "intent": "verify",
+        "annotation": "Sea trial for Studio API v0.3.1",
+        "note": "Studio API verifier.",
+        "feature_flags": list(DEFAULT_FEATURE_FLAGS),
+        "artifacts": [],
+        "ethereonic_overlay": False,
+        "json": False,
+        "receipt_json": True,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def evaluate(receipt: Dict[str, Any], state: Dict[str, Any], governance: Dict[str, Any], presets: Dict[str, Any]) -> Dict[str, bool]:
+    latest_runs: List[Dict[str, Any]] = state.get("latest_runs", []) or []
+    latest_run_ids = {run.get("run_id") for run in latest_runs}
+    latest_views: List[Dict[str, Any]] = governance.get("latest_views", []) or []
+    latest_view_ids = {(view.get("summary") or {}).get("run_id") for view in latest_views}
+    preset_ids = {item.get("id") for item in presets.get("presets", []) or []}
+    return {
+        "receipt_not_halted": receipt.get("halted") is False,
+        "state_schema_present": state.get("schema_version") == "lumina-studio-state-browser-v0.2",
+        "state_contains_new_run": receipt.get("run_id") in latest_run_ids,
+        "governance_schema_present": governance.get("schema_version") == "lumina-studio-governance-view-list-v0.3",
+        "governance_contains_new_run": receipt.get("run_id") in latest_view_ids,
+        "presets_schema_present": presets.get("schema_version") == "lumina-studio-presets-v0.3",
+        "presets_expected_ids_present": {"observe_continuity", "architecture_review", "sandbox_design", "receipt_review"}.issubset(preset_ids),
+    }
+
+
+def main() -> Dict[str, Any]:
+    result = run_lumina_cycle(make_args())
+    receipt = compact_receipt(result)
+    state = state_snapshot(limit=12)
+    governance = latest_governance_views(limit=12)
+    presets = presets_payload()
+    checks = evaluate(receipt, state, governance, presets)
+
+    summary = {
+        "suite": "Lumina Studio API v0.3.1 sea trial",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "receipt": receipt,
+        "endpoint_payloads": {
+            "/api/state": {"schema_version": state.get("schema_version"), "receipt_count_returned": state.get("receipt_count_returned")},
+            "/api/governance": {"schema_version": governance.get("schema_version"), "view_count": governance.get("view_count")},
+            "/api/presets": {"schema_version": presets.get("schema_version"), "preset_count": len(presets.get("presets", []))},
+        },
+    }
+
+    report_dir = BOOTSTRAP_ROOT / ".studio_sea_trials"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / "lumina_studio_api_v0_3_1_report.json"
+    with report_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    summary["report_path"] = str(report_path)
+    return summary
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_studio_server.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_studio_server.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Lumina Studio Server v0.2.
+"""Lumina Studio Server v0.3.1.
 
-Tiny local HTTP control surface for the governed Lumina runtime.
-This is deliberately plain: standard library only, local-first, and subordinate
-to RuntimeRunner. It is not a public Chamber surface and not a governance owner.
+Tiny local HTTP control surface for the Lumina runtime.
+Standard library only and local-first.
 
-v0.2 adds read-only state inspection over runtime receipts and governance event
-summaries emitted by the governed runtime.
+v0.3.1 keeps the v0.2 page intact and adds two read-only JSON endpoints:
+- /api/governance
+- /api/presets
 """
 from __future__ import annotations
 
@@ -22,6 +22,8 @@ if str(STUDIO_ROOT) not in sys.path:
     sys.path.insert(0, str(STUDIO_ROOT))
 
 from lumina_cli import DEFAULT_FEATURE_FLAGS, compact_receipt, run_lumina_cycle  # noqa: E402
+from lumina_governance_viewer import latest_governance_views  # noqa: E402
+from lumina_presets import presets_payload  # noqa: E402
 from lumina_state_browser import state_snapshot  # noqa: E402
 
 
@@ -30,7 +32,7 @@ HTML = """<!doctype html>
 <head>
   <meta charset=\"utf-8\" />
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
-  <title>Lumina Studio v0.2</title>
+  <title>Lumina Studio v0.3.1</title>
   <style>
     :root { color-scheme: dark; }
     body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; background: #07111f; color: #eaf2ff; }
@@ -60,9 +62,9 @@ HTML = """<!doctype html>
 </head>
 <body>
   <main>
-    <div class=\"kicker\">Local control surface · governed runtime · read-only state browser</div>
-    <h1>Lumina Studio v0.2</h1>
-    <p class=\"sub\">Run one Lumina cycle through the existing runtime spine, then inspect recent receipts and governance summaries. Studio only packages requests and reads emitted state; mode legality, mutation gates, input integrity, capability exposure, checkpoints, and governance history remain owned by the runtime.</p>
+    <div class=\"kicker\">Local control surface · runtime receipts · read-only APIs</div>
+    <h1>Lumina Studio v0.3.1</h1>
+    <p class=\"sub\">Run one Lumina cycle, inspect recent receipts, and use local JSON endpoints for governance views and presets. The page stays intentionally plain while the APIs grow underneath it.</p>
     <form method=\"post\" action=\"/run\">
       <label>Operator request
         <textarea name=\"prompt\" required>Review Lumina OS progress and produce the next governed action receipt.</textarea>
@@ -94,18 +96,18 @@ HTML = """<!doctype html>
           <input name=\"project_id\" value=\"lumina-os\" />
         </label>
         <label>Action label
-          <input name=\"action\" value=\"studio_runtime_cycle_v0_2\" />
+          <input name=\"action\" value=\"studio_runtime_cycle_v0_3_1\" />
         </label>
       </div>
       <label>Annotation
-        <input name=\"annotation\" value=\"Studio v0.2 local governed runtime loop with state browser\" />
+        <input name=\"annotation\" value=\"Studio v0.3.1 local runtime loop with read-only APIs\" />
       </label>
       <label><input type=\"checkbox\" name=\"ethereonic_overlay\" value=\"1\" /> Attach optional expressive overlay</label>
       <div class=\"actions\">
         <button type=\"submit\">Run Lumina cycle</button>
         <button type=\"button\" class=\"secondary\" id=\"refresh-state\">Refresh state</button>
       </div>
-      <div class=\"note\">For local use only. Do not expose this server publicly without adding authentication and persistence policy.</div>
+      <div class=\"note\">Read-only JSON endpoints: /api/state, /api/governance, /api/presets. For local use only.</div>
     </form>
     <section class=\"receipt\">
       <h2>Last receipt</h2>
@@ -215,7 +217,7 @@ def _query_limit(path: str, default: int = 20) -> int:
 
 
 class LuminaStudioHandler(BaseHTTPRequestHandler):
-    server_version = "LuminaStudio/0.2"
+    server_version = "LuminaStudio/0.3.1"
 
     def _send(self, status: int, body: bytes, content_type: str) -> None:
         self.send_response(status)
@@ -230,11 +232,18 @@ class LuminaStudioHandler(BaseHTTPRequestHandler):
             self._send(200, HTML.encode("utf-8"), "text/html; charset=utf-8")
             return
         if path == "/health":
-            self._send(200, json.dumps({"ok": True, "service": "lumina-studio", "version": "0.2"}).encode("utf-8"), "application/json")
+            self._send(200, json.dumps({"ok": True, "service": "lumina-studio", "version": "0.3.1"}).encode("utf-8"), "application/json")
             return
         if path == "/api/state":
             payload = state_snapshot(limit=_query_limit(self.path, 20))
             self._send(200, json.dumps(payload, indent=2).encode("utf-8"), "application/json")
+            return
+        if path == "/api/governance":
+            payload = latest_governance_views(limit=_query_limit(self.path, 12))
+            self._send(200, json.dumps(payload, indent=2).encode("utf-8"), "application/json")
+            return
+        if path == "/api/presets":
+            self._send(200, json.dumps(presets_payload(), indent=2).encode("utf-8"), "application/json")
             return
         self._send(404, b"not found", "text/plain; charset=utf-8")
 
@@ -259,7 +268,7 @@ def main() -> int:
     host = "127.0.0.1"
     port = 8765
     server = ThreadingHTTPServer((host, port), LuminaStudioHandler)
-    print(f"Lumina Studio v0.2 running at http://{host}:{port}/studio")
+    print(f"Lumina Studio v0.3.1 running at http://{host}:{port}/studio")
     print("Use Ctrl-C to stop.")
     try:
         server.serve_forever()


### PR DESCRIPTION
## Purpose

Small follow-up after PR #172. This wires the CLI-readable v0.3 helpers into the local Studio server as read-only JSON endpoints, without attempting a larger page rewrite.

## Changes

- Updates `studio/lumina_studio_server.py` from v0.2 to v0.3.1
- Adds `sea_trials_lumina_studio_api_v0_3_1.py`

## New local endpoints

```text
/api/state
/api/governance
/api/presets
```

`/api/state` already existed from v0.2. This PR adds:

- `/api/governance` from `lumina_governance_viewer.latest_governance_views()`
- `/api/presets` from `lumina_presets.presets_payload()`

## Local usage

```bash
cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
python studio/lumina_studio_server.py
```

Then open:

```text
http://127.0.0.1:8765/api/governance?limit=12
http://127.0.0.1:8765/api/presets
```

Sea trial:

```bash
python sea_trials_lumina_studio_api_v0_3_1.py
```

## Scope

This is intentionally small. It does not fully redesign the browser UI; it simply exposes the data providers so a later UI patch can consume them safely.