### PR TITLE
Surface Psi-42 v1.7 receipts across Lumina

### DIFF
--- a/.github/workflows/lumina-observation-cycle.yml
+++ b/.github/workflows/lumina-observation-cycle.yml
@@ -35,6 +35,7 @@ jobs:
             --action-type audit \
             --enable-flag ETHEREON_OBSERVATION \
             --enable-flag ETHEREON_PSI42 \
+            --enable-flag ETHEREON_PSI42_V17 \
             --enable-flag ETHEREON_RESONANCE \
             --overlay-json '{"active":true,"anchor_language":["english"],"continuity_phrase":"scheduled observation cycle","harmonic_signature":[],"spiral_reference":null}' \
             --runtime-config-json '{"toki_pona_required_for_resume":false,"binary_required_for_transition_validation":false,"light_language_required_for_capability_loading":false,"harmonic_frequency_required_for_mode_legality":false}'

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md
@@ -45,6 +45,7 @@ python bin/lumina state --limit 12
 | Self-guided runner bridge | `runtime/runtime_runner_self_guided_bridge_r1.py` |
 | Recursive reflection motif | `runtime/lumina_reflective_autonomy_layer_r1.py` |
 | Reflection-before-guidance runner bridge | `runtime/runtime_runner_reflective_self_guided_bridge_r1.py` |
+| Bridge-stack explanation | `docs/Lumina_Runner_Bridge_Stack_001.md` |
 
 Current motif:
 
@@ -82,13 +83,17 @@ Reflection and self-guidance are advisory. They do not own mode legality, mutati
 | CLI surface | `studio/lumina_cli.py` |
 | Local server | `studio/lumina_studio_server.py` |
 | State browser | `studio/lumina_state_browser.py` |
+| Psi-42 v1.7 receipt viewer | `studio/lumina_psi42_v17_receipt_view_r1.py` |
 | Studio sea trial | `sea_trials_lumina_studio_v0_1.py` |
 
 ## Psi-42 and quantum-adjacent boundaries
 
 | Responsibility | Primary files |
 |---|---|
-| Psi-42 transceiver | `runtime/psi42_transceiver_v1_6.py` |
+| Psi-42 v1.6 signal transceiver | `runtime/psi42_transceiver_v1_6.py` |
+| Psi-42 relational topology extension | `runtime/psi42_relational_topology_r1.py` |
+| Psi-42 v1.7 hybrid transceiver | `runtime/psi42_transceiver_v1_7.py` |
+| Psi-42 v1.7 receipt summary | `runtime/psi42_v17_observation_receipt_summary_r1.py` |
 | Quantum terminology boundary | `docs/Quantum_Concepts_Boundary_r1.md` |
 | Quantum concepts registry | `runtime/quantum_concepts_registry_r1.json` |
 | Branch resolution model | `runtime/branch_resolution_model_r1.json` |
@@ -107,6 +112,8 @@ Psi-42 is an instrument. It does not own governance, canon, or runtime law.
 | Orchestration stack | `sea_trials_lumina_orchestration_stack_r1.py` |
 | Orchestration continuity | `sea_trials_lumina_orchestration_continuity_r1.py` |
 | Studio | `sea_trials_lumina_studio_v0_1.py` |
+| Psi-42 v1.7 receipt summary | `runtime/sea_trials_psi42_v17_observation_receipt_summary_r1.py` |
+| Psi-42 v1.7 runtime integration | `runtime/sea_trials_psi42_v17_runtime_integration_r1.py` |
 
 ## Docs to read when uncertain
 
@@ -120,6 +127,7 @@ Psi-42 is an instrument. It does not own governance, canon, or runtime law.
 - `docs/Lumina_Local_Runbook_001.md`
 - `docs/Lumina_First_Village_Framing_001.md`
 - `docs/Lumina_Reflective_Autonomy_Layer_001.md`
