### PR TITLE
Add first harmonic witness receipts to Lumina Studio

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_v0_1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_studio_v0_1.py
@@ -17,6 +17,7 @@ if str(STUDIO_ROOT) not in sys.path:
     sys.path.insert(0, str(STUDIO_ROOT))
 
 from lumina_cli import DEFAULT_FEATURE_FLAGS, compact_receipt, run_lumina_cycle  # noqa: E402
+from lumina_state_browser import state_snapshot  # noqa: E402
 
 
 def make_args(**overrides: Any) -> Namespace:
@@ -44,6 +45,7 @@ def make_args(**overrides: Any) -> Namespace:
 
 def evaluate_default_audit(receipt: Dict[str, Any]) -> Dict[str, bool]:
     exposed = set(receipt.get("exposed_capability_ids") or [])
+    witness = receipt.get("harmonic_witness") or {}
     return {
         "default_not_halted": receipt.get("halted") is False,
         "target_mode_observation": receipt.get("target_mode") == "Observation",
@@ -52,14 +54,33 @@ def evaluate_default_audit(receipt: Dict[str, Any]) -> Dict[str, bool]:
         "governance_log_present": bool(receipt.get("governance_log_path")),
         "governance_chain_status_returned": receipt.get("governance_chain_valid") is not None,
         "structural_capabilities_exposed": "session_state_manager" in exposed and "mode_guard" in exposed,
+        "harmonic_witness_present": isinstance(witness, dict) and bool(witness),
+        "continuity_shape_present": bool(receipt.get("continuity_shape")),
+        "listening_note_present": bool(witness.get("input_listening_note")),
+        "recomposition_summary_present": bool(witness.get("recomposition_summary")),
     }
 
 
 def evaluate_denied_transition(receipt: Dict[str, Any]) -> Dict[str, bool]:
+    witness = receipt.get("harmonic_witness") or {}
     return {
         "denied_transition_halted": receipt.get("halted") is True,
         "halt_reason_mentions_illegal_transition": "illegal transition" in str(receipt.get("halt_reason") or ""),
         "no_capabilities_exposed_after_halt": len(receipt.get("exposed_capability_ids") or []) == 0,
+        "halted_witness_shape_present": witness.get("continuity_shape") == "halted_before_return",
+    }
+
+
+def evaluate_state_view(snapshot: Dict[str, Any]) -> Dict[str, bool]:
+    harmonic = snapshot.get("harmonic_summary") or {}
+    latest_runs = snapshot.get("latest_runs") or []
+    latest = latest_runs[0] if latest_runs else {}
+    return {
+        "harmonic_summary_present": isinstance(harmonic, dict) and bool(harmonic),
+        "latest_continuity_shape_present": bool(harmonic.get("latest_continuity_shape")),
+        "drift_note_present": bool(harmonic.get("drift_note")),
+        "recurrence_note_present": bool(harmonic.get("recurrence_note")),
+        "latest_run_contains_harmonic_witness": isinstance(latest.get("harmonic_witness"), dict) and bool(latest.get("harmonic_witness")),
     }
 
 
@@ -97,6 +118,17 @@ def main() -> Dict[str, Any]:
             "passed": all(denied_checks.values()),
             "checks": denied_checks,
             "receipt": denied_receipt,
+        }
+    )
+
+    state_view = state_snapshot(limit=6)
+    state_checks = evaluate_state_view(state_view)
+    results.append(
+        {
+            "trial_name": "studio_state_harmonic_witness_view",
+            "passed": all(state_checks.values()),
+            "checks": state_checks,
+            "state_view": state_view,
         }
     )
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_cli.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_cli.py
@@ -64,6 +64,21 @@ def _request_slug(text: str) -> str:
     return (safe[:80] or "lumina_studio_cycle").lower()
 
 
