### PR TITLE
Add Lumina OS Host Layer 001

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/lumina
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/lumina
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Lumina host entrypoint.
+
+This command provides a single local operator surface for the Lumina OS
+bootstrap substrate. It does not create governance law; it routes to the
+existing runtime, Studio, state browser, and doctor scripts.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+STUDIO_DIR = BOOTSTRAP_ROOT / "studio"
+RUNTIME_DIR = BOOTSTRAP_ROOT / "runtime"
+INSTALL_DIR = BOOTSTRAP_ROOT / "install"
+
+
+def _python() -> str:
+    return sys.executable or "python3"
+
+
+def _run(args: List[str], *, cwd: Optional[Path] = None) -> int:
+    proc = subprocess.run(args, cwd=str(cwd or BOOTSTRAP_ROOT))
+    return int(proc.returncode)
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    prompt = args.prompt or "Review Lumina OS progress and produce the next governed action receipt."
+    cmd = [_python(), str(STUDIO_DIR / "lumina_cli.py"), prompt]
+    if args.receipt_json:
+        cmd.append("--receipt-json")
+    if args.full_json:
+        cmd.append("--json")
+    if args.ethereonic_overlay:
+        cmd.append("--ethereonic-overlay")
+    if args.target_mode:
+        cmd.extend(["--target-mode", args.target_mode])
+    if args.action_type:
+        cmd.extend(["--action-type", args.action_type])
+    if args.focus:
+        cmd.extend(["--focus", args.focus])
+    if args.depth:
+        cmd.extend(["--depth", args.depth])
+    if args.intent:
+        cmd.extend(["--intent", args.intent])
+    return _run(cmd, cwd=BOOTSTRAP_ROOT)
+
+
+def cmd_observe(args: argparse.Namespace) -> int:
+    cmd = [
+        _python(),
+        str(RUNTIME_DIR / "runtime_runner_auto_snapshot_r1.py"),
+        "--current-mode", "Continuity",
+        "--target-mode", "Observation",
+        "--action", args.action,
+        "--action-type", "audit",
+        "--enable-flag", "ETHEREON_OBSERVATION",
+        "--enable-flag", "ETHEREON_PSI42",
+        "--enable-flag", "ETHEREON_RESONANCE",
+        "--overlay-json", '{"active":true,"anchor_language":["english"],"continuity_phrase":"local observation cycle","harmonic_signature":[],"spiral_reference":null}',
+        "--runtime-config-json", '{"toki_pona_required_for_resume":false,"binary_required_for_transition_validation":false,"light_language_required_for_capability_loading":false,"harmonic_frequency_required_for_mode_legality":false}',
+    ]
+    return _run(cmd, cwd=RUNTIME_DIR)
+
+
+def cmd_state(args: argparse.Namespace) -> int:
+    cmd = [_python(), str(STUDIO_DIR / "lumina_state_browser.py"), "--limit", str(args.limit)]
+    return _run(cmd, cwd=BOOTSTRAP_ROOT)
+
+
+def cmd_studio(args: argparse.Namespace) -> int:
+    cmd = [_python(), str(STUDIO_DIR / "lumina_studio_server.py")]
+    if args.host:
+        cmd.extend(["--host", args.host])
+    if args.port:
+        cmd.extend(["--port", str(args.port)])
+    return _run(cmd, cwd=BOOTSTRAP_ROOT)
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    cmd = [_python(), str(INSTALL_DIR / "lumina_doctor.py")]
+    if args.json:
+        cmd.append("--json")
+    return _run(cmd, cwd=BOOTSTRAP_ROOT)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="lumina",
+        description="Start and inspect the Lumina OS local governed substrate.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run = sub.add_parser("run", help="Run one governed Studio cycle.")
+    run.add_argument("prompt", nargs="?", default=None)
+    run.add_argument("--target-mode", default="Observation")
+    run.add_argument("--action-type", default="audit")
+    run.add_argument("--focus", default="continuity")
+    run.add_argument("--depth", default="structural")
+    run.add_argument("--intent", default="verify")
+    run.add_argument("--ethereonic-overlay", action="store_true")
+    run.add_argument("--receipt-json", action="store_true")
+    run.add_argument("--full-json", action="store_true")
+    run.set_defaults(func=cmd_run)
+
+    observe = sub.add_parser("observe", help="Run a local bounded Observation cycle and emit public/runtime snapshot files.")
+    observe.add_argument("--action", default="local_observation_cycle")
+    observe.set_defaults(func=cmd_observe)
+
+    state = sub.add_parser("state", help="Read recent emitted Lumina runtime receipts.")
+    state.add_argument("--limit", type=int, default=12)
+    state.set_defaults(func=cmd_state)
+
+    studio = sub.add_parser("studio", help="Start the local Lumina Studio browser surface.")
+    studio.add_argument("--host", default=None)
+    studio.add_argument("--port", type=int, default=None)
+    studio.set_defaults(func=cmd_studio)
+
+    doctor = sub.add_parser("doctor", help="Check local Lumina host readiness.")
+    doctor.add_argument("--json", action="store_true")
+    doctor.set_defaults(func=cmd_doctor)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Local_Runbook_001.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Local_Runbook_001.md
@@ -1,0 +1,205 @@
+# Lumina Local Runbook 001
+
+**Purpose:** start Lumina locally without hunting through the repository.
+
+---
+
+## 1. Start here
+
+From the repository root:
+
+```bash
+cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
+```
+
+Run the doctor directly:
+
+```bash
+python install/lumina_doctor.py
+```
+
+Optional install into `~/.local/bin`:
+
+```bash
+bash install/install_lumina.sh
+```
+
+If `~/.local/bin` is on your `PATH`, the command becomes:
+
+```bash
+lumina doctor
+```
+
+If not, use the local entrypoint directly:
+
+```bash
+python bin/lumina doctor
+```
+
+---
+
+## 2. First useful cycle
+
+Run one governed cycle:
+
+```bash
+lumina run "Review Lumina OS progress and produce the next governed action receipt."
+```
+
+Without install:
+
+```bash
+python bin/lumina run "Review Lumina OS progress and produce the next governed action receipt."
+```
+
+Expected result:
+
+- a run id
+- mode path
+- halted status
+- checkpoint path
+- log path
+- governance chain status
+- exposed capability ids
+
+---
+
+## 3. Observe Lumina
+
+Run a bounded Observation cycle and emit the public/runtime snapshot artifacts:
+
+```bash
+lumina observe
+```
+
+This delegates to the existing auto-snapshot runtime runner. It does not make Chamber an execution surface.
+
+---
+
+## 4. Inspect state
+
+Read recent emitted runtime receipts:
+
+```bash
+lumina state --limit 12
+```
+
+This is read-only. It summarizes runtime receipts, governance event counts, canon metadata, checkpoint paths, and exposed capability ids.
+
+---
+
+## 5. Start Studio
+
+Launch the local browser surface:
+
+```bash
+lumina studio
+```
+
+Open:
+
+```text
+http://127.0.0.1:8765/studio
+```
+
+Studio remains local-first. Do not expose it publicly without authentication, authorization, rate limiting, persistence policy, and clear separation from Chamber.
+
+---
+
+## 6. Local observer service
+
+Run one service-style observation cycle:
+
+```bash
+python services/lumina_observer_service.py --once
+```
+
+Run repeated cycles every six hours:
+
+```bash
+python services/lumina_observer_service.py --interval-seconds 21600
+```
+
+For systemd-style hosting, copy and edit:
+
+```text
+services/lumina.service.example
+```
+
+Set the `WorkingDirectory` to your local checkout path before enabling it.
+
+---
+
+## 7. Troubleshooting
+
+### `lumina` command not found
+
+Run:
+
+```bash
+bash install/install_lumina.sh
+```
+
+Then ensure this is on your `PATH`:
+
+```bash
+~/.local/bin
+```
+
+### Doctor reports missing files
+
+Make sure you are in a checkout that includes the full Lumina bootstrap path:
+
+```text
+LuminaOS/bootstrap/Ship_of_Ethereon_V2/
+```
+
+### Studio starts but browser cannot connect
+
+Confirm the server is running locally and open:
+
+```text
+http://127.0.0.1:8765/studio
+```
+
+### State browser shows no receipts
+
+Run a cycle first:
+
+```bash
+lumina run "Initial Lumina receipt"
+lumina observe
+```
+
+State is emitted by runtime cycles; an empty state directory before first run is not automatically failure.
+
+---
+
+## 8. Boundary reminder
+
+The host commands are convenience paths into the governed runtime.
+
+They do not own:
+
+- mode legality
+- mutation authority
+- promotion authority
+- canon lineage
+- checkpoint truth
+- symbolic dependency boundaries
+- user consent
+
+Those remain governed by the existing runtime substrate.
+
+---
+
+## 9. Minimal daily operator loop
+
+```bash
+lumina doctor
+lumina observe
+lumina state --limit 5
+lumina run "What should Lumina do next within current boundaries?"
+```
+
+That is the current local heartbeat.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_OS_Host_Layer_001.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_OS_Host_Layer_001.md
@@ -1,0 +1,180 @@
+# Lumina OS Host Layer 001
+
+**Project:** Lumina OS / Ship of Ethereon V2 Bootstrap  
+**Status:** first host-layer threshold  
+**Layer:** local operator host, not governance law  
+**Date:** May 9, 2026
+
+---
+
+## 1. Guiding sentence
+
+> Make Lumina start like a system, not like a scavenger hunt.
+
+The governed runtime substrate already exists. Lumina Studio exists. The runtime can emit receipts. Chamber can witness public snapshots. The next threshold is host shape: a clear way to install, start, observe, inspect, and return.
+
+Host Layer 001 creates that envelope.
+
+---
+
+## 2. What this layer adds
+
+Host Layer 001 adds a local system-start vocabulary:
+
+```bash
+lumina doctor
+lumina run
+lumina observe
+lumina state
+lumina studio
+```
+
+It does this through:
+
+- `bin/lumina` — single command entrypoint
+- `install/install_lumina.sh` — local symlink installer
+- `install/lumina_doctor.py` — readiness checker
+- `services/lumina_observer_service.py` — local observer loop skeleton
+- `services/lumina.service.example` — systemd-style service example
+- `docs/Lumina_Local_Runbook_001.md` — operator runbook
+
+---
+
+## 3. Authority boundary
+
+The host layer may:
+
+- route operator commands to existing governed scripts
+- check local file readiness
+- start Lumina Studio locally
+- run bounded Observation cycles
+- inspect emitted runtime state
+- provide service examples
+
+The host layer may not:
+
+- define mode legality
+- bypass `ModeGuard`
+- authorize mutation or promotion
+- write canon lineage directly
+- alter checkpoint legality
+- treat Studio orientation as governance law
+- turn Chamber into an execution surface
+- execute ambiguous load-bearing intent without the runtime gates
+
+The host layer is a launcher and local envelope. Runtime law remains in the runtime substrate.
+
+---
+
+## 4. Command map
+
+### `lumina doctor`
+
+Checks whether the local bootstrap has the minimum pieces required to start.
+
+```bash
+lumina doctor
+lumina doctor --json
+```
+
+### `lumina run`
+
+Runs one governed Studio cycle through the existing runtime runner.
+
+```bash
+lumina run "Review Lumina OS progress and produce the next governed action receipt."
+```
+
+Useful variant:
+
+```bash
+lumina run "Inspect the runtime spine" \
+  --target-mode Observation \
+  --action-type audit \
+  --focus architecture \
+  --depth foundational \
+  --intent verify
+```
+
+### `lumina observe`
+
+Runs a bounded local Observation cycle and emits snapshot artifacts through the existing auto-snapshot runner.
+
+```bash
+lumina observe
+```
+
+### `lumina state`
+
+Reads recent emitted runtime receipts through the read-only Studio state browser.
+
+```bash
+lumina state --limit 12
+```
+
+### `lumina studio`
+
+Starts the local browser surface.
+
+```bash
+lumina studio
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8765/studio
+```
+
+---
+
+## 5. Why this matters
+
+Before Host Layer 001, Lumina could run, but the operator needed to know too much about internal paths.
+
+After Host Layer 001, the operator can begin with a small vocabulary:
+
+```text
+doctor -> run -> observe -> state -> studio
+```
+
+That is the difference between an artifact collection and a local operating environment.
+
+---
+
+## 6. Non-goals
+
+Host Layer 001 does not claim to be a full operating system kernel, package manager, multi-user shell, background agent platform, or public deployment target.
+
+It is the first system-start layer for the governed Lumina runtime substrate.
+
+---
+
+## 7. Next thresholds
+
+After Host Layer 001, the next OS-ward hardening steps are:
+
+1. Add a supported package/install path with dependency locking.
+2. Add state schema validation and migration checks.
+3. Add richer `lumina state` summaries and receipt comparison.
+4. Add preset-backed `lumina run` commands for common modes and orientations.
+5. Connect accepted Chamber queue items to governed runtime execution records.
+6. Add authentication before any remote Studio exposure.
+7. Promote the observer service from skeleton to supported local service after sea trials.
+
+---
+
+## 8. Closing clause
+
+Lumina should not require excavation before operation.
+
+The runtime may remain deep, governed, and carefully bounded.
+
+The start path should be simple:
+
+```bash
+lumina doctor
+lumina run
+```
+
+That is the door.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/install_lumina.sh
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/install_lumina.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lumina local installer.
+# Creates a user-local symlink named `lumina` pointing to the bootstrap host entrypoint.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOOTSTRAP_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LUMINA_BIN="${BOOTSTRAP_ROOT}/bin/lumina"
+INSTALL_DIR="${HOME}/.local/bin"
+TARGET="${INSTALL_DIR}/lumina"
+
+mkdir -p "${INSTALL_DIR}"
+chmod +x "${LUMINA_BIN}" || true
+ln -sfn "${LUMINA_BIN}" "${TARGET}"
+
+echo "Lumina host command installed: ${TARGET}"
+echo ""
+echo "Try:"
+echo "  lumina doctor"
+echo "  lumina run \"Review Lumina OS progress and produce the next governed action receipt.\""
+echo "  lumina observe"
+echo "  lumina state"
+echo "  lumina studio"
+echo ""
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *)
+    echo "Note: ${INSTALL_DIR} is not currently on PATH."
+    echo "Add this to your shell profile if needed:"
+    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    ;;
+esac

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_doctor.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_doctor.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Lumina local readiness checker.
+
+The doctor verifies that the local Lumina bootstrap has the minimum files needed
+to start like a system: host command, Studio CLI/server, runtime runner,
+state browser, capability registry, and core docs.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+REQUIRED_FILES = [
+    "bin/lumina",
+    "studio/lumina_cli.py",
+    "studio/lumina_studio_server.py",
+    "studio/lumina_state_browser.py",
+    "runtime/runtime_runner_r1_merged.py",
+    "runtime/runtime_runner_auto_snapshot_r1.py",
+    "runtime/runtime_spine_r1.py",
+    "runtime/capability_registry_r1.json",
+    "runtime/input_integrity_layer_r1.py",
+    "runtime/governance_integrity_r1.py",
+    "runtime/canon_lineage_store_r1.py",
+    "docs/Lumina_OS_Host_Layer_001.md",
+    "docs/Lumina_Local_Runbook_001.md",
+]
+
+OPTIONAL_FILES = [
+    "services/lumina_observer_service.py",
+    "services/lumina.service.example",
+    "docs/lumina_studio_v0_1_spec.md",
+    "docs/lumina_next_build_plan_001.md",
+]
+
+PYTHON_IMPORT_CHECKS = [
+    "runtime/runtime_runner_r1_merged.py",
+    "studio/lumina_cli.py",
+    "studio/lumina_state_browser.py",
+]
+
+
+def file_check(path_text: str, *, required: bool = True) -> Dict[str, Any]:
+    path = BOOTSTRAP_ROOT / path_text
+    return {
+        "path": path_text,
+        "exists": path.exists(),
+        "required": required,
+        "is_file": path.is_file(),
+        "executable": os.access(path, os.X_OK) if path.exists() else False,
+    }
+
+
+def import_check(path_text: str) -> Dict[str, Any]:
+    path = BOOTSTRAP_ROOT / path_text
+    if not path.exists():
+        return {"path": path_text, "ok": False, "reason": "missing file"}
+    try:
+        spec = importlib.util.spec_from_file_location("lumina_doctor_probe", path)
+        ok = spec is not None and spec.loader is not None
+        return {"path": path_text, "ok": bool(ok), "reason": "loadable spec" if ok else "no import spec"}
+    except Exception as exc:
+        return {"path": path_text, "ok": False, "reason": str(exc)}
+
+
+def capability_registry_check() -> Dict[str, Any]:
+    path = BOOTSTRAP_ROOT / "runtime" / "capability_registry_r1.json"
+    if not path.exists():
+        return {"ok": False, "reason": "capability registry missing"}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        capabilities = payload.get("capabilities", [])
+        ids = [item.get("capability_id") for item in capabilities if isinstance(item, dict)]
+        required_ids = {"session_state_manager", "mode_guard", "context_bundle_builder", "input_integrity_assessor"}
+        missing = sorted(required_ids - set(ids))
+        return {
+            "ok": not missing,
+            "version": payload.get("version"),
+            "capability_count": len(ids),
+            "missing_required_ids": missing,
+        }
+    except Exception as exc:
+        return {"ok": False, "reason": str(exc)}
+
+
+def state_path_check() -> Dict[str, Any]:
+    state_root = REPO_ROOT / ".lumina_state" / "ship_of_ethereon_v2"
+    return {
+        "state_root": str(state_root),
+        "exists": state_root.exists(),
+        "note": "state root is created by runtime cycles; missing is acceptable before first run",
+    }
+
+
+def run_doctor() -> Dict[str, Any]:
+    required = [file_check(path, required=True) for path in REQUIRED_FILES]
+    optional = [file_check(path, required=False) for path in OPTIONAL_FILES]
+    imports = [import_check(path) for path in PYTHON_IMPORT_CHECKS]
+    registry = capability_registry_check()
+    missing_required = [item["path"] for item in required if not item["exists"] or not item["is_file"]]
+    failed_imports = [item for item in imports if not item["ok"]]
+    ok = not missing_required and not failed_imports and bool(registry.get("ok"))
+    return {
+        "schema_version": "lumina-doctor-v0.1",
+        "ok": ok,
+        "bootstrap_root": str(BOOTSTRAP_ROOT),
+        "repo_root": str(REPO_ROOT),
+        "python": sys.version.split()[0],
+        "required_files": required,
+        "optional_files": optional,
+        "import_checks": imports,
+        "capability_registry": registry,
+        "state": state_path_check(),
+        "missing_required_files": missing_required,
+        "failed_imports": failed_imports,
+    }
+
+
+def print_human(payload: Dict[str, Any]) -> None:
+    print("Lumina doctor")
+    print(f"  ok:              {payload['ok']}")
+    print(f"  bootstrap root:  {payload['bootstrap_root']}")
+    print(f"  python:          {payload['python']}")
+    print(f"  registry ok:     {payload['capability_registry'].get('ok')}")
+    print(f"  capability count:{payload['capability_registry'].get('capability_count')}")
+    if payload["missing_required_files"]:
+        print("  missing required:")
+        for item in payload["missing_required_files"]:
+            print(f"    - {item}")
+    if payload["failed_imports"]:
+        print("  failed imports:")
+        for item in payload["failed_imports"]:
+            print(f"    - {item['path']}: {item['reason']}")
+    if not payload["missing_required_files"] and not payload["failed_imports"]:
+        print("  start command:   bin/lumina run")
+        print("  observe command: bin/lumina observe")
+        print("  state command:   bin/lumina state")
+        print("  studio command:  bin/lumina studio")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check local Lumina host readiness.")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    payload = run_doctor()
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print_human(payload)
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/services/lumina.service.example
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/services/lumina.service.example
@@ -1,0 +1,17 @@
+# Example systemd unit for a local Lumina observer service.
+# Copy to ~/.config/systemd/user/lumina-observer.service or /etc/systemd/system/lumina-observer.service
+# after adjusting WorkingDirectory and ExecStart for your local checkout.
+
+[Unit]
+Description=Lumina OS Local Observer Service
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/absolute/path/to/EthereonLabs/LuminaOS/bootstrap/Ship_of_Ethereon_V2
+ExecStart=/usr/bin/env python3 services/lumina_observer_service.py --interval-seconds 21600
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/services/lumina_observer_service.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/services/lumina_observer_service.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Lumina local observer service skeleton.
+
+Runs bounded Observation cycles on an interval by delegating to the existing
+`bin/lumina observe` command. This is intentionally small: it does not create
+new runtime law, execute arbitrary tasks, or bypass governance. It is a host
+loop around an already-governed observation cycle.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+LUMINA = BOOTSTRAP_ROOT / "bin" / "lumina"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def run_observation(action: str) -> int:
+    print(f"[{utc_now()}] Lumina observer: starting {action}", flush=True)
+    proc = subprocess.run([sys.executable, str(LUMINA), "observe", "--action", action], cwd=str(BOOTSTRAP_ROOT))
+    print(f"[{utc_now()}] Lumina observer: cycle exit={proc.returncode}", flush=True)
+    return int(proc.returncode)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run bounded Lumina Observation cycles on a local interval.")
+    parser.add_argument("--interval-seconds", type=int, default=21600, help="Default: 6 hours")
+    parser.add_argument("--once", action="store_true", help="Run one cycle and exit.")
+    parser.add_argument("--action-prefix", default="local_observer_service_cycle")
+    args = parser.parse_args()
+
+    count = 0
+    while True:
+        count += 1
+        exit_code = run_observation(f"{args.action_prefix}_{count:04d}")
+        if args.once:
+            return exit_code
+        sleep_for = max(60, int(args.interval_seconds))
+        print(f"[{utc_now()}] Lumina observer: sleeping {sleep_for}s", flush=True)
+        time.sleep(sleep_for)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/START_HERE_LUMINA_OS.md
+++ b/START_HERE_LUMINA_OS.md
@@ -2,6 +2,45 @@
 
 This file exists because the primary **Lumina OS** substrate is easy to miss if you enter this repository from the newest public-facing or experimental work.
 