+- `docs/Lumina_Runner_Bridge_Stack_001.md`
 
 ## Maintenance rule
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Runner_Bridge_Stack_001.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Runner_Bridge_Stack_001.md
@@ -1,0 +1,79 @@
+# Lumina Runner Bridge Stack 001
+
+**Status:** active DryDock explanation  
+**Scope:** navigation and architecture clarity only; not runtime law.
+
+## Purpose
+
+This note explains why Lumina currently has several runner bridge files instead of one consolidated runner.
+
+The bridge stack is intentionally separated while the architecture is still proving itself. Each bridge adds one layer of behavior without silently changing the authority of the base runtime runner.
+
+## Current stack
+
+```text
+runtime_runner_r1_merged.py
+  -> runtime_runner_return_host_bridge_r1.py
+  -> runtime_runner_self_guided_bridge_r1.py
+  -> runtime_runner_reflective_self_guided_bridge_r1.py
+```
+
+## Layer meanings
+
+| Layer | Adds | Boundary |
+|---|---|---|
+| `runtime_runner_r1_merged.py` | Core governed runtime cycle, capability exposure, checkpoints, governance events, optional probes | Owns orchestration path only; governance law remains in `ModeGuard` |
+| `runtime_runner_return_host_bridge_r1.py` | Project return and workspace-host artifacts | Restores and frames project context; does not govern legality |
+| `runtime_runner_self_guided_bridge_r1.py` | Bounded next-action advisory from restored stance and history | Recommends only; does not authorize action |
+| `runtime_runner_reflective_self_guided_bridge_r1.py` | Recursive reflective trace before self-guidance | Reflection remains witness/sail, not governance/keel |
+
+## Why not consolidate yet?
+
+The bridges are useful proof-of-concept isolation.
+
+They let Lumina prove each layer independently:
+
+1. restore a project,
+2. host the restored working surface,
+3. recommend a next action,
+4. reflect before recommendation,
+5. then route through governed execution.
+
+Consolidating too early would hide failure ownership and make it harder to tell whether drift came from return, reflection, guidance, or runtime law.
+
+## Consolidation trigger
+
+Do not collapse the bridge stack until repeated sea trials show:
+
+- return/host artifacts remain stable,
+- self-guidance remains advisory,
+- reflective traces remain non-authoritative,
+- runtime governance still owns legality,
+- receipts make layer ownership easy to inspect.
+
+## Future shape
+
+A later Lumina runner may become configurable:
+
+```text
+lumina_runner(
+  enable_return_host=True,
+  enable_self_guidance=True,
+  enable_reflective_trace=True,
+  enable_psi42_v17=True,
+)
+```
+
+That future runner should still preserve explicit layer boundaries in its receipt.
+
+## Boundary reminder
+
+Bridge composition is convenience.
+
+It must not become hidden authority.
+
+Mode remains law.  
+Orientation remains stance.  
+Reflection remains witness.  
+Guidance remains advisory.  
+Runtime receipts remain evidence.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/psi42_v17_observation_receipt_summary_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/psi42_v17_observation_receipt_summary_r1.py
@@ -55,6 +55,22 @@ def _as_float(value: Any) -> Optional[float]:
         return None
 
 
+def _probe_run_id(probe: Dict[str, Any]) -> Optional[str]:
+    return (
+        probe.get("run_id")
+        or probe.get("signal_run_id")
+        or _nested(probe, "signal_result", "run_id")
+    )
+
+
+def _probe_pulse_id(probe: Dict[str, Any]) -> Optional[str]:
+    return (
+        probe.get("pulse_id")
+        or probe.get("signal_pulse_id")
+        or _nested(probe, "signal_result", "pulse_id")
+    )
+
+
 def summarize(receipt: Dict[str, Any], *, min_hybrid: float = 0.35) -> Dict[str, Any]:
     probe = receipt.get("probe_artifacts") or {}
     if not isinstance(probe, dict):
