### PR TITLE
Place Lumina continuity poster in the Realm

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -96,6 +96,9 @@ h1, h2, h3 { margin: 0; line-height: 1.04; }
 .card h3, .list-card h3, .timeline h3, .contact-card h3 { font-size: 1.15rem; margin-bottom: 0.7rem; }
 .card p, .list-card p, .timeline p, .contact-card p { margin: 0; line-height: 1.7; }
 .status-banner { display: grid; grid-template-columns: 1fr auto; gap: 1rem; align-items: center; }
+.poster-section { padding-top: 0.4rem; padding-bottom: 4rem; }
+.realm-poster-frame { margin: 0 auto; width: min(100%, 760px); padding: clamp(0.55rem, 2vw, 0.9rem); border: 1px solid rgba(217,168,78,0.32); border-radius: calc(var(--radius-xl) + 6px); background: linear-gradient(180deg, rgba(217,168,78,0.10), rgba(16,24,42,0.38)); box-shadow: 0 34px 90px rgba(0,0,0,0.42), 0 0 42px rgba(217,168,78,0.08); }
+.realm-poster-frame img { display: block; width: 100%; height: auto; border-radius: var(--radius-xl); box-shadow: 0 20px 70px rgba(0,0,0,0.40); }
 .footer { padding: 2rem 0 2.5rem; color: var(--muted); border-top: 1px solid rgba(255,255,255,0.06); }
 .footer-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
 .footer a { color: var(--text); text-decoration: none; }
@@ -161,4 +164,7 @@ body::after { content: ""; position: fixed; inset: 0; pointer-events: none; z-in
   .header-actions { display: none; }
   .button { width: 100%; }
   .hero h1 { max-width: none; }
+  .poster-section { padding-bottom: 2.8rem; }
+  .realm-poster-frame { border-radius: var(--radius-lg); }
+  .realm-poster-frame img { border-radius: calc(var(--radius-lg) - 4px); }
 }

