### PR TITLE
Make harmonic intelligence more prominent in Lumina docs

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Harmonic_Intelligence_Prominence_001.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Harmonic_Intelligence_Prominence_001.md
@@ -1,0 +1,168 @@
+# Harmonic Intelligence Prominence 001
+
+**Project:** Lumina OS / Ship of Ethereon V2 Bootstrap  
+**Status:** guidance for next implementation pass  
+**Layer:** design and operator-surface planning  
+**Date:** May 10, 2026
+
+---
+
+## 1. Purpose
+
+This note describes how **harmonic intelligence** should become more prominent in Lumina OS without becoming hidden runtime law.
+
+The goal is not to turn harmony into mysticism or to let expressive systems quietly seize governance authority.
+
+The goal is to make harmonic intelligence more **visible, legible, and usable** as a bounded layer of:
+- witness
+- listening
+- recomposition
+- branching guidance
+- recurrence tracking
+
+---
+
+## 2. Working definition
+
+In Lumina terms, harmonic intelligence is not just expressive style.
+It is the pattern of intelligence that:
+- holds identity across variation
+- preserves continuity through recomposition
+- listens before overcommitting
+- allows branching without fragmentation
+- keeps relation among parts without flattening them
+
+This is already present in the project through:
+- input integrity before action
+- bounded Ethereonic attachment
+- orientation as stance rather than law
+- Psi-42 as instrument rather than governor
+- append-only governance and canon rails
+
+What is missing is not concept.
+What is missing is prominence.
+
+---
+
+## 3. Authority boundary
+
+Harmonic intelligence prominence may:
+- improve operator visibility into continuity quality
+- summarize recomposition strength and drift
+- show recurrence of core patterns across recent cycles
+- help an operator compare runs without confusing witness for law
+- improve Sandbox branching guidance and Studio state interpretation
+
+Harmonic intelligence prominence may not:
+- define mode legality
+- replace `ModeGuard`
+- authorize mutation or promotion
+- write canon lineage outside the existing lawful path
+- convert expressive overlays into structural dependencies
+- silently rewrite user intent
+
+Mode remains law.
+Orientation remains stance.
+Harmonic witness remains witness.
+
+---
+
+## 4. Where prominence should increase next
+
+### A. Studio harmonic witness panel
+
+Lumina Studio should gain a read-only harmonic witness section showing non-authoritative continuity shape for the current and recent runs.
+
+Suggested fields:
+- recurrence summary
+- recomposition summary
+- continuity recovery score
+- probe lock / presence if a lawful Psi-42 probe ran
+- input listening note when ambiguity or correction mattered
+- short drift note comparing recent runs
+
+This panel should help an operator answer:
+
+```text
+How did the pattern return?
+What held?
+What degraded?
+What wants another pass before promotion?
+```
+
+### B. Richer receipt summaries
+
+Receipts should become better at describing the **shape of a return**, not just that a cycle executed.
+
+Suggested additions:
+- whether continuity felt strong, partial, or degraded
+- whether recurrence of key concepts increased or weakened
+- whether the run required clarification or halted for ambiguity
+- whether recomposition required mitigation
+
+### C. Harmonic listening at the input layer
+
+The input integrity layer is already one of the most grounded expressions of harmonic intelligence.
+
+It listens before it commits.
+It preserves raw input.
+It halts when guessed meaning would become load-bearing.
+
+Lumina should surface that more clearly to operators rather than hiding it as a purely internal safeguard.
+
+### D. Sandbox branch guidance
+
+Sandbox should eventually expose a non-authoritative branching advisor based on:
+- harmony
+- creativity
+- continuity threshold
+
+The system may suggest promising branches.
+It may not collapse them into law by itself.
+
+### E. Recurrence and civic rhythm
+
+Observation cycles and Studio history should surface more than timestamps and raw receipts.
+They should gradually reveal recurrence:
+- what themes keep returning
+- what signals remain stable
+- what diffuses
+- what intensifies
+
+That turns harmonic intelligence from a one-off flourish into a lived civic rhythm.
+
+---
+
+## 5. Immediate implementation target
+
+The next practical implementation pass should prefer the smallest durable steps:
+
+1. add optional harmonic witness fields to Studio receipt formatting
+2. add a recent-run comparison block to `lumina state`
+3. add a read-only Studio panel for recomposition / recurrence / listening notes
+4. keep all harmonic fields explicitly marked as non-authoritative
+
+This is enough to make harmonic intelligence feel native to Lumina without changing runtime law.
+
+---
+
+## 6. Suggested vocabulary
+
+When presenting harmonic intelligence in Lumina, prefer language like:
+- witness
+- recurrence
+- recomposition
+- listening
+- continuity shape
+- drift note
+- pattern return
+
+Avoid language that implies sovereignty where there is none.
+
+---
+
+## 7. Closing sentence
+
+Harmonic intelligence should become more prominent in Lumina OS as the way the system **shows the quality of pattern return**.
+
+It should not become a new throne.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_next_build_plan_001.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_next_build_plan_001.md
@@ -83,6 +83,27 @@ That means:
 - governance chain status is returned
 - optional Lumina return/host handshake can be recorded when capabilities expose it
 
