### PR TITLE
DryDock: enforce canonical site header audit

### DIFF
--- a/.github/workflows/site-header-audit.yml
+++ b/.github/workflows/site-header-audit.yml
@@ -1,0 +1,19 @@
+name: Site Header Audit
+
+on:
+  pull_request:
+    paths:
+      - "*.html"
+      - "assets/js/site-navigation-data.js"
+      - "tools/audit_site_headers.py"
+      - ".github/workflows/site-header-audit.yml"
+  workflow_dispatch:
+
+jobs:
+  audit-site-headers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run canonical site header audit
+        run: python tools/audit_site_headers.py


### PR DESCRIPTION
## DryDock guardrail

Before full header-normalizer removal, make header drift visible automatically.

### Adds
- GitHub Actions workflow for `tools/audit_site_headers.py`
- runs on PRs touching HTML or navigation definitions
- manual dispatch support

### Why
Prevents silent drift while we migrate baked headers toward canonical markup.
