### PR TITLE
Add observation receipt summary tool

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/psi42_v17_observation_receipt_summary_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/psi42_v17_observation_receipt_summary_r1.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""
+psi42_v17_observation_receipt_summary_r1.py
+
+Compact CI-friendly verifier for Lumina Observation JSON receipts.
+
+Expected input is the full JSON emitted by:
+
+python LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_cli.py \
+  --target-mode Observation \
+  --action-type audit \
+  --feature-flag ETHEREON_PSI42 \
+  --feature-flag ETHEREON_PSI42_V17 \
+  --json \
+  "Run Psi-42 v1.7 Observation verification."
+
+This tool emits a small pass/fail JSON summary and exits non-zero when the
+receipt does not meet the requested v1.7 Observation checks.
+"""
+
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import Any, Dict, Optional
+import json
+import sys
+
+TOPOLOGY_METRICS = ("RTC", "RDS", "RRS", "HRC")
+
+
+def _load_json(path: Optional[str]) -> Dict[str, Any]:
+    raw = sys.stdin.read() if path in (None, "-") else Path(path).read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("Receipt JSON root must be an object")
+    return payload
+
+
+def _nested(payload: Dict[str, Any], *keys: str) -> Any:
+    current: Any = payload
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _as_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def summarize(receipt: Dict[str, Any], *, min_hybrid: float = 0.35) -> Dict[str, Any]:
+    probe = receipt.get("probe_artifacts") or {}
+    if not isinstance(probe, dict):
+        probe = {}
+    metrics = probe.get("metrics") or {}
+    if not isinstance(metrics, dict):
+        metrics = {}
+
+    instrument_version = probe.get("instrument_version")
+    hybrid = _as_float(metrics.get("hybrid_continuity_coherence"))
+    topology_receipt = probe.get("topology_receipt")
+    governance_valid = bool(_nested(receipt, "governance_chain_status", "valid"))
+    halted = bool(receipt.get("halted"))
+
+    checks = {
+        "target_mode_observation": receipt.get("target_mode") == "Observation",
+        "action_type_audit": receipt.get("action_type") == "audit",
+        "not_halted": halted is False,
+        "governance_chain_valid": governance_valid,
+        "psi42_v17_selected": instrument_version == "v1.7",
+        "topology_receipt_present": isinstance(topology_receipt, dict),
+        "hybrid_continuity_present": hybrid is not None,
+        "hybrid_continuity_threshold": hybrid is not None and hybrid >= min_hybrid,
+        "topology_metrics_present": all(metric in metrics for metric in TOPOLOGY_METRICS),
+    }
+
+    summary = {
+        "summary_type": "psi42_v17_observation_receipt_summary_r1",
+        "run_id": receipt.get("run_id"),
+        "target_mode": receipt.get("target_mode"),
+        "action_type": receipt.get("action_type"),
+        "halted": halted,
+        "governance_chain_valid": governance_valid,
+        "instrument_version": instrument_version,
+        "hybrid_continuity_coherence": hybrid,
+        "topology_metrics": {metric: metrics.get(metric) for metric in TOPOLOGY_METRICS},
+        "checks": checks,
+        "overall_pass": all(checks.values()),
+    }
+    return summary
+
+
+def parse_args(argv: Optional[list[str]] = None) -> Namespace:
+    parser = ArgumentParser(description="Summarize and verify a Psi-42 v1.7 Observation receipt.")
+    parser.add_argument("receipt_json", nargs="?", default="-", help="Path to receipt JSON, or '-' / omitted for stdin.")
+    parser.add_argument("--min-hybrid", type=float, default=0.35, help="Minimum hybrid_continuity_coherence threshold.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    receipt = _load_json(args.receipt_json)
+    summary = summarize(receipt, min_hybrid=args.min_hybrid)
+    print(json.dumps(summary, indent=2 if args.pretty else None, sort_keys=True))
+    return 0 if summary["overall_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_psi42_v17_observation_receipt_summary_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_psi42_v17_observation_receipt_summary_r1.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from psi42_v17_observation_receipt_summary_r1 import summarize
+
+
+def main() -> int:
+    receipt = {
+        "run_id": "run-example",
+        "target_mode": "Observation",
+        "action_type": "audit",
+        "halted": False,
+        "governance_chain_status": {"valid": True},
+        "probe_artifacts": {
+            "instrument_version": "v1.7",
+            "metrics": {
+                "hybrid_continuity_coherence": 0.8096,
+                "RTC": 1.0,
+                "RDS": 0.0,
+                "RRS": 1.0,
+                "HRC": 1.0,
+            },
+            "topology_receipt": {"receipt_type": "psi42_relational_restoration_r1"},
+        },
+    }
+    summary = summarize(receipt)
+    assert summary["overall_pass"] is True
+    assert summary["checks"]["psi42_v17_selected"] is True
+    assert summary["checks"]["topology_metrics_present"] is True
+    assert summary["hybrid_continuity_coherence"] == 0.8096
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a small receipt summary script and a matching sea trial.

Files:
- LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/psi42_v17_observation_receipt_summary_r1.py
- LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_psi42_v17_observation_receipt_summary_r1.py

The script reads a Lumina JSON receipt from a file or stdin and prints a compact JSON summary with pass/fail checks for Observation mode, audit action, non-halted execution, valid governance chain, v1.7 probe selection, topology receipt presence, hybrid continuity, and topology metrics.

No runtime behavior is changed.