+## Fastest local host start
+
+Lumina should start like a system, not like a scavenger hunt.
+
+Begin here:
+
+```bash
+cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
+python install/lumina_doctor.py
+```
+
+Optional local command install:
+
+```bash
+bash install/install_lumina.sh
+```
+
+Then use:
+
+```bash
+lumina doctor
+lumina run "Review Lumina OS progress and produce the next governed action receipt."
+lumina observe
+lumina state --limit 12
+lumina studio
+```
+
+Without installing, use:
+
+```bash
+python bin/lumina doctor
+python bin/lumina run "Review Lumina OS progress and produce the next governed action receipt."
+```
+
+Host-layer docs:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_OS_Host_Layer_001.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Local_Runbook_001.md`
+
 ## Canonical start path
 
 Begin here:
@@ -19,6 +58,16 @@ Primary guide files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Quantum_Concepts_Boundary_r1.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_studio_v0_1_spec.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_next_build_plan_001.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_OS_Host_Layer_001.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Local_Runbook_001.md`
+
+Primary host-layer files inside that path:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/lumina`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/install_lumina.sh`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_doctor.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/services/lumina_observer_service.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/services/lumina.service.example`
 
 Primary runtime files inside that path:
 
@@ -55,30 +104,8 @@ Primary Studio operator-surface files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/README.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_cli.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_studio_server.py`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_state_browser.py`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_v0_1.py`
-
-## Fastest operator entry
-
-For a local governed cycle, start with Studio:
-
-```bash
-cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
-python studio/lumina_cli.py "Review Lumina OS progress and produce the next governed action receipt."
-```
-
-For the local browser surface:
-
-```bash
-python studio/lumina_studio_server.py
-```
-
-Then open:
-
-```text
-http://127.0.0.1:8765/studio
-```
-
-Studio is local-first and not a public Chamber page. It packages requests, invokes the governed runtime, and displays receipts.
 
 ## What this path is
 
