### PR TITLE
Sea Trials Fix: runtime snapshot path resolution

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_ui_snapshot_emitter_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_ui_snapshot_emitter_r1.py
@@ -7,7 +7,11 @@ import json
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[4]
+    path = Path(__file__).resolve()
+    for parent in [path.parent, *path.parents]:
+        if (parent / ".git").exists() or (parent / "chamber.html").exists():
+            return parent
+    return path.parents[4]
 
 
 REPO_ROOT = _repo_root()


### PR DESCRIPTION
## Sea Trials Finding

Observation workflow executed but did not update public snapshot.

## Root Cause

Emitter path resolution assumed fixed directory depth, causing snapshot write to fail silently in CI.

## Fix

- Dynamic repo root detection
- Ensures `/public/runtime/latest_cycle.json` is correctly written during GitHub Actions

## Result

Observation cycles will now:
- generate snapshot
- write to correct path
- commit successfully

## This unblocks

Actual live runtime state appearing in Chamber during scheduled/manual runs.