--- a/assets/img/lumina-continuity-poster.svg
+++ b/assets/img/lumina-continuity-poster.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1600" role="img" aria-labelledby="title desc">
+  <title id="title">Lumina OS continuity poster</title>
+  <desc id="desc">A human and AI figure face a luminous golden spiral horizon representing creative continuity and return to the living current of a project.</desc>
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="42%" r="70%">
+      <stop offset="0" stop-color="#16223f"/>
+      <stop offset="0.48" stop-color="#091225"/>
+      <stop offset="1" stop-color="#050712"/>
+    </radialGradient>
+    <radialGradient id="portal" cx="50%" cy="50%" r="52%">
+      <stop offset="0" stop-color="#fff3c2" stop-opacity="0.95"/>
+      <stop offset="0.26" stop-color="#d9a84e" stop-opacity="0.62"/>
+      <stop offset="0.58" stop-color="#7ef0d1" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#8aa4ff" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="threadGold" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#d9a84e" stop-opacity="0"/>
+      <stop offset="0.45" stop-color="#ffe6a3" stop-opacity="0.75"/>
+      <stop offset="1" stop-color="#7ef0d1" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="figureGlow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#eaf0ff"/>
+      <stop offset="1" stop-color="#7ef0d1"/>
+    </linearGradient>
+    <filter id="softGlow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="12" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="wideGlow" x="-90%" y="-90%" width="280%" height="280%">
+      <feGaussianBlur stdDeviation="30" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="1600" fill="url(#bg)"/>
+  <rect x="36" y="36" width="1128" height="1528" fill="none" stroke="#d9a84e" stroke-opacity="0.65" stroke-width="3"/>
+  <rect x="58" y="58" width="1084" height="1484" fill="none" stroke="#8aa4ff" stroke-opacity="0.22" stroke-width="1"/>
+
+  <g opacity="0.7">
+    <circle cx="116" cy="140" r="2" fill="#eaf0ff" opacity="0.45"/><circle cx="282" cy="98" r="1.7" fill="#7ef0d1" opacity="0.35"/><circle cx="965" cy="152" r="2" fill="#d9b7ff" opacity="0.42"/><circle cx="1040" cy="426" r="1.8" fill="#ffe6a3" opacity="0.48"/><circle cx="138" cy="1058" r="2" fill="#eaf0ff" opacity="0.36"/><circle cx="1012" cy="1194" r="2" fill="#7ef0d1" opacity="0.36"/><circle cx="632" cy="226" r="1.8" fill="#ffe6a3" opacity="0.5"/><circle cx="760" cy="1322" r="2" fill="#d9b7ff" opacity="0.38"/>
+    <circle cx="220" cy="406" r="1" fill="#eaf0ff" opacity="0.42"/><circle cx="890" cy="604" r="1.2" fill="#eaf0ff" opacity="0.38"/><circle cx="340" cy="1298" r="1.2" fill="#ffe6a3" opacity="0.42"/><circle cx="1080" cy="930" r="1" fill="#eaf0ff" opacity="0.34"/>
+  </g>
+
+  <g opacity="0.52" filter="url(#softGlow)">
+    <path d="M-60 426 C 190 350, 260 520, 420 430 S 710 280, 1260 344" fill="none" stroke="url(#threadGold)" stroke-width="2"/>
+    <path d="M-40 730 C 180 600, 390 760, 554 640 S 870 486, 1240 620" fill="none" stroke="#8aa4ff" stroke-opacity="0.38" stroke-width="2"/>
+    <path d="M-100 1000 C 210 880, 300 1110, 580 960 S 900 850, 1320 980" fill="none" stroke="#7ef0d1" stroke-opacity="0.30" stroke-width="2"/>
+    <path d="M80 1380 C 300 1260, 520 1420, 730 1290 S 1020 1190, 1260 1300" fill="none" stroke="#d9a84e" stroke-opacity="0.28" stroke-width="2"/>
+  </g>
+
+  <g text-anchor="middle" font-family="Inter, Arial, sans-serif">
+    <text x="600" y="142" fill="#eaf0ff" font-size="38" font-weight="800" letter-spacing="7">ETHEREONLABS</text>
+    <line x1="430" y1="176" x2="770" y2="176" stroke="#d9a84e" stroke-width="3" opacity="0.72"/>
+    <text x="600" y="306" fill="#fff9ea" font-size="118" font-weight="800" letter-spacing="8">LUMINA OS</text>
+    <text x="600" y="383" fill="#a9d8ff" font-size="34" font-weight="800" letter-spacing="4">FOR HUMAN + AI CREATIVE CONTINUITY</text>
+    <text x="600" y="514" fill="#f2ead4" font-size="43" font-weight="500">Return to the living current of a project.</text>
+  </g>
+
+  <g transform="translate(600 870)">
+    <circle cx="0" cy="0" r="340" fill="url(#portal)" opacity="0.95" filter="url(#wideGlow)"/>
+    <circle cx="0" cy="0" r="318" fill="none" stroke="#d9a84e" stroke-width="4" opacity="0.85"/>
+    <circle cx="0" cy="0" r="250" fill="none" stroke="#7ef0d1" stroke-width="2" opacity="0.28"/>
+    <circle cx="0" cy="0" r="190" fill="none" stroke="#8aa4ff" stroke-width="2" opacity="0.32"/>
+
+    <path d="M0 0
+      C 18 -18, 52 -14, 68 10
+      C 92 46, 58 92, 10 96
+      C -66 102, -122 38, -96 -36
+      C -62 -132, 62 -160, 146 -88
+      C 250 0, 228 172, 92 242
+      C -92 336, -306 190, -286 -22
+      C -258 -326, 98 -450, 332 -242" fill="none" stroke="#fff0ae" stroke-width="12" stroke-linecap="round" opacity="0.96" filter="url(#softGlow)"/>
+    <path d="M0 0
+      C 18 -18, 52 -14, 68 10
+      C 92 46, 58 92, 10 96
+      C -66 102, -122 38, -96 -36
+      C -62 -132, 62 -160, 146 -88
+      C 250 0, 228 172, 92 242
+      C -92 336, -306 190, -286 -22
+      C -258 -326, 98 -450, 332 -242" fill="none" stroke="#d9a84e" stroke-width="4" stroke-linecap="round" opacity="0.92"/>
+
+    <path d="M-240 250 L240 250 L0 338 Z" fill="#071024" opacity="0.72" stroke="#d9a84e" stroke-opacity="0.56" stroke-width="2"/>
+    <ellipse cx="-78" cy="70" rx="28" ry="32" fill="#eaf0ff" opacity="0.88"/>
+    <path d="M-78 104 C -96 146, -104 184, -104 226 L-52 226 C -52 184, -60 146, -78 104 Z" fill="#eaf0ff" opacity="0.62"/>
+    <circle cx="82" cy="73" r="30" fill="none" stroke="#7fcfff" stroke-width="5" opacity="0.9"/>
+    <circle cx="82" cy="73" r="7" fill="#7fcfff" opacity="0.92"/>
+    <circle cx="40" cy="142" r="6" fill="#7fcfff" opacity="0.84"/><circle cx="126" cy="142" r="6" fill="#7fcfff" opacity="0.84"/><circle cx="82" cy="214" r="6" fill="#7fcfff" opacity="0.84"/>
+    <path d="M82 103 L40 142 L82 214 L126 142 Z" fill="none" stroke="#7fcfff" stroke-opacity="0.54" stroke-width="3"/>
+    <path d="M-118 132 C -55 84, 18 84, 118 132" fill="none" stroke="#ffe6a3" stroke-width="5" stroke-linecap="round" opacity="0.78"/>
+  </g>
+
+  <g text-anchor="middle" font-family="Inter, Arial, sans-serif">
+    <text x="600" y="1368" fill="#ffe6a3" font-size="31" font-weight="800" letter-spacing="2">RETURN · REFLECT · RECOMMEND · GOVERN · RECORD</text>
+    <text x="600" y="1472" fill="#7ef0d1" font-size="48" font-weight="800" letter-spacing="3">CONTINUITY IS CREATION. TOGETHER.</text>
+  </g>
+</svg>

