### PR TITLE
Restore animated brand sigil after header cleanup

### DIFF
--- a/assets/js/brand-sigil.js
+++ b/assets/js/brand-sigil.js
@@ -1,0 +1,9 @@
+(() => {
+  const sigilMarkup = `<svg class="brand-sigil" viewBox="0 0 52 52" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><defs><radialGradient id="brandSigilCenter" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#1c2545"/><stop offset="100%" stop-color="#060913"/></radialGradient></defs><rect x="1" y="1" width="50" height="50" rx="14" fill="#07091a" stroke="rgba(138,164,255,0.14)"/><g><g class="sigil-orbit-a"><ellipse cx="26" cy="26" rx="22" ry="12" fill="none" stroke="rgba(138,164,255,0.22)" stroke-width="0.6"/></g><g class="sigil-orbit-b"><ellipse cx="26" cy="26" rx="12" ry="22" fill="none" stroke="rgba(126,240,209,0.18)" stroke-width="0.6"/></g><g class="sigil-ring-outer"><circle cx="26" cy="26" r="21.5" fill="none" stroke="rgba(205,220,255,0.45)" stroke-width="0.75" stroke-dasharray="1.4 2.2"/></g><g class="sigil-ring-inner"><circle cx="26" cy="26" r="18.2" fill="none" stroke="rgba(126,240,209,0.54)" stroke-width="0.7" stroke-dasharray="1 1.8"/></g><circle cx="26" cy="26" r="9.4" fill="url(#brandSigilCenter)"/><circle cx="26" cy="26" r="9.0" fill="rgba(138,164,255,0.14)" class="sigil-bloom"/><text x="26" y="35.8" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-weight="700" font-size="25" fill="rgba(248,252,255,0.99)" stroke="rgba(248,252,255,0.35)" stroke-width="0.35">Ψ</text></g></svg>`;
+
+  document.querySelectorAll('.brand-mark').forEach((mark) => {
+    if (!mark.querySelector('.brand-sigil')) {
+      mark.innerHTML = sigilMarkup;
+    }
+  });
+})();

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -11,7 +11,17 @@ const ensureNavData = (callback) => {
   document.head.appendChild(navDataScript);
 };
 
+const loadBrandSigil = () => {
+  if (document.querySelector('script[data-brand-sigil]')) return;
+  const script = document.createElement('script');
+  script.src = 'assets/js/brand-sigil.js';
+  script.setAttribute('data-brand-sigil', '');
+  document.head.appendChild(script);
+};
+
 const enhanceSite = () => {
+  loadBrandSigil();
+
   const fallbackFooterLinks = [
     ['principles.html', 'Principles'],
     ['realm.html', 'Realm'],


### PR DESCRIPTION
## Regression fix

PR #275 correctly retired runtime header normalization, but the animated brand sigil had been piggybacking on that script.

This focused repair:
- adds a dedicated `brand-sigil.js`
- restores animated logo injection into `.brand-mark`
- keeps canonical baked headers intact
- does **not** restore nav mutation logic

Scope is intentionally surgical.
