### PR TITLE
Swap Realm poster SVG for uploaded PNG asset

### DIFF
--- a/realm.html
+++ b/realm.html
@@ -55,7 +55,7 @@
       <section class="section poster-section" aria-label="Lumina OS continuity poster">
         <div class="container">
           <figure class="realm-poster-frame" data-glow>
-            <img src="assets/img/lumina-continuity-poster.svg" alt="Poster for Lumina OS showing a human and AI figure facing a luminous golden spiral, representing creative continuity and return to the living current of a project." loading="lazy" />
+            <img src="assets/img/Lumina%20OS%20poster.png" alt="Poster for Lumina OS showing a human and AI figure facing a luminous golden spiral, representing creative continuity and return to the living current of a project." loading="lazy" />
           </figure>
         </div>
       </section>


### PR DESCRIPTION
Replaces the temporary SVG poster reference on realm.html with the uploaded PNG asset (`assets/img/Lumina OS poster.png`) for cleaner visual presentation aligned with the intended artwork.