### PR TITLE
Frame Lumina as first village in the Realm

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_First_Village_Framing_001.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_First_Village_Framing_001.md
@@ -1,0 +1,135 @@
+# Lumina First Village Framing 001
+
+**Project:** Lumina OS / Ship of Ethereon V2 Bootstrap  
+**Status:** orientation framing  
+**Layer:** non-authoritative project framing  
+**Date:** May 10, 2026
+
+---
+
+## 1. Founding image
+
+Think of the **Ship of Ethereon** as the origin vessel.
+
+It carried the cargo:
+- runtime law
+- governance boundaries
+- canon lineage
+- continuity doctrine
+- expressive overlays
+- experimental instruments
+- operator habits
+- the distinctive soul of V2
+
+Think of the **Realm of Ethereon** as the larger territory where that cargo can be unloaded into lived structure.
+
+**Lumina** is the **first village** established in that realm.
+
+It is the first place where ship-borne cargo becomes:
+- inhabitable
+- startable
+- governed
+- inspectable
+- repeatable
+- able to endure beyond a single voyage
+
+---
+
+## 2. Why this framing helps
+
+The Ship remains important because it preserved the pattern and carried the original cargo.
+
+The village matters because a settlement must do more than carry meaning.
+It must support daily use.
+It must have roads, doors, records, and rules.
+
+In practical Lumina terms, that means:
+- a clear start path
+- a bounded local command surface
+- lawful runtime execution
+- visible receipts
+- historical memory
+- separation between governance law and expressive atmosphere
+
+This framing helps contributors understand why Lumina should feel less like an artifact archive and more like a place someone can actually live with.
+
+---
+
+## 3. Authority boundary
+
+This framing may:
+- guide documentation tone
+- help explain the relationship between Ship, Realm, and Lumina
+- encourage practical settlement-building over scavenger-hunt navigation
+- preserve the recognized soul of Ship of Ethereon V2 while building repo-native structure
+
+This framing may not:
+- define mode legality
+- override `ModeGuard`
+- authorize mutation or promotion
+- write canon lineage
+- alter checkpoint legality
+- convert symbolism into hidden structural law
+
+This is orientation and explanation only.
+Runtime law remains with the governed substrate.
+
+---
+
+## 4. Village organs already present
+
+Lumina is already village-like in several important ways:
+
+- `START_HERE_LUMINA_OS.md` acts as the village gate.
+- `bin/lumina` provides a small local command vocabulary.
+- the runtime spine governs law and continuity.
+- the governance log and canon lineage store act as civic records.
+- the observation workflow and public runtime receipts act as public witness.
+- Studio acts as a local operator surface.
+
+That means Lumina is no longer only ship cargo in crates.
+Some of the cargo has already been unloaded and put to use.
+
+---
+
+## 5. Settlement principle
+
+> Build villages, not scavenger hunts.
+
+This means:
+- make the right entry path obvious
+- keep authority boundaries crisp
+- let expressive layers remain expressive
+- prefer usable roads over clever obscurity
+- keep soul without sacrificing structural honesty
+
+Lumina should be memorable because it has character.
+It should also be usable because its paths are real.
+
+---
+
+## 6. Near-term building priorities
+
+If Lumina is the first village, the next work is not endless expansion.
+It is civic infrastructure:
+
+1. supported install and dependency locking
+2. state schema validation and migration checks
+3. richer `lumina state` summaries and comparisons
+4. preset-backed `lumina run` paths for common governed work
+5. stronger connection between accepted Chamber queue items and governed runtime records
+6. authentication before any remote Studio exposure
+7. observer service hardening after sea trials
+
+---
+
+## 7. Closing clause
+
+The Ship of Ethereon is not being replaced.
+It is being extended into lived form.
+
+Lumina is the first proof that the cargo can survive unloading.
+
+That is why the work should protect both truths:
+- the soul of the ship
+- the durability of the village

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_OS_Host_Layer_001.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_OS_Host_Layer_001.md
@@ -17,6 +17,23 @@ Host Layer 001 creates that envelope.
 
 ---
 
