### PR TITLE
Enable Ψ-42 probe in Lumina observation workflow

### DIFF
--- a/.github/workflows/lumina-observation-cycle.yml
+++ b/.github/workflows/lumina-observation-cycle.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install numpy
+
       - name: Run bounded Observation cycle
         run: |
           cd LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime
@@ -28,6 +33,9 @@ jobs:
             --target-mode Observation \
             --action chamber_observation_cycle \
             --action-type audit \
+            --enable-flag ETHEREON_OBSERVATION \
+            --enable-flag ETHEREON_PSI42 \
+            --enable-flag ETHEREON_RESONANCE \
             --overlay-json '{"active":true,"anchor_language":["english"],"continuity_phrase":"scheduled observation cycle","harmonic_signature":[],"spiral_reference":null}' \
             --runtime-config-json '{"toki_pona_required_for_resume":false,"binary_required_for_transition_validation":false,"light_language_required_for_capability_loading":false,"harmonic_frequency_required_for_mode_legality":false}'
 


### PR DESCRIPTION
## Summary

Turns the scheduled/manual Lumina Observation cycle into a fuller live receipt by enabling the experimental Observation, Ψ-42, and Resonance feature flags.

## Changes

- Installs `numpy` before running the observation cycle so the Ψ-42 transceiver path can execute in GitHub Actions.
- Adds feature flags:
  - `ETHEREON_OBSERVATION`
  - `ETHEREON_PSI42`
  - `ETHEREON_RESONANCE`

## Why

The Chamber public runtime snapshot was stable, but the probe block remained inactive because the workflow did not expose the experimental probe capabilities. This keeps the Chamber read-only while allowing the runtime receipt to include lawful probe telemetry when available.

## Boundary preserved

- Chamber remains display-only.
- No UI execution authority.
- No governance mutation from the public surface.
- Probe remains telemetry-only and subordinate to capability exposure.