### PR TITLE
Add Observe System button to Chamber (workflow link)

### DIFF
--- a/chamber.html
+++ b/chamber.html
@@ -89,6 +89,10 @@
                 <div><small>Probe</small><strong id="runtimeProbe">—</strong></div>
               </div>
               <p class="microcopy">This panel reads a public runtime receipt. It does not execute tools, authorize governance, alter canon, or change mode legality.</p>
+              <div class="composer-actions runtime-actions">
+                <a class="button secondary ping-target" href="https://github.com/ethereoninitiative/EthereonLabs/actions/workflows/lumina-observation-cycle.yml" target="_blank" rel="noopener noreferrer">Observe System</a>
+              </div>
+              <p class="microcopy">The button opens the GitHub workflow so an authorized operator can run the observation cycle. The public Chamber remains read-only.</p>
             </section>
 
             <div class="chamber-grid">


### PR DESCRIPTION
## Summary

Adds an **Observe System** button to the Chamber runtime panel.

## Behavior

- Opens the Lumina Observation GitHub workflow
- Allows authorized users to trigger a runtime cycle
- Keeps the Chamber strictly read-only

## Why this approach

Netlify/static site cannot safely execute Python runtime.

So instead of a fake trigger, this provides:

> real execution path via GitHub Actions

## Result

User experience:
- see system state
- trigger system (via GitHub)
- return and observe update

## Boundary preserved

- no runtime execution from UI
- no governance mutation
- no canon mutation

Chamber remains an observer, not an operator.
