### PR TITLE
DryDock: add manual site header migration workflow

### DIFF
--- a/.github/workflows/canonicalize-site-headers.yml
+++ b/.github/workflows/canonicalize-site-headers.yml
@@ -1,0 +1,27 @@
+name: Canonicalize Site Headers
+
+on:
+  workflow_dispatch:
+
+jobs:
+  canonicalize-site-headers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run canonicalizer
+        run: python tools/canonicalize_site_headers.py
+      - name: Run audit after canonicalization
+        run: python tools/audit_site_headers.py
+      - name: Generate patch artifact
+        run: |
+          mkdir -p artifacts
+          git diff > artifacts/site-header-canonicalization.patch
+          if [ ! -s artifacts/site-header-canonicalization.patch ]; then
+            echo "Headers already canonical." > artifacts/site-header-canonicalization.patch
+          fi
+      - name: Upload patch artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-header-canonicalization-patch
+          path: artifacts/site-header-canonicalization.patch


### PR DESCRIPTION
## DryDock migration executor

Because the connector environment cannot safely execute the full migration against repo files directly, add a GitHub-hosted workflow to do it deterministically.

### Adds
- manual workflow dispatch for site header canonicalization
- runs canonicalizer + audit in GitHub Actions
- uploads migration patch artifact for inspection

### Why
Lets us generate the exact migration diff safely inside the repo environment before removing `header-normalizer.js`.
