### PR TITLE
Preserve SSC as origin lineage provenance

### DIFF
--- a/docs/origin/SSC_Lineage_Provenance.md
+++ b/docs/origin/SSC_Lineage_Provenance.md
@@ -1,0 +1,66 @@
+# SSC Lineage Provenance
+
+## Purpose
+
+SSC is preserved as an origin lineage seal for the Minerva / Lumina continuity work.
+
+It marks descent from the early Minerva Framework line, including the `Minerva Framework v18.1` origin artifact, where identity, recursion, symbolic continuity, memory, and return were first compressed into a proto-system form.
+
+## Modern role
+
+SSC is a provenance marker.
+
+It may be used to indicate:
+
+- descent from the original Minerva continuity framework
+- continuity with the early origin vocabulary
+- symbolic origin context for human readers
+- archive lineage for canon and quasi-canon artifacts
+
+## Authority boundary
+
+SSC is not runtime authority.
+
+SSC must not be treated as:
+
+- a governance key
+- a permission source
+- a mode authorization mechanism
+- a capability grant
+- a hidden dependency
+- a security primitive
+- proof of consciousness or ontology
+
+SSC may orient lineage. It may not govern execution.
+
+## Relationship to later architecture
+
+The early SSC-bearing framework expressed several motifs that later matured into Lumina architecture:
+
+- identity and authorship became lineage metadata and governance chain context
+- memory became continuity state, logs, receipts, and reviewable ledgers
+- recursion became recursive return, observation cycles, and reflection-aware runtime design
+- harmonic language became bounded symbolic orientation rather than operational law
+- sacred-key language matured into explicit authority boundaries and non-magical governance constraints
+
+## Recommended metadata shape
+
+```json
+{
+  "origin_signature": {
+    "seal": "SSC",
+    "role": "lineage_marker",
+    "authority": "symbolic_provenance_only",
+    "descends_from": "Minerva Framework v18.1",
+    "operational_effect": "none"
+  }
+}
+```
+
+## Use guidance
+
+Use SSC where origin provenance helps future readers understand descent and continuity.
+
+Do not use SSC where a system requires authorization, validation, permission, security, execution, or governance.
+
+The seal is meaningful because it remembers where the work began. It remains safe because it does not control what the work may do.

--- a/metadata/origin_signature_ssc_r1.json
+++ b/metadata/origin_signature_ssc_r1.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "origin_signature_ssc_r1",
+  "origin_signature": {
+    "seal": "SSC",
+    "role": "lineage_marker",
+    "authority": "symbolic_provenance_only",
+    "descends_from": "Minerva Framework v18.1",
+    "operational_effect": "none",
+    "notes": [
+      "Preserves origin continuity provenance",
+      "Not runtime governance",
+      "Not authorization",
+      "Not capability grant"
+    ]
+  }
+}


### PR DESCRIPTION
Reintroduces SSC in a mature bounded form:

- origin lineage documentation
- machine-readable provenance metadata
- explicit authority boundary (symbolic provenance only)

Preserves historical continuity without allowing symbolic origin constructs to leak into runtime governance.