### PR TITLE
Add Psi-42 v1.7 hybrid probe fallback in runtime runner

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_r1_merged.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_r1_merged.py
@@ -453,12 +453,25 @@ class RuntimeRunner:
         output_dir = self.base_dir / "psi42_artifacts" / (self._active_session_id or "session") / run_slug
         if "psi42_transceiver_v17" in capability_ids and ResonanceTransceiverV17 is not None and Psi42V17Config is not None:
             rt = ResonanceTransceiverV17(Psi42V17Config(language_mode=language_mode, output_dir=str(output_dir), probe_mode="hybrid"))
+            result = rt.run(f"{requested_action} :: {target_mode}", {"OBSERVATION": 1.0 if target_mode == "Observation" else 0.0, "SANDBOX": 1.0 if target_mode == "Sandbox" else 0.0, "CONTINUITY": 0.8, "HABITAT": 0.7})
+            return {
+                "instrument_version": "v1.7",
+                "instrument_class": result.get("instrument_class"),
+                "probe_mode": result.get("probe_mode"),
+                "metrics": result.get("metrics"),
+                "paths": result.get("paths"),
+                "topology_receipt": result.get("topology_receipt"),
+                "signal_run_id": (result.get("signal_result") or {}).get("run_id"),
+                "signal_pulse_id": (result.get("signal_result") or {}).get("pulse_id"),
+                "authority_boundary": result.get("authority_boundary"),
+            }
         elif ResonanceTransceiverV16 is not None:
             rt = ResonanceTransceiverV16(Psi42Config(language_mode=language_mode, output_dir=str(output_dir)))
         else:
             return None
         result = rt.run(f"{requested_action} :: {target_mode}", {"OBSERVATION": 1.0 if target_mode == "Observation" else 0.0, "SANDBOX": 1.0 if target_mode == "Sandbox" else 0.0, "CONTINUITY": 0.8})
         return {
+            "instrument_version": "v1.6",
             "run_id": result.get("run_id"),
             "pulse_id": result.get("pulse_id"),
             "metrics": result.get("metrics"),

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_r1_merged.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_r1_merged.py
@@ -24,11 +24,12 @@ except Exception:
         ResonanceTransceiverV16 = None
 
 try:
-    from .psi42_transceiver_v1_7 import ResonanceTransceiverV17
+    from .psi42_transceiver_v1_7 import Config as Psi42V17Config, ResonanceTransceiverV17
 except Exception:
     try:
-        from psi42_transceiver_v1_7 import ResonanceTransceiverV17
+        from psi42_transceiver_v1_7 import Config as Psi42V17Config, ResonanceTransceiverV17
     except Exception:
+        Psi42V17Config = None
         ResonanceTransceiverV17 = None
 
 try:
@@ -450,8 +451,8 @@ class RuntimeRunner:
         language_mode = "ethereonic" if any(x in anchors for x in ["toki_pona", "binary", "light_language"]) else "neutral"
         run_slug = "".join(c if c.isalnum() or c in "-_" else "_" for c in f"{requested_action}_{target_mode}")[:80]
         output_dir = self.base_dir / "psi42_artifacts" / (self._active_session_id or "session") / run_slug
-        if "psi42_transceiver_v17" in capability_ids and ResonanceTransceiverV17 is not None:
-            rt = ResonanceTransceiverV17(Psi42Config(language_mode=language_mode, output_dir=str(output_dir), probe_mode="hybrid"))
+        if "psi42_transceiver_v17" in capability_ids and ResonanceTransceiverV17 is not None and Psi42V17Config is not None:
+            rt = ResonanceTransceiverV17(Psi42V17Config(language_mode=language_mode, output_dir=str(output_dir), probe_mode="hybrid"))
         elif ResonanceTransceiverV16 is not None:
             rt = ResonanceTransceiverV16(Psi42Config(language_mode=language_mode, output_dir=str(output_dir)))
         else:

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_r1_merged.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_r1_merged.py
@@ -24,6 +24,14 @@ except Exception:
         ResonanceTransceiverV16 = None
 
 try:
+    from .psi42_transceiver_v1_7 import ResonanceTransceiverV17
+except Exception:
+    try:
+        from psi42_transceiver_v1_7 import ResonanceTransceiverV17
+    except Exception:
+        ResonanceTransceiverV17 = None
+
+try:
     from .input_integrity_layer_r1 import InputIntegrityAssessor
 except Exception:
     try:
@@ -430,10 +438,10 @@ class RuntimeRunner:
         ethereonic_overlay: Optional[Dict[str, Any]],
         exposed_capabilities: List[Dict[str, Any]],
     ) -> Optional[Dict[str, Any]]:
-        if ResonanceTransceiverV16 is None or Psi42Config is None:
+        if Psi42Config is None:
             return None
         capability_ids = {cap.get("capability_id") for cap in exposed_capabilities}
-        if "psi42_transceiver_v16" not in capability_ids and "psi42_probe_interface" not in capability_ids:
+        if "psi42_transceiver_v16" not in capability_ids and "psi42_transceiver_v17" not in capability_ids and "psi42_probe_interface" not in capability_ids:
             return None
         if target_mode not in {"Observation", "Sandbox"}:
             return None
@@ -442,7 +450,12 @@ class RuntimeRunner:
         language_mode = "ethereonic" if any(x in anchors for x in ["toki_pona", "binary", "light_language"]) else "neutral"
         run_slug = "".join(c if c.isalnum() or c in "-_" else "_" for c in f"{requested_action}_{target_mode}")[:80]
         output_dir = self.base_dir / "psi42_artifacts" / (self._active_session_id or "session") / run_slug
-        rt = ResonanceTransceiverV16(Psi42Config(language_mode=language_mode, output_dir=str(output_dir)))
+        if "psi42_transceiver_v17" in capability_ids and ResonanceTransceiverV17 is not None:
+            rt = ResonanceTransceiverV17(Psi42Config(language_mode=language_mode, output_dir=str(output_dir), probe_mode="hybrid"))
+        elif ResonanceTransceiverV16 is not None:
+            rt = ResonanceTransceiverV16(Psi42Config(language_mode=language_mode, output_dir=str(output_dir)))
+        else:
+            return None
         result = rt.run(f"{requested_action} :: {target_mode}", {"OBSERVATION": 1.0 if target_mode == "Observation" else 0.0, "SANDBOX": 1.0 if target_mode == "Sandbox" else 0.0, "CONTINUITY": 0.8})
         return {
             "run_id": result.get("run_id"),


### PR DESCRIPTION
### Motivation
- Support the new Psi-42 v1.7 transceiver when available while preserving the existing v1.6 behavior and probe restrictions. 
- Ensure probes remain limited to `Observation`/`Sandbox` and that the change is a minimal, reviewable patch to the runtime runner file. 

### Description
- Added a guarded import for `ResonanceTransceiverV17` from `psi42_transceiver_v1_7` next to the existing v1.6 imports in `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_r1_merged.py`. 
- Updated only the `_maybe_run_psi42_probe()` routine to detect `psi42_transceiver_v17` in the exposed capabilities and to prefer `ResonanceTransceiverV17` when it is importable. 
- When `ResonanceTransceiverV17` is selected it is instantiated with `probe_mode="hybrid"`, and otherwise the code falls back to the exact prior `ResonanceTransceiverV16` path. 
- Preserved the existing checks that require `Psi42Config` and that probes only run for `Observation` or `Sandbox`, and made no other runner logic changes or reformatting. 

### Testing
- Ran `python -m py_compile LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_r1_merged.py` and the file compiled successfully. 
- No other automated tests were modified or run as part of this change. 

Closes #224

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08aac4679483249663bb98a5d7aaa1)