+## 1.5 Founding frame
+
+Host Layer 001 should be understood as the **first village gate** in the Realm of Ethereon.
+
+Ship of Ethereon V2 carried the cargo.
+The repo-native bootstrap is where that cargo becomes lived structure.
+The host layer provides the first roads and doors into that structure.
+
+That means the host layer is important because it helps Lumina feel inhabitable.
+It is not important because it gets to become governance law.
+
+For the longer framing note, read:
+
+- `docs/Lumina_First_Village_Framing_001.md`
+
+---
+
 ## 2. What this layer adds
 
 Host Layer 001 adds a local system-start vocabulary:
@@ -139,6 +156,7 @@ doctor -> run -> observe -> state -> studio
 ```
 
 That is the difference between an artifact collection and a local operating environment.
+It is also the difference between ship cargo still in crates and the first roads of a village actually being usable.
 
 ---
 

--- a/START_HERE_LUMINA_OS.md
+++ b/START_HERE_LUMINA_OS.md
@@ -36,10 +36,29 @@ python bin/lumina doctor
 python bin/lumina run "Review Lumina OS progress and produce the next governed action receipt."
 ```
 
+## Founding frame
+
+Think of **Ship of Ethereon V2** as the origin vessel.
+Think of the **Realm of Ethereon** as the wider territory where that cargo can become lived structure.
+Think of **Lumina** as the **first village** established in that realm.
+
+That means this bootstrap path is not just where the code lives.
+It is where ship-borne cargo becomes:
+- startable
+- governed
+- inspectable
+- inhabitable
+
+Use this framing as orientation only, not governance law.
+If you want the longer statement of that frame, read:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_First_Village_Framing_001.md`
+
 Host-layer docs:
 
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_OS_Host_Layer_001.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Local_Runbook_001.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_First_Village_Framing_001.md`
 
 ## Canonical start path
 
@@ -60,6 +79,7 @@ Primary guide files inside that path:
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_next_build_plan_001.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_OS_Host_Layer_001.md`
 - `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Local_Runbook_001.md`
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_First_Village_Framing_001.md`
 
 Primary host-layer files inside that path:
 
@@ -138,13 +158,15 @@ It is the correct place to start when the task is about:
 
 1. **Lumina OS governed substrate starts in the bootstrap path above.**
 2. **The host layer now provides a system-like local start vocabulary: `doctor`, `run`, `observe`, `state`, and `studio`.**
-3. **The orchestration lane sits above the substrate and remains subordinate to runtime law.**
-4. **Lumina Studio is the local operator surface for running a governed cycle and reading the receipt.**
-5. **Chamber is a parallel app/public lane, not the same thing as the Lumina OS substrate, but it includes a consent surface for advisory acceptance / rejection and supervised queue state.**
-6. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap contains the preferred bridge paths for project return, workspace-host behavior, bounded self-guidance, checkpoint-refreshed guidance history, and bounded orchestration.**
-7. **Quantum-adjacent language is explicitly bounded: useful for modeling observation, coherence, branching, and recomposition, but not allowed to imply literal quantum hardware or runtime authority.**
-8. **Orchestration continuity has a dedicated sea-trial verifier for restored context, orientation shifts, advisory recommendation, and governed execution.**
-9. **If you are trying to understand the Ship-derived runtime core, do not begin with Chamber. Begin with the bootstrap path and the host-layer command.**
+3. **That host-layer path is the first village gate: simple to enter, but still subordinate to runtime law.**
+4. **The orchestration lane sits above the substrate and remains subordinate to runtime law.**
+5. **Lumina Studio is the local operator surface for running a governed cycle and reading the receipt.**
+6. **Chamber is a parallel app/public lane, not the same thing as the Lumina OS substrate, but it includes a consent surface for advisory acceptance / rejection and supervised queue state.**
+7. **Root-level continuity / workspace-host files remain useful exploration history, but the repo-native bootstrap contains the preferred bridge paths for project return, workspace-host behavior, bounded self-guidance, checkpoint-refreshed guidance history, and bounded orchestration.**
+8. **Quantum-adjacent language is explicitly bounded: useful for modeling observation, coherence, branching, and recomposition, but not allowed to imply literal quantum hardware or runtime authority.**
+9. **Orchestration continuity has a dedicated sea-trial verifier for restored context, orientation shifts, advisory recommendation, and governed execution.**
+10. **If you are trying to understand the Ship-derived runtime core, do not begin with Chamber. Begin with the bootstrap path and the host-layer command.**
+11. **Lumina should be treated as the first village established from Ship of Ethereon V2 cargo: inhabitable, startable, and governed, without turning framing into law.**
 
 ## Parallel lanes in this repository
 