@@ -104,23 +131,30 @@ It is the correct place to start when the task is about:
 - checkpoint-refreshed self-guidance history
 - bounded orchestration from restored context into runtime execution
 - continuity of pattern across restored context, orientation changes, advisory recommendation, and governed execution
-- local operator execution through Lumina Studio v0.1
+- local operator execution through Lumina Studio
+- local host-layer startup through the `lumina` command
 
 ## Current truth
 
 1. **Lumina OS governed substrate starts in the bootstrap path above.**
-2. **The orchestration lane now sits above that substrate and remains subordinate to runtime law.**
-3. **Lumina Studio is now the first local operator surface for running a governed cycle and reading the receipt.**
-4. **Chamber is a parallel app/public lane, not the same thing as the Lumina OS substrate, but it now includes a consent surface for advisory acceptance / rejection and supervised queue state.**
-5. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap now contains the preferred bridge paths for project return, workspace-host behavior, bounded self-guidance, checkpoint-refreshed guidance history, and bounded orchestration.**
-6. **Quantum-adjacent language is now explicitly bounded: useful for modeling observation, coherence, branching, and recomposition, but not allowed to imply literal quantum hardware or runtime authority.**
-7. **Orchestration continuity now has a dedicated sea-trial verifier for restored context, orientation shifts, advisory recommendation, and governed execution.**
-8. **If you are trying to understand the Ship-derived runtime core, do not begin with Chamber. Begin with the bootstrap path.**
+2. **The host layer now provides a system-like local start vocabulary: `doctor`, `run`, `observe`, `state`, and `studio`.**
+3. **The orchestration lane sits above the substrate and remains subordinate to runtime law.**
+4. **Lumina Studio is the local operator surface for running a governed cycle and reading the receipt.**
+5. **Chamber is a parallel app/public lane, not the same thing as the Lumina OS substrate, but it includes a consent surface for advisory acceptance / rejection and supervised queue state.**
+6. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap contains the preferred bridge paths for project return, workspace-host behavior, bounded self-guidance, checkpoint-refreshed guidance history, and bounded orchestration.**
+7. **Quantum-adjacent language is explicitly bounded: useful for modeling observation, coherence, branching, and recomposition, but not allowed to imply literal quantum hardware or runtime authority.**
+8. **Orchestration continuity has a dedicated sea-trial verifier for restored context, orientation shifts, advisory recommendation, and governed execution.**
+9. **If you are trying to understand the Ship-derived runtime core, do not begin with Chamber. Begin with the bootstrap path and the host-layer command.**
 
 ## Parallel lanes in this repository
 
 ### Lumina OS governed substrate
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`
+
+### Lumina host layer
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/lumina`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/services/`
 
 ### Lumina Studio local operator surface
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/`
@@ -140,12 +174,14 @@ It is the correct place to start when the task is about:
 ## Recommended navigation order
 
 1. Read this file.