@@ -64,10 +80,13 @@ def summarize(receipt: Dict[str, Any], *, min_hybrid: float = 0.35) -> Dict[str,
         metrics = {}
 
     instrument_version = probe.get("instrument_version")
+    probe_mode = probe.get("probe_mode")
     hybrid = _as_float(metrics.get("hybrid_continuity_coherence"))
     topology_receipt = probe.get("topology_receipt")
     governance_valid = bool(_nested(receipt, "governance_chain_status", "valid"))
     halted = bool(receipt.get("halted"))
+    probe_run_id = _probe_run_id(probe)
+    probe_pulse_id = _probe_pulse_id(probe)
 
     checks = {
         "target_mode_observation": receipt.get("target_mode") == "Observation",
@@ -75,6 +94,8 @@ def summarize(receipt: Dict[str, Any], *, min_hybrid: float = 0.35) -> Dict[str,
         "not_halted": halted is False,
         "governance_chain_valid": governance_valid,
         "psi42_v17_selected": instrument_version == "v1.7",
+        "probe_mode_hybrid": probe_mode in (None, "hybrid") if instrument_version != "v1.7" else probe_mode == "hybrid",
+        "probe_identity_present": bool(probe_run_id),
         "topology_receipt_present": isinstance(topology_receipt, dict),
         "hybrid_continuity_present": hybrid is not None,
         "hybrid_continuity_threshold": hybrid is not None and hybrid >= min_hybrid,
@@ -89,6 +110,9 @@ def summarize(receipt: Dict[str, Any], *, min_hybrid: float = 0.35) -> Dict[str,
         "halted": halted,
         "governance_chain_valid": governance_valid,
         "instrument_version": instrument_version,
+        "probe_mode": probe_mode,
+        "probe_run_id": probe_run_id,
+        "probe_pulse_id": probe_pulse_id,
         "hybrid_continuity_coherence": hybrid,
         "topology_metrics": {metric: metrics.get(metric) for metric in TOPOLOGY_METRICS},
         "checks": checks,

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_ui_snapshot_emitter_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_ui_snapshot_emitter_r1.py
@@ -9,122 +9,198 @@ import json
 def _repo_root() -> Path:
     path = Path(__file__).resolve()
     for parent in [path.parent, *path.parents]:
-        if (parent / '.git').exists() or (parent / 'chamber.html').exists():
+        if (parent / ".git").exists() or (parent / "chamber.html").exists():
             return parent
     return path.parents[4]
 
-REPO_ROOT = _repo_root()
-PUBLIC_RUNTIME_DIR = REPO_ROOT / 'public' / 'runtime'
-PUBLIC_SNAPSHOT_PATH = PUBLIC_RUNTIME_DIR / 'latest_cycle.json'
-PUBLIC_HISTORY_DIR = PUBLIC_RUNTIME_DIR / 'history'
-PUBLIC_HISTORY_INDEX = PUBLIC_HISTORY_DIR / 'index.json'
-STATE_SNAPSHOT_PATH = REPO_ROOT / '.lumina_state' / 'ship_of_ethereon_v2' / 'runtime_outputs' / 'latest_cycle.json'
 
-# existing helper funcs unchanged behavior
+REPO_ROOT = _repo_root()
+PUBLIC_RUNTIME_DIR = REPO_ROOT / "public" / "runtime"
+PUBLIC_SNAPSHOT_PATH = PUBLIC_RUNTIME_DIR / "latest_cycle.json"
+PUBLIC_HISTORY_DIR = PUBLIC_RUNTIME_DIR / "history"
+PUBLIC_HISTORY_INDEX = PUBLIC_HISTORY_DIR / "index.json"
+STATE_SNAPSHOT_PATH = REPO_ROOT / ".lumina_state" / "ship_of_ethereon_v2" / "runtime_outputs" / "latest_cycle.json"
+
 
 def _read_json(path: str | Path) -> Dict[str, Any]:
-    with Path(path).open('r', encoding='utf-8') as f:
+    with Path(path).open("r", encoding="utf-8") as f:
         return json.load(f)
+
 
 def _allowed(governance: Dict[str, Any], key: str) -> Optional[bool]:
     value = governance.get(key)
     if isinstance(value, dict):
-        allowed = value.get('allowed')
+        allowed = value.get("allowed")
         return allowed if isinstance(allowed, bool) else None
     return None
+
 
 def _probe_metric(probe: Optional[Dict[str, Any]], *names: str) -> Optional[float]:
     if not isinstance(probe, dict):
         return None
-    metrics = probe.get('metrics') or {}
+    metrics = probe.get("metrics") or {}
+    if not isinstance(metrics, dict):
+        return None
     for name in names:
         value = metrics.get(name)
         if isinstance(value, (int, float)):
             return float(value)
     return None
 
+
+def _probe_metrics(probe: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(probe, dict):
+        return {}
+    metrics = probe.get("metrics") or {}
+    return metrics if isinstance(metrics, dict) else {}
+
+
+def _probe_run_id(probe: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not isinstance(probe, dict):
+        return None
+    signal = probe.get("signal_result") if isinstance(probe.get("signal_result"), dict) else {}
+    return probe.get("run_id") or probe.get("signal_run_id") or signal.get("run_id")
+
+
+def _probe_pulse_id(probe: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not isinstance(probe, dict):
+        return None
+    signal = probe.get("signal_result") if isinstance(probe.get("signal_result"), dict) else {}
+    return probe.get("pulse_id") or probe.get("signal_pulse_id") or signal.get("pulse_id")
+
+
+def _topology_metrics(probe: Optional[Dict[str, Any]]) -> Dict[str, Optional[float]]:
+    metrics = _probe_metrics(probe)
+    keys = ("RTC", "RDS", "RRS", "HRC", "node_coherence", "edge_coherence", "anchor_coherence")
+    return {key: float(metrics[key]) for key in keys if isinstance(metrics.get(key), (int, float))}
+
+
 def build_ui_snapshot(result: Dict[str, Any]) -> Dict[str, Any]:
-    governance = result.get('governance') or {}
-    chain = result.get('governance_chain_status') or {}
-    canon = result.get('canon_lineage') or {}
-    probe = result.get('probe_artifacts')
-    capabilities = [c.get('capability_id') for c in result.get('exposed_capabilities', []) if isinstance(c, dict) and c.get('capability_id')]
-    halted = bool(result.get('halted', False))
+    governance = result.get("governance") or {}
+    chain = result.get("governance_chain_status") or {}
+    canon = result.get("canon_lineage") or {}
+    probe = result.get("probe_artifacts")
+    capabilities = [
+        c.get("capability_id")
+        for c in result.get("exposed_capabilities", [])
+        if isinstance(c, dict) and c.get("capability_id")
+    ]
+    halted = bool(result.get("halted", False))
     return {
-        'schema_version': 'lumina-runtime-ui-cycle-v0.2',
-        'timestamp': result.get('created_at'),
-        'run_id': result.get('run_id'),
-        'requested_action': result.get('requested_action'),
-        'action_type': result.get('action_type'),
-        'mode': {'requested': result.get('requested_mode'), 'current': result.get('target_mode')},
-        'status': {'halted': halted, 'reason': result.get('halt_reason'), 'label': 'Halted' if halted else 'Stable'},
-        'governance': {
-            'transition': _allowed(governance, 'transition'),
-            'mutation': _allowed(governance, 'mutation'),
-            'promotion': _allowed(governance, 'promotion'),
-            'symbolic_dependency': _allowed(governance, 'symbolic_dependency'),
-            'ethereonic_attachment': _allowed(governance, 'ethereonic_attachment'),
-            'chain_valid': chain.get('valid'),
+        "schema_version": "lumina-runtime-ui-cycle-v0.3",
+        "timestamp": result.get("created_at"),
+        "run_id": result.get("run_id"),
+        "requested_action": result.get("requested_action"),
+        "action_type": result.get("action_type"),
+        "mode": {"requested": result.get("requested_mode"), "current": result.get("target_mode")},
+        "status": {"halted": halted, "reason": result.get("halt_reason"), "label": "Halted" if halted else "Stable"},
+        "governance": {
+            "transition": _allowed(governance, "transition"),
+            "mutation": _allowed(governance, "mutation"),
+            "promotion": _allowed(governance, "promotion"),
+            "symbolic_dependency": _allowed(governance, "symbolic_dependency"),
+            "ethereonic_attachment": _allowed(governance, "ethereonic_attachment"),
+            "chain_valid": chain.get("valid"),
         },
-        'canon': {'current_head': canon.get('current_head') or canon.get('canon_version'), 'valid': canon.get('valid'), 'record_count': canon.get('record_count')},
-        'capabilities': capabilities,
-        'probe': {'active': probe is not None, 'coherence': _probe_metric(probe, 'coherence', 'coherence_score'), 'presence': _probe_metric(probe, 'presence'), 'lock': _probe_metric(probe, 'alignment_strength', 'lock')},
-        'authority_boundary': 'Display receipt only; does not authorize action, alter governance, mutate canon, change mode legality, expose capabilities, or execute tools.',
+        "canon": {
+            "current_head": canon.get("current_head") or canon.get("canon_version"),
+            "valid": canon.get("valid"),
+            "record_count": canon.get("record_count"),
+        },
+        "capabilities": capabilities,
+        "probe": {
+            "active": isinstance(probe, dict),
+            "instrument_version": probe.get("instrument_version") if isinstance(probe, dict) else None,
+            "instrument_class": probe.get("instrument_class") if isinstance(probe, dict) else None,
+            "probe_mode": probe.get("probe_mode") if isinstance(probe, dict) else None,
+            "run_id": _probe_run_id(probe),
+            "pulse_id": _probe_pulse_id(probe),
+            "coherence": _probe_metric(
+                probe,
+                "hybrid_continuity_coherence",
+                "continuity_coherence",
+                "coherence",
+                "coherence_score",
+            ),
+            "presence": _probe_metric(probe, "presence"),
+            "lock": _probe_metric(probe, "alignment_strength", "lock"),
+            "hybrid_continuity_coherence": _probe_metric(probe, "hybrid_continuity_coherence"),
+            "topology_metrics": _topology_metrics(probe),
+            "topology_receipt_present": isinstance(probe, dict) and isinstance(probe.get("topology_receipt"), dict),
+        },
+        "authority_boundary": "Display receipt only; does not authorize action, alter governance, mutate canon, change mode legality, expose capabilities, or execute tools.",
     }
+
 
 def _archive_public_snapshot(snapshot: Dict[str, Any]) -> None:
     PUBLIC_HISTORY_DIR.mkdir(parents=True, exist_ok=True)
-    run_id = snapshot.get('run_id') or 'unknown-run'
-    safe_run = str(run_id).replace('/', '-').replace(':', '-')
-    ts = str(snapshot.get('timestamp') or 'unknown-time').replace(':', '-').replace('+', '_')
-    archive_name = f'{ts}_{safe_run}.json'
+    run_id = snapshot.get("run_id") or "unknown-run"
+    safe_run = str(run_id).replace("/", "-").replace(":", "-")
+    ts = str(snapshot.get("timestamp") or "unknown-time").replace(":", "-").replace("+", "_")
+    archive_name = f"{ts}_{safe_run}.json"
     archive_path = PUBLIC_HISTORY_DIR / archive_name
-    with archive_path.open('w', encoding='utf-8') as f:
+    with archive_path.open("w", encoding="utf-8") as f:
         json.dump(snapshot, f, indent=2)
-        f.write('\n')
+        f.write("\n")
+
     index = []
     if PUBLIC_HISTORY_INDEX.exists():
         try:
             index = _read_json(PUBLIC_HISTORY_INDEX)
         except Exception:
             index = []
-    entry = {'timestamp': snapshot.get('timestamp'), 'run_id': run_id, 'status': snapshot.get('status', {}).get('label'), 'mode': snapshot.get('mode', {}).get('current'), 'file': f'/runtime/history/{archive_name}'}
-    index = [entry] + [e for e in index if e.get('run_id') != run_id]
+
+    entry = {
+        "timestamp": snapshot.get("timestamp"),
+        "run_id": run_id,
+        "status": snapshot.get("status", {}).get("label"),
+        "mode": snapshot.get("mode", {}).get("current"),
+        "file": f"/runtime/history/{archive_name}",
+        "probe_instrument_version": snapshot.get("probe", {}).get("instrument_version"),
+        "hybrid_continuity_coherence": snapshot.get("probe", {}).get("hybrid_continuity_coherence"),
+    }
+    index = [entry] + [e for e in index if e.get("run_id") != run_id]
     index = index[:25]
-    with PUBLIC_HISTORY_INDEX.open('w', encoding='utf-8') as f:
+    with PUBLIC_HISTORY_INDEX.open("w", encoding="utf-8") as f:
         json.dump(index, f, indent=2)
-        f.write('\n')
+        f.write("\n")
+
 
 def write_snapshot(snapshot: Dict[str, Any], paths: Iterable[str | Path]) -> None:
     wrote_public = False
     for path in paths:
         target = Path(path)
         target.parent.mkdir(parents=True, exist_ok=True)
-        with target.open('w', encoding='utf-8') as f:
+        with target.open("w", encoding="utf-8") as f:
             json.dump(snapshot, f, indent=2)
-            f.write('\n')
+            f.write("\n")
         if target == PUBLIC_SNAPSHOT_PATH:
             wrote_public = True
     if wrote_public:
         _archive_public_snapshot(snapshot)
 
+
 def emit_from_result_file(result_path: str | Path, *, public: bool = True, state: bool = True) -> Dict[str, Any]:
     result = _read_json(result_path)
     snapshot = build_ui_snapshot(result)
     paths = []
-    if public: paths.append(PUBLIC_SNAPSHOT_PATH)
-    if state: paths.append(STATE_SNAPSHOT_PATH)
+    if public:
+        paths.append(PUBLIC_SNAPSHOT_PATH)
+    if state:
+        paths.append(STATE_SNAPSHOT_PATH)
     write_snapshot(snapshot, paths)
-    return {'snapshot': snapshot, 'paths': [str(p) for p in paths]}
+    return {"snapshot": snapshot, "paths": [str(p) for p in paths]}
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument('result_json')
-    parser.add_argument('--no-public', action='store_true')
-    parser.add_argument('--no-state', action='store_true')
+    parser.add_argument("result_json")
+    parser.add_argument("--no-public", action="store_true")
+    parser.add_argument("--no-state", action="store_true")
     return parser.parse_args()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     args = parse_args()
     emitted = emit_from_result_file(args.result_json, public=not args.no_public, state=not args.no_state)
     print(json.dumps(emitted, indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_psi42_v17_observation_receipt_summary_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_psi42_v17_observation_receipt_summary_r1.py
@@ -12,6 +12,9 @@ def main() -> int:
         "governance_chain_status": {"valid": True},
         "probe_artifacts": {
             "instrument_version": "v1.7",
+            "probe_mode": "hybrid",
+            "signal_run_id": "example-run-id",
+            "signal_pulse_id": "example-pulse-id",
             "metrics": {
                 "hybrid_continuity_coherence": 0.8096,
                 "RTC": 1.0,
@@ -25,6 +28,7 @@ def main() -> int:
     summary = summarize(receipt)
     assert summary["overall_pass"] is True
     assert summary["checks"]["psi42_v17_selected"] is True
+    assert summary["checks"]["probe_identity_present"] is True
     assert summary["checks"]["topology_metrics_present"] is True
     assert summary["hybrid_continuity_coherence"] == 0.8096
     print(summary)

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_psi42_v17_runtime_integration_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_psi42_v17_runtime_integration_r1.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+import json
+import shutil
+
+from runtime_runner_r1_merged import RuntimeRunner
+from psi42_v17_observation_receipt_summary_r1 import summarize
+
+
+BASE_DIR = Path(__file__).resolve().parent / "_sea_trials_tmp" / "psi42_v17_runtime_integration_r1"
+REGISTRY_PATH = Path(__file__).with_name("capability_registry_r1.json")
+
+SAFE_RUNTIME_CONFIG = {
+    "toki_pona_required_for_resume": False,
+    "binary_required_for_transition_validation": False,
+    "light_language_required_for_capability_loading": False,
+    "harmonic_frequency_required_for_mode_legality": False,
+}
+
+ETHEREONIC_OVERLAY = {
+    "active": True,
+    "anchor_language": ["english", "toki_pona", "binary", "light_language"],
+    "continuity_phrase": "psi42 v1.7 runtime integration sea trial",
+    "harmonic_signature": [432, 528, 963],
+    "spiral_reference": "RSE-v1",
+}
+
+
+def main() -> int:
+    if BASE_DIR.exists():
+        shutil.rmtree(BASE_DIR)
+    BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+    runner = RuntimeRunner(base_dir=BASE_DIR, registry_path=REGISTRY_PATH)
+    result = runner.run_cycle(
+        current_mode="Continuity",
+        target_mode="Observation",
+        requested_action="trial_psi42_v17_runtime_integration",
+        action_type="audit",
+        enabled_feature_flags=[
+            "ETHEREON_OBSERVATION",
+            "ETHEREON_PSI42",
+            "ETHEREON_PSI42_V17",
+            "ETHEREON_RESONANCE",
+        ],
+        ethereonic_overlay=ETHEREONIC_OVERLAY,
+        runtime_config=SAFE_RUNTIME_CONFIG,
+        raw_user_input="Run Psi-42 v1.7 runtime integration sea trial.",
+    )
+
+    receipt: Dict[str, Any] = result.to_dict()
+    summary = summarize(receipt)
+    exposed_ids = [
+        cap.get("capability_id")
+        for cap in receipt.get("exposed_capabilities", [])
+        if isinstance(cap, dict)
+    ]
+
+    checks = {
+        **summary["checks"],
+        "overall_summary_pass": summary["overall_pass"],
+        "v17_capability_exposed": "psi42_transceiver_v17" in exposed_ids,
+        "v16_fallback_still_available": "psi42_transceiver_v16" in exposed_ids,
+        "receipt_has_probe_artifacts": isinstance(receipt.get("probe_artifacts"), dict),
+        "receipt_has_checkpoint": bool(receipt.get("checkpoint_path")),
+    }
+
+    report = {
+        "suite": "Sea Trials - Psi-42 v1.7 runtime integration r1",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "summary": summary,
+        "exposed_capability_ids": exposed_ids,
+        "receipt_run_id": receipt.get("run_id"),
+        "receipt_log_path": receipt.get("log_path"),
+        "checkpoint_path": receipt.get("checkpoint_path"),
+        "governance_log_path": receipt.get("governance_log_path"),
+    }
+
+    report_path = BASE_DIR / "sea_trials_psi42_v17_runtime_integration_r1_report.json"
+    with report_path.open("w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+        f.write("\n")
+
+    print(json.dumps(report, indent=2))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/README.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/README.md
@@ -17,6 +17,7 @@ It is a local control surface that packages a request, invokes the existing runt
 - lets the runtime own input integrity, mode legality, mutation gates, capability exposure, checkpoints, governance logs, canon metadata, and optional probe execution
 - returns a compact receipt with checkpoint, governance, exposed capabilities, and halt status
 - reads recent runtime receipts and governance summaries through a read-only state browser
+- can summarize Psi-42 v1.7 Observation receipts through a read-only receipt viewer
 
 ## What Studio must not do
 
@@ -56,6 +57,22 @@ python lumina_cli.py "Draft the next Studio build step" \
   --intent build \
   --ethereonic-overlay
 ```
+
+## Psi-42 v1.7 receipt viewer
+
+After generating a full JSON Observation receipt, summarize the v1.7 probe fields through Studio:
+
+```bash
+python lumina_psi42_v17_receipt_view_r1.py /tmp/lumina_psi42_v17_receipt.json
+```
+
+For machine-readable output:
+
+```bash
+python lumina_psi42_v17_receipt_view_r1.py /tmp/lumina_psi42_v17_receipt.json --pretty
+```
+
+The viewer is read-only. It verifies and displays instrument version, probe mode, probe identity, hybrid continuity coherence, topology metrics, topology receipt presence, and governance-chain status. It does not run Lumina or authorize action.
 
 ## State browser usage
 
@@ -147,6 +164,7 @@ Studio v0.2 succeeds if it can additionally:
 - report canon head/count if present
 - expose the same read-only snapshot through `/api/state`
 - keep state inspection read-only and non-authoritative
+- read and summarize Psi-42 v1.7 Observation receipts without becoming a probe authority
 
 ## Next hardening steps
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_psi42_v17_receipt_view_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_psi42_v17_receipt_view_r1.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Studio helper for reading Psi-42 v1.7 Observation receipts.
+
+This is a read-only operator surface. It does not run Lumina, authorize action,
+alter governance, mutate canon, or change capability exposure.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_ROOT = BOOTSTRAP_ROOT / "runtime"
+if str(RUNTIME_ROOT) not in sys.path:
+    sys.path.insert(0, str(RUNTIME_ROOT))
+
+from psi42_v17_observation_receipt_summary_r1 import summarize
+
+
+def _load_json(path: str) -> Dict[str, Any]:
+    payload = json.loads(sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Receipt JSON root must be an object")
+    return payload
+
+
+def print_human(summary: Dict[str, Any]) -> None:
+    print("Psi-42 v1.7 Observation receipt")
+    print(f"  run:        {summary.get('run_id')}")
+    print(f"  mode:       {summary.get('target_mode')}")
+    print(f"  action:     {summary.get('action_type')}")
+    print(f"  halted:     {summary.get('halted')}")
+    print(f"  chain ok:   {summary.get('governance_chain_valid')}")
+    print(f"  instrument: {summary.get('instrument_version')} / {summary.get('probe_mode')}")
+    print(f"  probe run:  {summary.get('probe_run_id')}")
+    print(f"  hybrid:     {summary.get('hybrid_continuity_coherence')}")
+    topo = summary.get("topology_metrics") or {}
+    if topo:
+        print("  topology:   " + ", ".join(f"{k}={v}" for k, v in topo.items()))
+    print(f"  passed:     {summary.get('overall_pass')}")
+    failed = [key for key, ok in (summary.get("checks") or {}).items() if not ok]
+    if failed:
+        print("  failed:     " + ", ".join(failed))
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Read and summarize a Psi-42 v1.7 Observation receipt.")
+    parser.add_argument("receipt_json", help="Path to receipt JSON, or '-' for stdin.")
+    parser.add_argument("--pretty", action="store_true", help="Print JSON summary instead of human text.")
+    parser.add_argument("--min-hybrid", type=float, default=0.35)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    receipt = _load_json(args.receipt_json)
+    summary = summarize(receipt, min_hybrid=args.min_hybrid)
+    if args.pretty:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print_human(summary)
+    return 0 if summary.get("overall_pass") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Engages the five-part DryDock follow-up for Psi-42 v1.7 receipt identity, live validation, Studio/public surfacing, scheduled Observation, and bridge-stack documentation.

## What changed

### 1. Psi-42 v1.7 receipt identity / verifier hardening
- Updates `runtime/psi42_v17_observation_receipt_summary_r1.py`
- Verifier now accepts v1.7 signal identity via `run_id`, `signal_run_id`, or nested `signal_result.run_id`
- Adds checks for:
  - hybrid probe mode
  - probe identity presence
  - topology receipt presence
  - hybrid continuity coherence
  - RTC / RDS / RRS / HRC topology metrics

### 2. Live runtime integration sea trial
- Adds `runtime/sea_trials_psi42_v17_runtime_integration_r1.py`
- Runs an actual `RuntimeRunner` Observation audit with:
  - `ETHEREON_OBSERVATION`
  - `ETHEREON_PSI42`
  - `ETHEREON_PSI42_V17`
  - `ETHEREON_RESONANCE`
- Verifies v1.7 is exposed and selected, v1.6 fallback remains available, receipt is not halted, governance chain is valid, and topology/hybrid metrics exist.

### 3. Studio and public surfacing
- Adds `studio/lumina_psi42_v17_receipt_view_r1.py`
  - read-only operator helper for v1.7 Observation receipts
- Updates `studio/README.md` with usage
- Updates `runtime/runtime_ui_snapshot_emitter_r1.py`
  - public/runtime snapshots now include instrument version, probe mode, probe identity, hybrid continuity coherence, topology metrics, and topology receipt presence

### 4. Scheduled Observation v1.7 witness
- Updates `.github/workflows/lumina-observation-cycle.yml`
- Adds `ETHEREON_PSI42_V17` to the scheduled/manual Observation cycle so future public runtime ledger entries can show the hybrid signal-topology instrument.

### 5. Bridge-stack documentation
- Adds `docs/Lumina_Runner_Bridge_Stack_001.md`
- Updates `ACTIVE_RUNTIME_INDEX.md`
- Documents why the runner bridge stack remains separated during proof phase and when consolidation should happen.

## Boundary preserved

This PR does **not** make Psi-42 authoritative.
It does **not** alter mode legality, mutation permission, promotion gates, canon lineage, checkpoint legality, or consent.

Psi-42 v1.7 remains an instrument/witness. Studio and public snapshots remain read-only surfaces.

## Validation notes

Local syntax check was run on the generated Python files before committing:

```bash
python -m py_compile \
  lumina_cli.py \
  runtime_ui_snapshot_emitter_r1.py \
  psi42_v17_observation_receipt_summary_r1.py \
  sea_trials_psi42_v17_observation_receipt_summary_r1.py \
  sea_trials_psi42_v17_runtime_integration_r1.py
```

I did not run the full repo runtime locally from the connector environment.

## Known deliberate restraint

I avoided broad surgery on `runtime_runner_r1_merged.py`. The v1.7 summary now reads existing signal identity fields safely, and the UI surfaces them. A later tiny runner patch may still normalize top-level `run_id` / `pulse_id` inside v1.7 probe artifacts if desired.