### PR TITLE
Live Runtime Loop Wiring r1 (Loop + Store Integrated)

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_live_loop_adapter_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_live_loop_adapter_r1.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from lumina_runtime_loop_receipt_r1 import LuminaRuntimeLoop
+from runtime_loop_receipt_store_r1 import RuntimeLoopReceiptStore
+
+
+class LuminaLiveLoopAdapter:
+    """Runtime-facing adapter for live Lumina loop receipts.
+
+    This connects the callable loop and persistent store without granting execution authority.
+    It is intended to be invoked by runtime_runner after input integrity has completed.
+    """
+
+    schema_version = "lumina_live_loop_adapter_r1"
+
+    def __init__(self, store_base_path: Optional[str] = None) -> None:
+        self.loop = LuminaRuntimeLoop()
+        self.store = RuntimeLoopReceiptStore(base_path=store_base_path)
+
+    def process_cycle(
+        self,
+        raw_input: str,
+        *,
+        mode: str = "Observation",
+        context: Optional[Dict[str, Any]] = None,
+        output_hint: str = "processed",
+        persist: bool = True,
+    ) -> Dict[str, Any]:
+        previous_signal = self.store.load_previous_signal()
+        receipt = self.loop.build_receipt(
+            raw_input,
+            mode=mode,
+            context=context or {},
+            output_hint=output_hint,
+            previous_signal=previous_signal,
+        ).to_dict()
+
+        live_snapshot = {
+            "schema_version": self.schema_version,
+            "authority_boundary": "diagnostic/advisory only; runtime remains authority",
+            "receipt": receipt,
+            "previous_signal_present": previous_signal is not None,
+        }
+
+        if persist:
+            self.store.append_receipt(receipt)
+
+        return live_snapshot


### PR DESCRIPTION
This PR wires the Lumina runtime loop and persistent store into a single callable runtime-facing adapter.

Includes:
- lumina_live_loop_adapter_r1.py

Capabilities:
- Calls LuminaRuntimeLoop per cycle
- Loads previous signal from RuntimeLoopReceiptStore
- Builds loop receipt with continuity chaining
- Persists receipt to .lumina_state
- Returns live diagnostic snapshot

Boundaries preserved:
- No execution authority
- No governance authority
- Runtime remains decision-maker

Purpose:
This completes the first live cognition loop with memory inside Lumina.

Next step:
Integrate this adapter into runtime_runner and begin real usage cycles.