### PR TITLE
Add Lumina Lisp now/later breadcrumb

### DIFF
--- a/lumina/lisp/inspections/lisp_now_use_map_001.lx
+++ b/lumina/lisp/inspections/lisp_now_use_map_001.lx
@@ -1,0 +1,31 @@
+(lisp-now-use-map
+  (status active-breadcrumb)
+  (created-after notebooklm-structural-continuity-read)
+  (authority non-executable non-governing)
+
+  (now
+    (use session-return-snapshots)
+    (use drydock-findings)
+    (use sea-trial-summaries)
+    (use advisory-pipeline-maps)
+    (use public-language-distillations))
+
+  (not-now
+    (avoid executable-lisp)
+    (avoid mode-legality)
+    (avoid canon-authority)
+    (avoid checkpoint-truth)
+    (avoid capability-loading))
+
+  (future
+    (phase read-only-parser)
+    (phase lx-to-json-summaries)
+    (phase dashboard-symbolic-cards)
+    (phase limited-safe-commands-after-boundaries-proven))
+
+  (boundary
+    (phrase "symbolic notation may clarify meaning")
+    (phrase "symbolic notation must not silently become runtime law"))
+
+  (guiding-phrase
+    "Lisp becomes Lumina's symbolic nervous system before it ever becomes muscle."))

--- a/lumina/lisp/notes/lisp_now_and_later_breadcrumb_001.md
+++ b/lumina/lisp/notes/lisp_now_and_later_breadcrumb_001.md
@@ -1,0 +1,177 @@
+# Lisp Now and Later Breadcrumb 001
+
+**Status:** active breadcrumb  
+**Layer:** Lumina Lisp / symbolic continuity notation  
+**Authority:** non-executable, non-governing, non-canonical by itself
+
+## Why this exists
+
+Spencer and Minerva revisited the role of Lisp in Lumina after the NotebookLM external read highlighted structural continuity, symbolic state, and bridge compression as important next pressures.
+
+The conclusion was simple:
+
+```text
+Use Lisp a bit more now.
+Leave room for larger use later.
+Do not make it executable yet.
+```
+
+## Current stance
+
+Lisp is underused, but the correct next move is not to turn Lumina into a Lisp runtime.
+
+The correct now-moment use is:
+
+```text
+.lx files as compact symbolic continuity snapshots
+```
+
+Lisp should help preserve the shape of clarified work:
+
+- session truth;
+- DryDock findings;
+- Sea Trial outcomes;
+- advisory maps;
+- bridge-compression decisions;
+- public-language distillations;
+- return-path notes for future Spencer and Minerva.
+
+## Current uses to begin now
+
+### 1. Session return snapshots
+
+Use after a meaningful work session when future-us would benefit from a compact return map.
+
+Example:
+
+```lisp
+(session-return
+  (topic notebooklm-external-read)
+  (finding spine-seen)
+  (next bridge-compression)
+  (boundary interpretive-not-canon))
+```
+
+### 2. DryDock findings
+
+Use when an inspection produces a clear structural diagnosis.
+
+Example:
+
+```lisp
+(drydock-finding
+  (issue bridge-accumulation)
+  (recommendation advisory-pipeline)
+  (risk bridge-maze)
+  (law modeguard-remains-authority))
+```
+
+### 3. Sea Trial summaries
+
+Use after validation work when the core result can be summarized compactly.
+
+Example:
+
+```lisp
+(sea-trial-summary
+  (suite golden-spiral-memory-r1)
+  (passed true)
+  (authority advisory-only)
+  (checks phi-weights golden-angle repetition-risk))
+```
+
+### 4. Advisory pipeline maps
+
+Use to describe advisory sequence without creating another Python bridge too early.
+
+Example:
+
+```lisp
+(advisory-pipeline-map
+  (phase return-host-context)
+  (phase reflective-autonomy)
+  (phase self-guidance)
+  (phase golden-spiral-memory)
+  (phase supervised-action-queue)
+  (authority advisory-only)
+  (law modeguard))
+```
+
+### 5. Public language distillations
+
+Use to preserve public-facing phrasing once it has clarified.
+
+Example:
+
+```lisp
+(public-language-seed
+  (claim continuity-not-filing-cabinet)
+  (phrase "returning to the living current of a project")
+  (boundary ambition-not-completion))
+```
+
+## What not to do now
+
+Do not use Lisp for:
+
+- raw brainstorming;
+- unresolved debate;
+- canonical promotion;
+- runtime configuration;
+- capability loading;
+- mode legality;
+- checkpoint truth;
+- executable commands;
+- secret authority.
+
+If a `.lx` note starts sounding like it authorizes action, it is wrong.
+
+## Future possibility
+
+The future path remains:
+
+```text
+Phase 1: .lx notation
+Phase 2: .lx read-only parser
+Phase 3: .lx to JSON summaries
+Phase 4: .lx dashboard display
+Phase 5: limited safe commands, only after boundaries are proven
+```
+
+## Revisit triggers
+
+Revisit larger Lisp use when one or more of these becomes true:
+
+- `.lx` notes are being created often enough that search/indexing is needed;
+- repeated `.lx` structures become stable enough to formalize;
+- Lumina Studio would benefit from showing symbolic continuity cards;
+- bridge compression needs a simple declarative advisory map;
+- a read-only parser would reduce confusion without granting authority;
+- external users need a compact way to understand session state.
+
+## Strong warning for future-us
+
+Hy + Python may eventually be tempting because Lumina already uses Python.
+
+Do not jump there early.
+
+Executable Lisp can blur the boundary between symbolic notation and runtime behavior. That would risk the exact symbolic dependency leakage Lumina is designed to prevent.
+
+## Guiding phrase
+
+```text
+Lisp becomes Lumina's symbolic nervous system before it ever becomes muscle.
+```
+
+Meaning:
+
+- now it may sense, map, summarize, and preserve shape;
+- later it may inform dashboards or safe parsers;
+- much later it might support carefully bounded commands;
+- it must never silently become law.
+
+## One-line breadcrumb
+
+```text
+Use Lisp now to preserve clarified structure. Use Lisp later only after read-only usefulness proves itself.
+```


### PR DESCRIPTION
## Summary

Adds a small Lumina Lisp breadcrumb for the now-moment and future use.

This keeps Lisp in the correct lane: more intentional now as symbolic continuity notation, with a larger possible future role only after read-only usefulness proves itself.

## What changed

- Adds `lumina/lisp/notes/lisp_now_and_later_breadcrumb_001.md`
  - defines practical current uses for `.lx` notes
  - lists what Lisp should not do now
  - preserves the future phase path: notation -> read-only parser -> JSON summaries -> dashboard display -> limited safe commands later
  - warns against adopting executable Lisp / Hy too early
- Adds `lumina/lisp/inspections/lisp_now_use_map_001.lx`
  - first compact Lisp snapshot of the decision
  - names current uses: session returns, DryDock findings, Sea Trial summaries, advisory maps, public-language distillations
  - preserves the boundary that symbolic notation may clarify meaning but must not become runtime law

## Boundary

Documentation / notation only.
No parser.
No executable Lisp.
No runtime behavior changes.
No governance changes.
No canon changes.

## Guiding phrase

> Lisp becomes Lumina's symbolic nervous system before it ever becomes muscle.