### PR TITLE
Add Chamber runtime presence live-loop seed

### DIFF
--- a/assets/js/runtime-viewer.js
+++ b/assets/js/runtime-viewer.js
@@ -1,0 +1,25 @@
+(function(){
+  async function loadRuntime(){
+    try{
+      const res = await fetch('/runtime/latest_cycle.json');
+      const data = await res.json();
+
+      const set = (id,val)=>{
+        const el=document.getElementById(id);
+        if(el) el.textContent=val ?? '—';
+      };
+
+      set('runtimeMode', data.mode?.current);
+      set('runtimeStatus', data.status?.halted ? 'HALTED' : 'STABLE');
+      set('runtimeCanon', data.canon?.current_head || 'none');
+      set('runtimeGov', data.governance?.transition ? 'VALID' : 'BLOCKED');
+      set('runtimeProbe', data.probe?.active ? 'ACTIVE' : 'IDLE');
+
+    }catch(e){
+      console.warn('runtime load failed',e);
+    }
+  }
+
+  setInterval(loadRuntime,3000);
+  loadRuntime();
+})();

--- a/public/runtime/latest_cycle.json
+++ b/public/runtime/latest_cycle.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "lumina-runtime-ui-cycle-v0.1",
+  "timestamp": "2026-05-05T00:00:00Z",
+  "run_id": "sample-static-snapshot",
+  "requested_action": "public_runtime_snapshot_seed",
+  "action_type": "audit",
+  "mode": {
+    "requested": "Continuity",
+    "current": "Observation"
+  },
+  "status": {
+    "halted": false,
+    "reason": null,
+    "label": "Stable"
+  },
+  "governance": {
+    "transition": true,
+    "mutation": false,
+    "promotion": null,
+    "symbolic_dependency": true,
+    "ethereonic_attachment": true,
+    "chain_valid": true
+  },
+  "canon": {
+    "current_head": null,
+    "valid": true,
+    "record_count": 0
+  },
+  "capabilities": [],
+  "probe": {
+    "active": false,
+    "coherence": null,
+    "presence": null,
+    "lock": null
+  },
+  "notes": [
+    "Static seed snapshot for Chamber runtime presence panel.",
+    "Generated runtime receipts should replace this file when the live loop is invoked."
+  ]
+}


### PR DESCRIPTION
## Summary

Creates the first public-facing runtime presence seed for the Chamber live-loop integration.

This PR adds:

- `public/runtime/latest_cycle.json` — a UI-facing runtime snapshot contract that the Chamber can read without owning governance.
- `assets/js/runtime-viewer.js` — a small polling reader that updates runtime presence elements from `/runtime/latest_cycle.json`.

## Authority boundary

This is display-only. The public Chamber reads a distilled runtime snapshot but does not authorize actions, alter governance, alter canon lineage, change mode legality, expose capabilities, or execute tools.

## Notes

The Chamber HTML integration still needs a small follow-up patch to add the runtime presence panel markup. The earlier direct overwrite attempt was blocked, so this PR intentionally preserves the existing Chamber file instead of forcing a risky replacement.

## Next step after merge

Wire the Lumina runtime runner to emit this UI contract automatically so the static seed becomes a live governed receipt.