### PR TITLE
Runtime Runner Hook r1 (Live Loop Diagnostic Attachment)

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_live_loop_hook_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_live_loop_hook_r1.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from lumina_live_loop_adapter_r1 import LuminaLiveLoopAdapter
+
+
+class RuntimeRunnerLiveLoopHook:
+    """Minimal hook for attaching Lumina live-loop diagnostics to a runner cycle.
+
+    Intended placement:
+    - after input integrity has completed
+    - before runtime authority decisions are finalized
+
+    Boundary:
+    - diagnostic/advisory only
+    - does not authorize execution
+    - does not mutate governance
+    """
+
+    schema_version = "runtime_runner_live_loop_hook_r1"
+
+    def __init__(self, store_base_path: Optional[str] = None) -> None:
+        self.live_loop = LuminaLiveLoopAdapter(store_base_path=store_base_path)
+
+    def build_diagnostic(
+        self,
+        raw_input: str,
+        *,
+        mode: str = "Observation",
+        context: Optional[Dict[str, Any]] = None,
+        output_hint: str = "processed",
+    ) -> Dict[str, Any]:
+        snapshot = self.live_loop.process_cycle(
+            raw_input,
+            mode=mode,
+            context=context or {},
+            output_hint=output_hint,
+            persist=True,
+        )
+        return {
+            "schema_version": self.schema_version,
+            "authority_boundary": "diagnostic/advisory only; runner remains authority",
+            "lumina_live_loop": snapshot,
+        }


### PR DESCRIPTION
Adds a minimal, safe integration hook for attaching Lumina live-loop diagnostics to the runtime runner.

Includes:
- runtime_runner_live_loop_hook_r1.py

Purpose:
- Provide a clean entry point for runtime_runner to call LuminaLiveLoopAdapter
- Attach diagnostic snapshot without affecting execution authority

Usage pattern:
1. After input integrity
2. Call build_diagnostic(raw_input, mode, context)
3. Attach returned dict to governance/context diagnostics

Boundaries preserved:
- No execution authority
- No governance mutation
- No runtime decision influence

This completes the Dry Dock recommendation: enabling live-loop diagnostics to be safely integrated into the runtime without guessing runner internals.