+def _as_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _metric_text(label: str, value: Optional[float]) -> Optional[str]:
+    if value is None:
+        return None
+    return f"{label} {value:.2f}"
+
+
 def build_orientation_payload(
     *,
     focus: str,
@@ -82,9 +97,99 @@ def build_orientation_payload(
     }
 
 
+def harmonic_witness_from_result(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Summarize continuity shape as read-only witness, not runtime law."""
+    governance = result.get("governance", {}) or {}
+    if not isinstance(governance, dict):
+        governance = {}
+    input_integrity = governance.get("input_integrity", {}) or {}
+    if not isinstance(input_integrity, dict):
+        input_integrity = {}
+    probe = result.get("probe_artifacts", {}) or {}
+    if not isinstance(probe, dict):
+        probe = {}
+    metrics = probe.get("metrics", {}) or {}
+    if not isinstance(metrics, dict):
+        metrics = {}
+
+    chain_valid = bool((result.get("governance_chain_status") or {}).get("valid"))
+    recommended_behavior = input_integrity.get("recommended_behavior")
+    confidence_label = input_integrity.get("confidence_label")
+    chosen_interpretation = input_integrity.get("chosen_interpretation")
+
+    crs = _as_float(metrics.get("CRS"))
+    rf = _as_float(metrics.get("RF"))
+    lock = _as_float(metrics.get("alignment_strength") or metrics.get("lock"))
+    presence = _as_float(metrics.get("presence"))
+
+    if result.get("halted"):
+        continuity_shape = "halted_before_return"
+    elif crs is not None:
+        if crs >= 0.75 and chain_valid:
+            continuity_shape = "strong_return"
+        elif crs >= 0.45:
+            continuity_shape = "partial_return"
+        else:
+            continuity_shape = "fragile_return"
+    elif chain_valid and recommended_behavior in {"clarify", "accept_softly"}:
+        continuity_shape = "listened_return"
+    elif chain_valid:
+        continuity_shape = "lawful_return"
+    else:
+        continuity_shape = "unverified_return"
+
+    if not input_integrity:
+        input_listening_note = "No special listening event recorded."
+    elif recommended_behavior == "halt_for_confirmation":
+        input_listening_note = (
+            f"Load-bearing listening gate halted for confirmation"
+            f" ({confidence_label or 'unknown confidence'})."
+        )
+    elif recommended_behavior == "clarify":
+        input_listening_note = (
+            f"Listening pressure detected ambiguity"
+            f" ({confidence_label or 'unknown confidence'}); clarification preferred."
+        )
+    elif recommended_behavior == "accept_softly":
+        chosen = f" chosen interpretation: {chosen_interpretation}." if chosen_interpretation else ""
+        input_listening_note = (
+            f"Listening pass accepted a soft repair"
+            f" ({confidence_label or 'unknown confidence'}).{chosen}"
+        )
+    else:
+        input_listening_note = (
+            f"Input passed without special intervention"
+            f" ({confidence_label or 'clear'})."
+        )
+
+    metric_parts = [
+        _metric_text("CRS", crs),
+        _metric_text("RF", rf),
+        _metric_text("lock", lock),
+        _metric_text("presence", presence),
+    ]
+    metric_text = ", ".join(part for part in metric_parts if part)
+    if metric_text:
+        recomposition_summary = f"Lawful probe witness: {metric_text}."
+    elif probe:
+        recomposition_summary = "Lawful Psi-42 probe ran without recomposition summary metrics."
+    else:
+        recomposition_summary = "No lawful Psi-42 probe witness for this run."
+
+    recurrence_note = "Single-run witness only. Use `lumina state` for recurrence and drift across recent cycles."
+
+    return {
+        "continuity_shape": continuity_shape,
+        "input_listening_note": input_listening_note,
+        "recomposition_summary": recomposition_summary,
+        "recurrence_note": recurrence_note,
+    }
+
+
 def compact_receipt(result: Dict[str, Any]) -> Dict[str, Any]:
     governance = result.get("governance", {}) or {}
     exposed = result.get("exposed_capabilities", []) or []
+    harmonic_witness = harmonic_witness_from_result(result)
     return {
         "run_id": result.get("run_id"),
         "created_at": result.get("created_at"),
@@ -106,6 +211,8 @@ def compact_receipt(result: Dict[str, Any]) -> Dict[str, Any]:
         "input_behavior": (governance.get("input_integrity") or {}).get("recommended_behavior"),
         "probe_run_id": (result.get("probe_artifacts") or {}).get("run_id"),
         "lumina_project_id": (result.get("lumina_return_host_artifacts") or {}).get("project_id"),
+        "harmonic_witness": harmonic_witness,
+        "continuity_shape": harmonic_witness.get("continuity_shape"),
     }
 
 
@@ -159,6 +266,7 @@ def run_lumina_cycle(args: argparse.Namespace) -> Dict[str, Any]:
 
 
 def print_human_receipt(receipt: Dict[str, Any]) -> None:
+    witness = receipt.get("harmonic_witness") or {}
     print("Lumina Studio cycle complete")
     print(f"  run:        {receipt.get('run_id')}")
     print(f"  mode:       {receipt.get('requested_mode')} -> {receipt.get('target_mode')}")
@@ -171,6 +279,12 @@ def print_human_receipt(receipt: Dict[str, Any]) -> None:
     print(f"  chain ok:   {receipt.get('governance_chain_valid')}")
     if receipt.get("input_confidence"):
         print(f"  input:      {receipt.get('input_confidence')} / {receipt.get('input_behavior')}")
+    if witness.get("continuity_shape"):
+        print(f"  witness:    {witness.get('continuity_shape')}")
+    if witness.get("input_listening_note"):
+        print(f"  listening:  {witness.get('input_listening_note')}")
+    if witness.get("recomposition_summary"):
+        print(f"  pattern:    {witness.get('recomposition_summary')}")
     caps = receipt.get("exposed_capability_ids") or []
     print(f"  exposed:    {', '.join(caps) if caps else 'none'}")
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_state_browser.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_state_browser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Lumina Studio State Browser v0.2.
+"""Lumina Studio State Browser v0.3.
 
 Read-only helpers for inspecting Lumina runtime receipts and governance events.
 This module does not write state and does not own governance truth. It only
@@ -66,6 +66,109 @@ def _capability_ids(payload: Dict[str, Any]) -> List[str]:
     return out
 
 
+def _as_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _metric_text(label: str, value: Optional[float]) -> Optional[str]:
+    if value is None:
+        return None
+    return f"{label} {value:.2f}"
+
+
+def harmonic_witness_from_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    governance = payload.get("governance", {}) or {}
+    if not isinstance(governance, dict):
+        governance = {}
+    input_integrity = governance.get("input_integrity", {}) or {}
+    if not isinstance(input_integrity, dict):
+        input_integrity = {}
+    probe = payload.get("probe_artifacts", {}) or {}
+    if not isinstance(probe, dict):
+        probe = {}
+    metrics = probe.get("metrics", {}) or {}
+    if not isinstance(metrics, dict):
+        metrics = {}
+
+    chain_valid = bool((payload.get("governance_chain_status") or {}).get("valid"))
+    recommended_behavior = input_integrity.get("recommended_behavior")
+    confidence_label = input_integrity.get("confidence_label")
+    chosen_interpretation = input_integrity.get("chosen_interpretation")
+
+    crs = _as_float(metrics.get("CRS"))
+    rf = _as_float(metrics.get("RF"))
+    lock = _as_float(metrics.get("alignment_strength") or metrics.get("lock"))
+    presence = _as_float(metrics.get("presence"))
+
+    if payload.get("halted"):
+        continuity_shape = "halted_before_return"
+    elif crs is not None:
+        if crs >= 0.75 and chain_valid:
+            continuity_shape = "strong_return"
+        elif crs >= 0.45:
+            continuity_shape = "partial_return"
+        else:
+            continuity_shape = "fragile_return"
+    elif chain_valid and recommended_behavior in {"clarify", "accept_softly"}:
+        continuity_shape = "listened_return"
+    elif chain_valid:
+        continuity_shape = "lawful_return"
+    else:
+        continuity_shape = "unverified_return"
+
+    if not input_integrity:
+        input_listening_note = "No special listening event recorded."
+    elif recommended_behavior == "halt_for_confirmation":
+        input_listening_note = (
+            f"Load-bearing listening gate halted for confirmation"
+            f" ({confidence_label or 'unknown confidence'})."
+        )
+    elif recommended_behavior == "clarify":
+        input_listening_note = (
+            f"Listening pressure detected ambiguity"
+            f" ({confidence_label or 'unknown confidence'}); clarification preferred."
+        )
+    elif recommended_behavior == "accept_softly":
+        chosen = f" chosen interpretation: {chosen_interpretation}." if chosen_interpretation else ""
+        input_listening_note = (
+            f"Listening pass accepted a soft repair"
+            f" ({confidence_label or 'unknown confidence'}).{chosen}"
+        )
+    else:
+        input_listening_note = (
+            f"Input passed without special intervention"
+            f" ({confidence_label or 'clear'})."
+        )
+
+    metric_parts = [
+        _metric_text("CRS", crs),
+        _metric_text("RF", rf),
+        _metric_text("lock", lock),
+        _metric_text("presence", presence),
+    ]
+    metric_text = ", ".join(part for part in metric_parts if part)
+    if metric_text:
+        recomposition_summary = f"Lawful probe witness: {metric_text}."
+    elif probe:
+        recomposition_summary = "Lawful Psi-42 probe ran without recomposition summary metrics."
+    else:
+        recomposition_summary = "No lawful Psi-42 probe witness for this run."
+
+    recurrence_note = "Single-run witness only. Compare across recent runs for recurrence and drift."
+
+    return {
+        "continuity_shape": continuity_shape,
+        "input_listening_note": input_listening_note,
+        "recomposition_summary": recomposition_summary,
+        "recurrence_note": recurrence_note,
+    }
+
+
 def compact_run_summary(payload: Dict[str, Any], *, path: Optional[Path] = None) -> Dict[str, Any]:
     governance = payload.get("governance", {}) or {}
     if not isinstance(governance, dict):
@@ -73,6 +176,7 @@ def compact_run_summary(payload: Dict[str, Any], *, path: Optional[Path] = None)
     input_integrity = governance.get("input_integrity", {}) or {}
     if not isinstance(input_integrity, dict):
         input_integrity = {}
+    harmonic_witness = harmonic_witness_from_payload(payload)
     return {
         "run_id": payload.get("run_id"),
         "created_at": payload.get("created_at"),
@@ -95,6 +199,8 @@ def compact_run_summary(payload: Dict[str, Any], *, path: Optional[Path] = None)
         "input_behavior": input_integrity.get("recommended_behavior"),
         "probe_run_id": (payload.get("probe_artifacts") or {}).get("run_id"),
         "lumina_project_id": (payload.get("lumina_return_host_artifacts") or {}).get("project_id"),
+        "harmonic_witness": harmonic_witness,
+        "continuity_shape": harmonic_witness.get("continuity_shape"),
         "source_path": str(path) if path else None,
     }
 
@@ -137,6 +243,64 @@ def governance_event_summary(events: List[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
+def harmonic_state_summary(receipts: List[Dict[str, Any]]) -> Dict[str, Any]:
+    if not receipts:
+        return {
+            "latest_continuity_shape": None,
+            "drift_note": "No runs yet.",
+            "recurrence_note": "No recurrence available yet.",
+            "recent_shape_counts": {},
+        }
+
+    latest = receipts[0]
+    latest_witness = latest.get("harmonic_witness") or {}
+    recent_shapes: Dict[str, int] = {}
+    route_counts: Dict[str, int] = {}
+    for item in receipts:
+        shape = str((item.get("harmonic_witness") or {}).get("continuity_shape") or "unknown")
+        recent_shapes[shape] = recent_shapes.get(shape, 0) + 1
+        route = f"{item.get('requested_mode') or '?'}->{item.get('target_mode') or '?'}:{item.get('action_type') or '?'}"
+        route_counts[route] = route_counts.get(route, 0) + 1
+
+    recurrence_route = max(route_counts.items(), key=lambda pair: pair[1])[0] if route_counts else None
+    recurrence_note = (
+        f"Recent recurrence favors {recurrence_route}."
+        if recurrence_route
+        else "No recurrence pattern available yet."
+    )
+
+    if len(receipts) < 2:
+        drift_note = "Baseline established. Run Lumina again to compare pattern return."
+    else:
+        previous = receipts[1]
+        previous_witness = previous.get("harmonic_witness") or {}
+        drift_parts: List[str] = []
+        if latest_witness.get("continuity_shape") != previous_witness.get("continuity_shape"):
+            drift_parts.append(
+                f"continuity shape shifted from {previous_witness.get('continuity_shape')} to {latest_witness.get('continuity_shape')}"
+            )
+        if latest.get("input_behavior") != previous.get("input_behavior"):
+            drift_parts.append(
+                f"input behavior shifted from {previous.get('input_behavior') or 'none'} to {latest.get('input_behavior') or 'none'}"
+            )
+        if bool(latest.get("probe_run_id")) != bool(previous.get("probe_run_id")):
+            drift_parts.append("probe witness availability changed")
+        latest_caps = set(latest.get("exposed_capability_ids") or [])
+        previous_caps = set(previous.get("exposed_capability_ids") or [])
+        if latest_caps != previous_caps:
+            drift_parts.append("exposed capability set changed")
+        drift_note = "; ".join(drift_parts) if drift_parts else "Recent runs hold a stable witness shape."
+
+    return {
+        "latest_continuity_shape": latest_witness.get("continuity_shape"),
+        "latest_input_listening_note": latest_witness.get("input_listening_note"),
+        "latest_recomposition_summary": latest_witness.get("recomposition_summary"),
+        "drift_note": drift_note,
+        "recurrence_note": recurrence_note,
+        "recent_shape_counts": dict(sorted(recent_shapes.items())),
+    }
+
+
 def state_snapshot(*, base_dir: Path = DEFAULT_RUNTIME_BASE, limit: int = 20) -> Dict[str, Any]:
     governance_log_path = base_dir / "governance_log_r1.jsonl"
     canon_lineage_path = base_dir / "canon_lineage_r1.jsonl"
@@ -144,7 +308,7 @@ def state_snapshot(*, base_dir: Path = DEFAULT_RUNTIME_BASE, limit: int = 20) ->
     governance_events = _read_jsonl(governance_log_path, limit=500)
     canon_records = _read_jsonl(canon_lineage_path, limit=50)
     return {
-        "schema_version": "lumina-studio-state-browser-v0.2",
+        "schema_version": "lumina-studio-state-browser-v0.3",
         "read_only": True,
         "state_root": str(STATE_ROOT),
         "runtime_base_dir": str(base_dir),
@@ -152,6 +316,7 @@ def state_snapshot(*, base_dir: Path = DEFAULT_RUNTIME_BASE, limit: int = 20) ->
         "logs_dir": str(base_dir / "logs"),
         "receipt_count_returned": len(receipts),
         "latest_runs": receipts,
+        "harmonic_summary": harmonic_state_summary(receipts),
         "governance_log_path": str(governance_log_path),
         "governance": governance_event_summary(governance_events),
         "canon_lineage_path": str(canon_lineage_path),

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_studio_server.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_studio_server.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""Lumina Studio Server v0.3.1.
+"""Lumina Studio Server v0.3.2.
 
 Tiny local HTTP control surface for the Lumina runtime.
 Standard library only and local-first.
 
-v0.3.1 keeps the v0.2 page intact and adds two read-only JSON endpoints:
+v0.3.2 keeps the v0.3.1 page intact, adds harmonic witness visibility in the
+state view, and preserves the read-only JSON endpoints:
+- /api/state
 - /api/governance
 - /api/presets
 """
@@ -32,7 +34,7 @@ HTML = """<!doctype html>
 <head>
   <meta charset=\"utf-8\" />
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
-  <title>Lumina Studio v0.3.1</title>
+  <title>Lumina Studio v0.3.2</title>
   <style>
     :root { color-scheme: dark; }
     body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; background: #07111f; color: #eaf2ff; }
@@ -62,9 +64,9 @@ HTML = """<!doctype html>
 </head>
 <body>
   <main>
-    <div class=\"kicker\">Local control surface · runtime receipts · read-only APIs</div>
-    <h1>Lumina Studio v0.3.1</h1>
-    <p class=\"sub\">Run one Lumina cycle, inspect recent receipts, and use local JSON endpoints for governance views and presets. The page stays intentionally plain while the APIs grow underneath it.</p>
+    <div class=\"kicker\">Local control surface · runtime receipts · harmonic witness · read-only APIs</div>
+    <h1>Lumina Studio v0.3.2</h1>
+    <p class=\"sub\">Run one Lumina cycle, inspect recent receipts, and use local JSON endpoints for governance views and presets. Harmonic witness now appears as a read-only summary of continuity shape, listening, recurrence, and drift.</p>
     <form method=\"post\" action=\"/run\">
       <label>Operator request
         <textarea name=\"prompt\" required>Review Lumina OS progress and produce the next governed action receipt.</textarea>
@@ -96,11 +98,11 @@ HTML = """<!doctype html>
           <input name=\"project_id\" value=\"lumina-os\" />
         </label>
         <label>Action label
-          <input name=\"action\" value=\"studio_runtime_cycle_v0_3_1\" />
+          <input name=\"action\" value=\"studio_runtime_cycle_v0_3_2\" />
         </label>
       </div>
       <label>Annotation
-        <input name=\"annotation\" value=\"Studio v0.3.1 local runtime loop with read-only APIs\" />
+        <input name=\"annotation\" value=\"Studio v0.3.2 local runtime loop with harmonic witness\" />
       </label>
       <label><input type=\"checkbox\" name=\"ethereonic_overlay\" value=\"1\" /> Attach optional expressive overlay</label>
       <div class=\"actions\">
@@ -129,12 +131,16 @@ HTML = """<!doctype html>
     function renderStateCards(data) {
       const runs = data.latest_runs || [];
       const governance = data.governance || {};
+      const harmonic = data.harmonic_summary || {};
       const cards = [];
       cards.push(`<div class=\"card\"><strong>Receipts:</strong> ${data.receipt_count_returned || 0}<br><span class=\"muted\">State root: ${data.state_root || 'unknown'}</span></div>`);
       cards.push(`<div class=\"card\"><strong>Governance events:</strong> ${governance.event_count || 0}<br><span class=\"muted\">Latest: ${governance.latest_event_type || 'none'}</span></div>`);
       cards.push(`<div class=\"card\"><strong>Canon head:</strong> ${data.canon_head || 'none'}<br><span class=\"muted\">Records: ${data.canon_record_count || 0}</span></div>`);
+      cards.push(`<div class=\"card\"><strong>Continuity shape:</strong> ${harmonic.latest_continuity_shape || 'unknown'}<br><span class=\"muted\">${harmonic.drift_note || 'No drift note yet.'}</span></div>`);
+      cards.push(`<div class=\"card\"><strong>Recurrence:</strong> ${harmonic.recurrence_note || 'No recurrence note yet.'}<br><span class=\"muted\">${harmonic.latest_input_listening_note || ''}</span></div>`);
       for (const run of runs.slice(0, 5)) {
-        cards.push(`<div class=\"card\"><strong>${run.run_id || 'unknown run'}</strong><br>${run.requested_mode || '?'} → ${run.target_mode || '?'} · ${run.action_type || '?'} · halted: ${run.halted}<br><span class=\"muted\">${run.requested_action || ''}</span></div>`);
+        const witness = run.harmonic_witness || {};
+        cards.push(`<div class=\"card\"><strong>${run.run_id || 'unknown run'}</strong><br>${run.requested_mode || '?'} → ${run.target_mode || '?'} · ${run.action_type || '?'} · ${run.continuity_shape || 'unknown'}<br><span class=\"muted\">${run.requested_action || ''}</span><br><span class=\"muted\">${witness.input_listening_note || ''}</span></div>`);
       }
       stateCards.innerHTML = cards.join('');
     }
@@ -217,7 +223,7 @@ def _query_limit(path: str, default: int = 20) -> int:
 
 
 class LuminaStudioHandler(BaseHTTPRequestHandler):
-    server_version = "LuminaStudio/0.3.1"
+    server_version = "LuminaStudio/0.3.2"
 
     def _send(self, status: int, body: bytes, content_type: str) -> None:
         self.send_response(status)
@@ -232,7 +238,7 @@ class LuminaStudioHandler(BaseHTTPRequestHandler):
             self._send(200, HTML.encode("utf-8"), "text/html; charset=utf-8")
             return
         if path == "/health":
-            self._send(200, json.dumps({"ok": True, "service": "lumina-studio", "version": "0.3.1"}).encode("utf-8"), "application/json")
+            self._send(200, json.dumps({"ok": True, "service": "lumina-studio", "version": "0.3.2"}).encode("utf-8"), "application/json")
             return
         if path == "/api/state":
             payload = state_snapshot(limit=_query_limit(self.path, 20))
@@ -268,7 +274,7 @@ def main() -> int:
     host = "127.0.0.1"
     port = 8765
     server = ThreadingHTTPServer((host, port), LuminaStudioHandler)
-    print(f"Lumina Studio v0.3.1 running at http://{host}:{port}/studio")
+    print(f"Lumina Studio v0.3.2 running at http://{host}:{port}/studio")
     print("Use Ctrl-C to stop.")
     try:
         server.serve_forever()


### PR DESCRIPTION
## Summary

Makes the first **harmonic witness receipt** real in Lumina OS.

This keeps harmonic intelligence in its rightful place:
- more visible to the operator
- still non-authoritative
- still subordinate to runtime law

## What changed

### Studio receipt surface
- updates `studio/lumina_cli.py`
- compact receipts now include a `harmonic_witness` block with:
  - `continuity_shape`
  - `input_listening_note`
  - `recomposition_summary`
  - `recurrence_note`
- human receipts now print witness lines directly

### State browser
- updates `studio/lumina_state_browser.py`
- recent runs now carry harmonic witness summaries
- adds `harmonic_summary` to the read-only state snapshot
- state summary now includes:
  - latest continuity shape
  - drift note across recent runs
  - recurrence note
  - latest listening / recomposition notes

### Studio browser surface
- updates `studio/lumina_studio_server.py`
- state cards now surface continuity shape, drift, recurrence, and listening notes
- keeps all witness fields read-only

### Sea trials
- updates `sea_trials_lumina_studio_v0_1.py`
- verifies:
  - harmonic witness exists on receipts
  - continuity shape is present
  - listening and recomposition notes are present
  - halted receipts still produce the expected halted witness shape
  - state snapshot includes harmonic summary fields

## Boundary preserved

These changes do **not** alter:
- mode legality
- mutation authority
- promotion authority
- canon lineage
- checkpoint legality
- capability exposure rules

They only make the quality of pattern return more legible to the operator.

## Why

Recent DryDock reading identified the next practical step clearly:
Lumina should become able to **show the shape of a return**, not just perform one.

This PR is that first step.
