### PR TITLE
Map current EthereonLabs operating structure

### DIFF
--- a/CURRENT_OPERATING_MAP.md
+++ b/CURRENT_OPERATING_MAP.md
@@ -1,0 +1,60 @@
+# Current Operating Map
+
+**Status:** active navigation aid.  
+**Scope:** repository orientation, not runtime authority.
+
+This file gives a fast map of the current EthereonLabs lanes.
+
+## Primary lanes
+
+| Lane | Path | Role |
+|---|---|---|
+| Lumina OS substrate | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/` | Active governed runtime scaffold |
+| Lumina host layer | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/`, `install/`, `services/` | Local command, doctor, observer, service examples |
+| Lumina Studio | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/` | Local operator surface |
+| Lumina orchestration | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_*` | Context loading and action routing |
+| Self-guidance and reflection | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_*`, `runtime/lumina_reflective_*` | Advisory recommendation and reflection before guidance |
+| Chamber | `chamber.html`, `chamber-app/`, `docs/chamber_*` | Public interface and app lane |
+| RSE research | `research/rse_crystalline/` | Research, simulations, and figures |
+| Ship of Ethereon Psi Class | `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`, `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/` | Staging and project consolidation |
+| Lumina Lisp | `lumina/lisp/` | Non-executable symbolic snapshots |
+| Root spikes | `continuity_restore_spike_r1.py`, `lumina_workspace_host_spike_r1.py` | Reference / exploration history |
+
+## Current active Lumina path
+
+```text
+host or Studio
+  -> project return / host context
+  -> reflective trace
+  -> self-guidance advisory
+  -> governed runtime cycle
+  -> checkpoint and receipt
+```
+
+Short form:
+
+```text
+return -> reflect -> recommend -> govern -> record
+```
+
+## Start points
+
+- New human reader: `START_HERE_HUMANS.md`
+- Lumina OS work: `START_HERE_LUMINA_OS.md`
+- Active Lumina file ownership: `LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md`
+- Psi Class staging: `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`
+- Lisp symbolic continuity: `lumina/lisp/README.md`
+
+## Boundary reminders
+
+- Runtime work belongs in the Lumina OS substrate lane.
+- Reflection and self-guidance are advisory.
+- Chamber is public/app surface, not the runtime substrate.
+- RSE research does not define runtime behavior by default.
+- Lisp preserves thought-shapes and is not executable.
+- Psi Class is staging unless promoted through validated work.
+- Root spikes are reference material unless deliberately moved into the bootstrap path.
+
+## Next maintenance step
+
+Keep this file short. When a lane changes status, update this map and the matching lane-specific start file.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md
@@ -1,0 +1,126 @@
+# Active Runtime Index — Ship of Ethereon V2 / Lumina OS
+
+**Status:** active file-ownership index.  
+**Scope:** navigation only. Runtime source files remain authoritative.
+
+Use this file when you need to know which files currently own which part of the Lumina OS bootstrap.
+
+## Fast start
+
+```bash
+cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
+python install/lumina_doctor.py
+python bin/lumina run "Review Lumina OS progress and produce the next governed action receipt."
+python bin/lumina observe
+python bin/lumina state --limit 12
+```
+
+## Runtime core
+
+| Responsibility | Primary files |
+|---|---|
+| Runtime runner | `runtime/runtime_runner_r1_merged.py` |
+| Runtime spine / session / context / mode guard | `runtime/runtime_spine_r1.py` |
+| Capability exposure | `runtime/capability_registry_r1.json` |
+| Input ambiguity and correction safety | `runtime/input_integrity_layer_r1.py` |
+| Governance integrity chain | `runtime/governance_integrity_r1.py` |
+| Canon lineage | `runtime/canon_lineage_store_r1.py` |
+| Ethereonic overlay boundary | `runtime/ethereonic_layer_r1.py`, `runtime/ethereonic_layer_registry_r1.json` |
+
+## Return, host, and continuity
+
+| Responsibility | Primary files |
+|---|---|
+| Repo-native project return | `runtime/project_return_repo_native_r1.py` |
+| Workspace host state | `runtime/workspace_host_repo_native_r1.py` |
+| Return / host runner bridge | `runtime/runtime_runner_return_host_bridge_r1.py` |
+| Return host bridge helper | `runtime/lumina_return_host_repo_native_bridge_r1.py` |
+
+## Self-guidance and reflection
+
+| Responsibility | Primary files |
+|---|---|
+| Bounded next-action advisory | `runtime/lumina_self_guidance_steward_r1.py` |
+| Checkpoint-linked advisory history | `runtime/lumina_self_guidance_history_r1.py` |
+| Self-guided runner bridge | `runtime/runtime_runner_self_guided_bridge_r1.py` |
+| Recursive reflection motif | `runtime/lumina_reflective_autonomy_layer_r1.py` |
+| Reflection-before-guidance runner bridge | `runtime/runtime_runner_reflective_self_guided_bridge_r1.py` |
+
+Current motif:
+
+```text
+return -> reflect -> recommend -> govern -> record
+```
+
+Reflection and self-guidance are advisory. They do not own mode legality, mutation permission, canon lineage, promotion gates, checkpoint legality, or consent.
+
+## Orchestration lane
+
+| Responsibility | Primary files |
+|---|---|
+| Context loading | `lumina_context_loader_v0_1.py` |
+| Next-action selection | `lumina_decision_engine_v0_1.py` |
+| Orchestration runner | `lumina_orchestrator_v0_4.py` |
+| Orchestration stack validation | `sea_trials_lumina_orchestration_stack_r1.py` |
+| Orchestration continuity validation | `sea_trials_lumina_orchestration_continuity_r1.py` |
+
+## Host layer
+
+| Responsibility | Primary files |
+|---|---|
+| Local command entry | `bin/lumina` |
+| Installer | `install/install_lumina.sh` |
+| Doctor | `install/lumina_doctor.py` |
+| Observer service | `services/lumina_observer_service.py` |
+| Service example | `services/lumina.service.example` |
+
+## Studio
+
+| Responsibility | Primary files |
+|---|---|
+| Studio docs | `studio/README.md`, `docs/lumina_studio_v0_1_spec.md` |
+| CLI surface | `studio/lumina_cli.py` |
+| Local server | `studio/lumina_studio_server.py` |
+| State browser | `studio/lumina_state_browser.py` |
+| Studio sea trial | `sea_trials_lumina_studio_v0_1.py` |
+
+## Psi-42 and quantum-adjacent boundaries
+
+| Responsibility | Primary files |
+|---|---|
+| Psi-42 transceiver | `runtime/psi42_transceiver_v1_6.py` |
+| Quantum terminology boundary | `docs/Quantum_Concepts_Boundary_r1.md` |
+| Quantum concepts registry | `runtime/quantum_concepts_registry_r1.json` |
+| Branch resolution model | `runtime/branch_resolution_model_r1.json` |
+| Quantum boundary sea trial | `runtime/sea_trials_quantum_boundary_r1.py` |
+
+Psi-42 is an instrument. It does not own governance, canon, or runtime law.
+
+## Sea trials
+
+| Validation target | Primary file |
+|---|---|
+| Core runtime / governance / canon | `runtime/sea_trials_set_one_r1_merged.py` |
+| Self-guidance | `runtime/sea_trials_lumina_self_guidance_r1.py` |
+| Reflective autonomy | `sea_trials_lumina_reflective_autonomy_r1.py` |
+| Reflective autonomy wiring | `sea_trials_lumina_reflective_autonomy_wiring_r1.py` |
+| Orchestration stack | `sea_trials_lumina_orchestration_stack_r1.py` |
+| Orchestration continuity | `sea_trials_lumina_orchestration_continuity_r1.py` |
+| Studio | `sea_trials_lumina_studio_v0_1.py` |
+
+## Docs to read when uncertain
+
+- `README.md`
+- `README_IMPORT.md`
+- `REPO_NATIVE_BOOTSTRAP_NOTE.md`
+- `RETURN_WITH_STANCE_BOOTSTRAP_NOTE_R1.md`
+- `SELF_GUIDANCE_STEWARD_NOTE_R1.md`
+- `LUMINA_ORCHESTRATION_STACK_NOTE_R1.md`
+- `docs/Lumina_OS_Host_Layer_001.md`
+- `docs/Lumina_Local_Runbook_001.md`
+- `docs/Lumina_First_Village_Framing_001.md`
+- `docs/Lumina_Reflective_Autonomy_Layer_001.md`
+
+## Maintenance rule
+
+When a new runtime bridge, sea trial, or advisory layer becomes active, add it here. Keep prose short. This file is a map, not a doctrine.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ EthereonLabs is an experimental repository for continuity-oriented AI interface 
 
 This repository contains multiple active work lanes. The key distinction is that not every lane has the same authority: runtime files, public interface files, staging documents, and research experiments should not be treated as interchangeable.
 
+## Current Operating Map
+
+For the fastest current repository orientation, start with:
+
+- `CURRENT_OPERATING_MAP.md`
+
+This is the short harbor map for active lanes, current runtime path, symbolic-only layers, and recommended touch order.
+
 ## Lumina Lisp Layer
 
 Structured symbolic snapshots of system state, intent, and reflection.
@@ -23,6 +31,7 @@ Non-executable. Human-readable. System-aligned.
 ## Quick Start
 
 - New human reader: start with `START_HERE_HUMANS.md`.
+- Current operating map: start with `CURRENT_OPERATING_MAP.md`.
 - Lumina OS / runtime work: start with `START_HERE_LUMINA_OS.md`.
 - Ship of Ethereon Ψ Class staging: start with `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`.
 - Chamber / website work: start with `chamber.html`, `chamber-app/`, and `docs/chamber_*`.
@@ -98,6 +107,7 @@ Use this lane for simulations, figure generators, and exploratory artifacts supp
 
 ## Guidance
 
+- For current repo orientation, begin with `CURRENT_OPERATING_MAP.md`.
 - For Ship / Lumina OS substrate questions, begin with the bootstrap path.
 - For Ψ Class staging questions, begin with the Ψ Class start-here waypoint and staging bay.
 - For Chamber questions, begin with the Chamber lane.


### PR DESCRIPTION
## Summary

Adds a lightweight operating map for the repository and a focused active runtime index for the Lumina OS V2 bootstrap.

This is navigation work, not runtime-law work.

## Added

- `CURRENT_OPERATING_MAP.md`
  - one-page harbor map for current lanes
  - names active substrate, Chamber, RSE, Psi Class, Lisp, and exploratory spikes
  - captures the current Lumina flow:

```text
return -> reflect -> recommend -> govern -> record
```

- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md`
  - lean file-ownership index for the active V2 bootstrap
  - maps runtime core, return/host continuity, self-guidance/reflection, orchestration, host layer, Studio, Psi-42 boundaries, and sea trials

## Updated

- `README.md`
  - adds `CURRENT_OPERATING_MAP.md` as the fastest current orientation point
  - keeps existing lane structure intact

## Boundary

No folders moved. No runtime law changed. No capability registry altered.

This keeps the ship intact and adds better harbor signage.

## Notes

I intentionally left `START_HERE_LUMINA_OS.md` mostly untouched in this pass. It already works as a long-form entrypoint; the new `ACTIVE_RUNTIME_INDEX.md` gives the lean map beside it rather than bloating it further.