### PR TITLE
Add runtime truth bundle and symbolic dependency contract

### DIFF
--- a/artifacts/runtime_truth/current/README.md
+++ b/artifacts/runtime_truth/current/README.md
@@ -1,0 +1,38 @@
+# Runtime Truth Bundle
+
+This directory exists to hold machine-verifiable runtime truth artifacts rather than narrative summaries alone.
+
+## Purpose
+
+Lumina / Ethereon runtime claims should increasingly resolve to receipts.
+This bundle is the designated home for structural verification artifacts.
+
+This is not a symbolic layer.
+This is structural evidence.
+
+## Intended Artifacts
+
+- `governance_chain_verification.json`
+- `canon_lineage_verification.json`
+- `capability_registry_audit.json`
+- `symbolic_dependency_contract.json`
+- `protocol_conformance_report.json`
+
+## Structural Rule
+
+Expressive overlays may exist.
+They may annotate.
+They may orient.
+They may emit experimental probe artifacts.
+
+They may not become hidden dependencies for:
+
+- session recovery
+- governance legality
+- mutation authorization
+- promotion gating
+- canon lineage authority
+- checkpoint legality
+- capability exposure
+
+If a claim cannot eventually point to a receipt here, it should be treated as provisional.

--- a/artifacts/runtime_truth/current/symbolic_dependency_contract.json
+++ b/artifacts/runtime_truth/current/symbolic_dependency_contract.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0",
+  "purpose": "Explicitly define the boundary between expressive symbolic systems and structural runtime authority.",
+  "allowed_symbolic_roles": [
+    "annotation",
+    "orientation",
+    "supplemental context",
+    "experimental probe metadata",
+    "non-authoritative expressive overlays"
+  ],
+  "forbidden_symbolic_dependencies": [
+    "session recovery legality",
+    "mode transition legality",
+    "mutation authorization",
+    "promotion gating",
+    "canon lineage authority",
+    "checkpoint legality",
+    "capability exposure",
+    "governance verification"
+  ],
+  "semantic_clarity": {
+    "symbolic_context_present": true,
+    "symbolic_dependency_allowed": false,
+    "notes": "Presence of expressive context must never be interpreted as structural dependency."
+  },
+  "enforcement_expectation": "Runtime law should halt when symbolic dependency leakage is detected."
+}

--- a/docs/system/runtime-receipt-digest.md
+++ b/docs/system/runtime-receipt-digest.md
@@ -1,0 +1,29 @@
+# Runtime Receipt Digest
+
+## Purpose
+
+This document provides a human-readable digest of structural runtime receipts.
+
+The machine emits artifacts.
+Humans deserve summaries that do not require spelunking through JSON caverns with a torch and questionable life choices.
+
+## Digest Structure
+
+Each meaningful runtime milestone should summarize:
+
+- what changed
+- why it changed
+- validation artifacts produced
+- governance chain status
+- canon lineage impact
+- capability exposure implications
+- symbolic dependency boundary status
+- unresolved risks
+- recommended next action
+
+## Rule
+
+This digest summarizes receipts.
+It does not replace them.
+
+Canonical truth remains in verifiable artifacts, not prose.


### PR DESCRIPTION
## Summary
Establishes a runtime truth scaffold for structural verification artifacts and explicitly codifies the symbolic dependency boundary.

## Added
- artifacts/runtime_truth/current/README.md
- artifacts/runtime_truth/current/symbolic_dependency_contract.json
- docs/system/runtime-receipt-digest.md

## Intent
Improve semantic clarity between expressive symbolic context and structural runtime dependency.

This makes future claims increasingly receipt-driven rather than narrative-only.