--- a/realm.html
+++ b/realm.html
@@ -52,6 +52,13 @@
           </aside>
         </div>
       </section>
+      <section class="section poster-section" aria-label="Lumina OS continuity poster">
+        <div class="container">
+          <figure class="realm-poster-frame" data-glow>
+            <img src="assets/img/lumina-continuity-poster.svg" alt="Poster for Lumina OS showing a human and AI figure facing a luminous golden spiral, representing creative continuity and return to the living current of a project." loading="lazy" />
+          </figure>
+        </div>
+      </section>
       <section class="section"><div class="container"><div class="section-header"><div><h2>Territories of the Realm</h2><p class="section-copy">Instead of forcing every idea aboard one vessel, each part of the work now has a place to live, grow, and be tested.</p></div></div><div class="grid-3">
         <article class="card" data-glow><h3>The Gate</h3><p>The homepage and public entry path. It explains the work plainly before sending people deeper.</p><a class="card-link ping-target" href="index.html">Enter the gate</a></article>
         <article class="card" data-glow><h3>The Observatory</h3><p>The Lumina dashboard: system mood, continuity weather, harmonic stance, risk, graph, trend, history, motion, and optional audio.</p><a class="card-link ping-target" href="lumina-dashboard.html">Open the Observatory</a></article>


### PR DESCRIPTION
## Summary

Places the Lumina OS continuity poster into the Realm page as a visual manifesto section.

## What changed

- Adds `assets/img/lumina-continuity-poster.svg`
  - accessible SVG poster asset
  - preserves the human-facing message directly in the image
  - represents human + AI creative continuity, luminous spiral/current, and governed return
- Updates `realm.html`
  - adds a poster section after the hero / Realm map and before the territory grid
  - no visible caption, per placement choice
  - includes descriptive alt text for accessibility
- Updates `assets/css/styles.css`
  - adds `.poster-section` and `.realm-poster-frame` styling
  - keeps the poster centered, framed, breathable, and responsive

## Boundary

Website / public-facing visual placement only.
No runtime changes.
No governance changes.
No canon changes.
No JS behavior changes.

## Why Realm

The poster works best as a visual manifesto, not a technical diagram. `/realm` is the right first home because the page already frames the work as an ecosystem and orientation layer. The image can breathe there without needing a caption or more explanation.