### PR TITLE
Add runtime presence panel to Chamber (live loop UI)

### DIFF
--- a/chamber.html
+++ b/chamber.html
@@ -76,6 +76,21 @@
               </div>
             </div>
 
+            <section class="chamber-runtime-panel" aria-label="Lumina runtime presence">
+              <div class="panel-title-row">
+                <h2>Runtime Presence</h2>
+                <span class="panel-tag">display-only</span>
+              </div>
+              <div class="runtime-presence-grid">
+                <div><small>Mode</small><strong id="runtimeMode">—</strong></div>
+                <div><small>Status</small><strong id="runtimeStatus">—</strong></div>
+                <div><small>Canon</small><strong id="runtimeCanon">—</strong></div>
+                <div><small>Governance</small><strong id="runtimeGov">—</strong></div>
+                <div><small>Probe</small><strong id="runtimeProbe">—</strong></div>
+              </div>
+              <p class="microcopy">This panel reads a public runtime receipt. It does not execute tools, authorize governance, alter canon, or change mode legality.</p>
+            </section>
+
             <div class="chamber-grid">
               <aside class="chamber-column chamber-column-left">
                 <section class="chamber-panel">
@@ -177,5 +192,6 @@
   <script src="assets/js/site.js"></script>
   <script src="assets/js/chamber_config.js"></script>
   <script src="assets/js/chamber.js"></script>
+  <script src="assets/js/runtime-viewer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

This PR makes the Chamber *actually reflect system state*.

Adds a Runtime Presence panel that reads `/runtime/latest_cycle.json` and displays:
- Mode
- Status
- Canon head
- Governance validity
- Probe state

## Important boundary

This panel is strictly **read-only**:
- Does NOT execute runtime
- Does NOT alter governance
- Does NOT mutate canon
- Does NOT expose capabilities

It is a **window into Lumina**, not a control surface.

## Why this matters

This transforms the Chamber from:
> "a pretty thing"

into:
> a truthful observational interface

## Next step

Wire runtime runner to emit real snapshots → replace static seed with live governed output.