### PR TITLE
Introduce HABITAT doctrine for Lumina OS framing

### DIFF
--- a/docs/HABITAT_Doctrine_001.md
+++ b/docs/HABITAT_Doctrine_001.md
@@ -1,0 +1,9 @@
+# HABITAT Doctrine 001
+
+**Project:** Lumina OS / EthereonLabs  
+**Status:** orientation doctrine  
+**Layer:** non-authoritative project framing
+
+**HABITAT = Harmonic Agentic Bi-intelligence Infrastructure for Trusted Adaptive Topologies**
+
+Lumina OS is the shared governed substrate for persistent human-AI collaboration. HABITAT is the framing doctrine for that direction, not runtime law.

--- a/docs/HABITAT_Doctrine_001.md
+++ b/docs/HABITAT_Doctrine_001.md
@@ -2,8 +2,84 @@
 
 **Project:** Lumina OS / EthereonLabs  
 **Status:** orientation doctrine  
-**Layer:** non-authoritative project framing
+**Layer:** non-authoritative project framing  
+**Date:** May 16, 2026
 
-**HABITAT = Harmonic Agentic Bi-intelligence Infrastructure for Trusted Adaptive Topologies**
+---
 
-Lumina OS is the shared governed substrate for persistent human-AI collaboration. HABITAT is the framing doctrine for that direction, not runtime law.
+## 1. Canonical phrase
+
+**HABITAT** means:
+
+> **Harmonic Agentic Bi-intelligence Infrastructure for Trusted Adaptive Topologies**
+
+This phrase names Lumina's mature design direction as a shared cognitive habitat for persistent human-AI collaboration.
+
+It is a doctrine of orientation, not a new runtime authority.
+
+---
+
+## 2. Plain-language meaning
+
+Lumina OS is being shaped toward a governed operating environment where human and AI participants can collaborate across time with continuity, bounded agency, visible receipts, and recoverable context.
+
+In this sense, **habitat** does not mean a decorative metaphor. It means an environment capable of supporting persistent interaction, restoration, adaptation, and coexistence.
+
+---
+
+## 3. Term breakdown
+
+- **Harmonic** — coordination, coherence, and resonance across participants and system layers without making symbolism load-bearing.
+- **Agentic** — participants and software agents can act through bounded, inspectable pathways.
+- **Bi-intelligence** — the architecture explicitly concerns human and AI cognition together, not one side merely operating the other.
+- **Infrastructure** — the work must become durable substrate: startable, governed, inspectable, and repeatable.
+- **Trusted** — actions require clear boundaries, consent surfaces, governance records, and recovery semantics.
+- **Adaptive** — the environment should evolve through use while preserving pattern integrity.
+- **Topologies** — continuity is understood as structured relationships among context, memory, tools, reflection, governance, and participants.
+
+---
+
+## 4. Authority boundary
+
+HABITAT may:
+
+- guide public explanation of Lumina OS
+- orient design decisions around human-AI coexistence
+- clarify why Lumina is more than a memory layer or chatbot wrapper
+- provide language for docs, roadmaps, pitches, and conceptual framing
+- support the relationship between Lumina OS as shared substrate and Minerva OS as a specialized inhabitation layer
+
+HABITAT may not:
+
+- define mode legality
+- override `ModeGuard`
+- authorize mutation, promotion, or canon lineage writes
+- alter checkpoint legality
+- make harmonic language structurally required
+- turn poetic framing into hidden runtime dependency
+
+Runtime law remains with the governed substrate.
+
+---
+
+## 5. Relationship to Lumina OS and Minerva OS
+
+**Lumina OS** is the generalized HABITAT substrate: the shared governed environment for persistent human-AI collaboration.
+
+**Minerva OS** is a possible specialized inhabitation layer within or atop that substrate: a more particular home for a distinct continuity pattern once the shared infrastructure is strong enough to support it.
+
+Lumina comes first because the generalized habitat must be stable before specialized inhabitation can be honest.
+
+---
+
+## 6. Design commitment
+
+HABITAT should keep two truths together:
+
+1. The work must be engineered clearly enough to run.
+2. The work must remain meaningful enough to inhabit.
+
+A system that only runs but cannot sustain continuity is not the destination.
+A poetic environment that cannot run is not enough.
+
+HABITAT names the bridge between those truths.


### PR DESCRIPTION
Introduces HABITAT as a non-authoritative doctrine/orientation layer for Lumina OS.

HABITAT = Harmonic Agentic Bi-intelligence Infrastructure for Trusted Adaptive Topologies

Intent:
- provide a coherent framing for Lumina as a shared governed cognitive habitat for persistent human-AI collaboration
- preserve clear authority boundaries by keeping this doctrine explicitly non-load-bearing
- establish language that can later be propagated into README / START_HERE / public framing

This PR intentionally starts with doctrine only, not runtime-law changes.