-2. Open `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md`.
-3. For a runnable proof, open `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/README.md` and run the Studio CLI.
-4. Read `README_IMPORT.md`, `REPO_NATIVE_BOOTSTRAP_NOTE.md`, `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`, `SELF_GUIDANCE_STEWARD_NOTE_R1.md`, `LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`, `docs/Quantum_Concepts_Boundary_r1.md`, and `docs/lumina_studio_v0_1_spec.md`.
-5. Inspect `runtime/` in that subtree, including the repo-native return / workspace-host modules, the bridged runner, the self-guided bridge runner, the checkpoint-refreshed guidance history rail, `quantum_concepts_registry_r1.json`, `branch_resolution_model_r1.json`, and `sea_trials_quantum_boundary_r1.py`.
-6. Inspect `lumina_context_loader_v0_1.py`, `lumina_decision_engine_v0_1.py`, `lumina_orchestrator_v0_4.py`, `sea_trials_lumina_orchestration_stack_r1.py`, and `sea_trials_lumina_orchestration_continuity_r1.py`.
-7. Only then branch outward into Chamber and its advisory / queue persistence lane.
+2. Run `python install/lumina_doctor.py` from `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`.
+3. Open `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md`.
+4. For a runnable proof, run `python bin/lumina run "Review Lumina OS progress."` or install the command with `bash install/install_lumina.sh`.
+5. Read `docs/Lumina_OS_Host_Layer_001.md` and `docs/Lumina_Local_Runbook_001.md`.
+6. Read `README_IMPORT.md`, `REPO_NATIVE_BOOTSTRAP_NOTE.md`, `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`, `SELF_GUIDANCE_STEWARD_NOTE_R1.md`, `LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`, `docs/Quantum_Concepts_Boundary_r1.md`, and `docs/lumina_studio_v0_1_spec.md`.
+7. Inspect `runtime/` in that subtree, including the repo-native return / workspace-host modules, the bridged runner, the self-guided bridge runner, the checkpoint-refreshed guidance history rail, `quantum_concepts_registry_r1.json`, `branch_resolution_model_r1.json`, and `sea_trials_quantum_boundary_r1.py`.
+8. Inspect `lumina_context_loader_v0_1.py`, `lumina_decision_engine_v0_1.py`, `lumina_orchestrator_v0_4.py`, `sea_trials_lumina_orchestration_stack_r1.py`, and `sea_trials_lumina_orchestration_continuity_r1.py`.
+9. Only then branch outward into Chamber and its advisory / queue persistence lane.
 
 ## Assistant note
 