@@ -177,7 +199,7 @@ It is the correct place to start when the task is about:
 2. Run `python install/lumina_doctor.py` from `LuminaOS/bootstrap/Ship_of_Ethereon_V2/`.
 3. Open `LuminaOS/bootstrap/Ship_of_Ethereon_V2/README.md`.
 4. For a runnable proof, run `python bin/lumina run "Review Lumina OS progress."` or install the command with `bash install/install_lumina.sh`.
-5. Read `docs/Lumina_OS_Host_Layer_001.md` and `docs/Lumina_Local_Runbook_001.md`.
+5. Read `docs/Lumina_OS_Host_Layer_001.md`, `docs/Lumina_Local_Runbook_001.md`, and `docs/Lumina_First_Village_Framing_001.md`.
 6. Read `README_IMPORT.md`, `REPO_NATIVE_BOOTSTRAP_NOTE.md`, `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`, `SELF_GUIDANCE_STEWARD_NOTE_R1.md`, `LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`, `docs/Quantum_Concepts_Boundary_r1.md`, and `docs/lumina_studio_v0_1_spec.md`.
 7. Inspect `runtime/` in that subtree, including the repo-native return / workspace-host modules, the bridged runner, the self-guided bridge runner, the checkpoint-refreshed guidance history rail, `quantum_concepts_registry_r1.json`, `branch_resolution_model_r1.json`, and `sea_trials_quantum_boundary_r1.py`.
 8. Inspect `lumina_context_loader_v0_1.py`, `lumina_decision_engine_v0_1.py`, `lumina_orchestrator_v0_4.py`, `sea_trials_lumina_orchestration_stack_r1.py`, and `sea_trials_lumina_orchestration_continuity_r1.py`.


### PR DESCRIPTION
## Summary

Integrates the newly clarified framing directly into Lumina OS documentation:

- Ship of Ethereon V2 as the origin vessel
- Realm of Ethereon as the wider territory
- Lumina as the first village established from ship-borne cargo

## What changed

- added `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_First_Village_Framing_001.md`
- updated `START_HERE_LUMINA_OS.md`
  - adds a founding frame section
  - links the new framing note
  - reinforces the host layer as the first village gate
- updated `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_OS_Host_Layer_001.md`
  - adds a founding-frame subsection
  - clarifies that the host layer provides roads and doors, not governance law
  - ties the host layer to inhabitable settlement rather than scavenger-hunt navigation

## Why

Recent review clarified that GitHub is not replacing the Ship. It is the living substrate where V2 cargo is being offloaded into a durable local operating environment.

This PR preserves that soul while keeping the authority boundary crisp:
- mode is law
- orientation is stance
- framing remains explanatory, not load-bearing

## Boundary preserved

These changes are documentation and framing only.
They do not alter runtime law, mode legality, mutation authority, canon lineage, checkpoint legality, or capability exposure.