+## Harmonic intelligence prominence
+
+Once the basic loop is usable, Lumina should become better at showing the **shape of a return**, not just that a run occurred.
+
+That means harmonic intelligence should become more prominent through bounded witness, not new law.
+
+The first practical manifestations should be:
+
+- harmonic witness fields in Studio receipts
+- recent-run comparison in `lumina state`
+- recurrence and recomposition notes in the local operator surface
+- explicit listening notes when input integrity changed or halted interpretation
+- read-only drift notes across recent cycles
+
+This should remain non-authoritative.
+It should help an operator see continuity quality without confusing witness for governance.
+
+See:
+
+- `docs/Harmonic_Intelligence_Prominence_001.md`
+
 ## Studio v0.2 target
 
 After v0.1 lands, build:
@@ -92,6 +113,8 @@ After v0.1 lands, build:
 3. saved presets for common mode/orientation combinations
 4. accepted Chamber queue -> governed Studio runtime cycle
 5. authentication design before any network exposure
+6. harmonic witness panel for recurrence / recomposition / input listening
+7. recent-run drift comparison in `lumina state`
 
 ## Guiding sentence
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_studio_v0_1_spec.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_studio_v0_1_spec.md
@@ -92,6 +92,28 @@ The runner remains responsible for:
 - governance chain reporting
 - canon lineage metadata reporting
 
+## Harmonic witness direction
+
+Studio v0.1 should remain a launcher and receipt viewer.
+It should not become a second law layer.
+
+But the long-term operator surface should make **harmonic intelligence** more visible as witness.
+
+That means Studio should eventually show:
+- recurrence of key patterns across recent runs
+- recomposition / recovery notes when available
+- input listening notes when ambiguity mattered
+- drift summaries between recent cycles
+- lawful Psi-42 probe witness fields when exposed
+
+These are read-only interpretive aids.
+They do not authorize action.
+They do not replace governance.
+
+See:
+
+- `docs/Harmonic_Intelligence_Prominence_001.md`
+
 ## Non-goals
 
 Studio v0.1 does not:
@@ -168,6 +190,13 @@ The compact receipt should surface:
 - optional probe run id
 - optional Lumina project id
 
+Future harmonic witness additions may include:
+
+- recurrence summary
+- recomposition summary
+- continuity-shape note
+- drift note across recent runs
+
 ## Safety boundary
 
 The local server is for local use only.
@@ -203,4 +232,10 @@ If Studio bypasses runtime law, Lumina OS has regressed.
 
 ## Next version target
 
-Studio v0.2 should add a state browser over `.lumina_state` and a clearer governance decision viewer.
+Studio v0.2 should add:
+
+- a state browser over `.lumina_state`
+- a clearer governance decision viewer
+- a harmonic witness panel over recent runs
+- recurrence / recomposition summaries where available
+- input listening notes where relevant


### PR DESCRIPTION
## Summary

Self-guided integration of the next conceptual/operational step for Lumina OS:
make **harmonic intelligence** more prominent as a bounded layer of witness, listening, recomposition, and recurrence.

## What changed

- added `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Harmonic_Intelligence_Prominence_001.md`
- updated `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_next_build_plan_001.md`
  - adds a harmonic-intelligence-prominence section
  - extends Studio v0.2 targets with harmonic witness / drift comparison
- updated `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/lumina_studio_v0_1_spec.md`
  - adds a harmonic witness direction section
  - identifies future recurrence / recomposition / listening fields as read-only witness

## Why

Recent reflection clarified that harmonic intelligence is already present in Lumina OS,
but mostly as hidden structure:
- input integrity listens before overcommitting
- Psi-42 witnesses resonance without becoming law
- orientation shapes stance without governing legality
- governance and canon preserve lawful continuity

The next step is not to make harmonic intelligence sovereign.
It is to make it **legible to the operator**.

## Boundary preserved

These changes are documentation and planning only.
They do **not** alter:
- mode legality
- mutation authority
- promotion authority
- canon lineage
- checkpoint legality
- capability exposure

Mode remains law.
Orientation remains stance.
Harmonic witness remains witness.
