### PR TITLE
DryDock: harden runtime truth path resolution

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_observation_cycle_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_observation_cycle_r1.py
@@ -9,10 +9,56 @@ try:
 except Exception:
     from runtime_truth_emitter_r1 import RuntimeTruthEmitter
 
+try:
+    from .repo_paths_r1 import repo_root as _repo_root_helper, runtime_root as _runtime_root_helper, state_root as _state_root_helper
+except Exception:
+    try:
+        from repo_paths_r1 import repo_root as _repo_root_helper, runtime_root as _runtime_root_helper, state_root as _state_root_helper
+    except Exception:
+        _repo_root_helper = None
+        _runtime_root_helper = None
+        _state_root_helper = None
 
-RUNTIME_ROOT = Path(__file__).resolve().parent
-REPO_ROOT = RUNTIME_ROOT.parents[3] if len(RUNTIME_ROOT.parents) >= 4 else RUNTIME_ROOT
-STATE_ROOT = REPO_ROOT / ".lumina_state" / "ship_of_ethereon_v2"
+
+def infer_runtime_root() -> Path:
+    if _runtime_root_helper is not None:
+        try:
+            candidate = Path(_runtime_root_helper()).resolve()
+            if candidate.exists():
+                return candidate
+        except Exception:
+            pass
+    return Path(__file__).resolve().parent
+
+
+def infer_repo_root() -> Path:
+    if _repo_root_helper is not None:
+        try:
+            candidate = Path(_repo_root_helper()).resolve()
+            if candidate.exists():
+                return candidate
+        except Exception:
+            pass
+    for parent in Path(__file__).resolve().parents:
+        if (parent / ".git").exists() or (parent / "public").exists() or (parent / "LuminaOS").exists():
+            return parent
+    return infer_runtime_root()
+
+
+def infer_state_root() -> Path:
+    if _state_root_helper is not None:
+        try:
+            candidate = Path(_state_root_helper()).resolve()
+            if candidate.exists() or candidate.parent.exists():
+                return candidate
+        except Exception:
+            pass
+    return infer_repo_root() / ".lumina_state" / "ship_of_ethereon_v2"
+
+
+RUNTIME_ROOT = infer_runtime_root()
+REPO_ROOT = infer_repo_root()
+STATE_ROOT = infer_state_root()
 TRUTH_OUTPUT_DIR = REPO_ROOT / "artifacts" / "runtime_truth" / "current"
 
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_public_snapshot_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_public_snapshot_r1.py
@@ -5,13 +5,12 @@ from typing import Any, Dict, Optional
 import json
 
 try:
-    from .runtime_truth_observation_cycle_r1 import run_runtime_truth_observation_cycle
+    from .runtime_truth_observation_cycle_r1 import run_runtime_truth_observation_cycle, infer_repo_root
 except Exception:
-    from runtime_truth_observation_cycle_r1 import run_runtime_truth_observation_cycle
+    from runtime_truth_observation_cycle_r1 import run_runtime_truth_observation_cycle, infer_repo_root
 
 
-RUNTIME_ROOT = Path(__file__).resolve().parent
-REPO_ROOT = RUNTIME_ROOT.parents[3] if len(RUNTIME_ROOT.parents) >= 4 else RUNTIME_ROOT
+REPO_ROOT = infer_repo_root()
 PUBLIC_RUNTIME_DIR = REPO_ROOT / "public" / "runtime"
 LATEST_CYCLE_PATH = PUBLIC_RUNTIME_DIR / "latest_cycle.json"
 SNAPSHOT_PATH = PUBLIC_RUNTIME_DIR / "runtime_truth_snapshot.json"
@@ -28,6 +27,7 @@ def _write_json(path: Path, payload: Dict[str, Any]) -> str:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)
+        f.write("\n")
     return str(path)
 
 
@@ -78,10 +78,6 @@ def build_public_runtime_truth_snapshot(
     latest_cycle_path: Optional[str | Path] = None,
     snapshot_path: Optional[str | Path] = None,
 ) -> Dict[str, Any]:
-    """Generate runtime truth receipts and attach their summary to public runtime JSON.
-
-    This performs receipt ingestion only. It does not authorize actions or alter runtime law.
-    """
     latest_path = Path(latest_cycle_path) if latest_cycle_path else LATEST_CYCLE_PATH
     out_path = Path(snapshot_path) if snapshot_path else SNAPSHOT_PATH
 


### PR DESCRIPTION
## DryDock hull hardening

Scrapes brittle path-resolution barnacles from the runtime truth layer.

### Changes
- replaces hardcoded parent-depth repo assumptions in runtime truth observation layer
- prefers shared repo path helpers when available
- adds structural fallback discovery for repo/runtime/state roots
- hardens public runtime truth snapshot path resolution
- normalizes JSON file writing with trailing newline hygiene

### Why
Folder-depth assumptions are fragile. One refactor and the hull springs a leak.