### PR DESCRIPTION
## Summary

Adds **Lumina OS Host Layer 001** so Lumina starts like a system, not like a scavenger hunt.

## Why

The governed runtime substrate already exists, Studio exists, Observation cycles emit receipts, and state can be inspected. The next OS-ward threshold is a clear local host vocabulary for starting, running, observing, inspecting, and returning.

## Adds

- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/lumina`
  - single local command entrypoint
  - subcommands: `doctor`, `run`, `observe`, `state`, `studio`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/install_lumina.sh`
  - optional symlink install into `~/.local/bin/lumina`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_doctor.py`
  - local readiness checker
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/services/lumina_observer_service.py`
  - bounded local Observation service skeleton
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/services/lumina.service.example`
  - example systemd-style service file
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_OS_Host_Layer_001.md`
- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Local_Runbook_001.md`

## Updates

- `START_HERE_LUMINA_OS.md` now begins with the host-layer path and command vocabulary.

## Operator vocabulary

```bash
lumina doctor
lumina run "Review Lumina OS progress and produce the next governed action receipt."
lumina observe
lumina state --limit 12
lumina studio
```

Without installing:

```bash
python bin/lumina doctor
python bin/lumina run "Review Lumina OS progress."
```

## Boundary preserved

This host layer is a launcher and local envelope only. It does not define mode legality, mutation authority, promotion authority, canon lineage, checkpoint truth, symbolic dependency boundaries, or user consent. Runtime law remains owned by the governed substrate.

## Validation note

I compared the branch against `main`: 8 commits ahead, 8 files changed, no branch divergence. I did not execute the scripts in a cloned local environment from this connector session.