### PR TITLE
DryDock: realign public runtime truth receipts

### DIFF
--- a/public/runtime/latest_cycle.json
+++ b/public/runtime/latest_cycle.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "lumina-runtime-ui-cycle-v0.3",
+  "schema_version": "lumina-runtime-ui-cycle-v0.4",
   "timestamp": "2026-05-17T19:36:33.310267+00:00",
   "run_id": "run-28d5f853-fc7",
   "requested_action": "chamber_observation_cycle",
@@ -17,14 +17,45 @@
     "transition": true,
     "mutation": false,
     "promotion": null,
-    "symbolic_dependency": true,
-    "ethereonic_attachment": true,
+    "symbolic_context_present": true,
+    "symbolic_dependency_allowed": false,
     "chain_valid": true
   },
   "canon": {
     "current_head": null,
     "valid": true,
     "record_count": 0
+  },
+  "runtime_truth": {
+    "governance_chain": {
+      "status": "verified_summary",
+      "valid": true,
+      "event_count": null
+    },
+    "canon_lineage": {
+      "status": "verified_summary",
+      "valid": true,
+      "current_head": null,
+      "record_count": 0
+    },
+    "protocol_conformance": {
+      "status": "receipt_emitter_available",
+      "valid": true,
+      "issues": [],
+      "source": "LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_emitter_r1.py"
+    },
+    "capability_registry": {
+      "status": "audited_summary",
+      "valid": true,
+      "capability_count": 13,
+      "issues": [],
+      "source": "LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json"
+    },
+    "symbolic_boundary": {
+      "symbolic_context_present": true,
+      "symbolic_dependency_allowed": false,
+      "contract_version": "1.0"
+    }
   },
   "capabilities": [
     "session_state_manager",


### PR DESCRIPTION
## DryDock runtime truth alignment

Fixes split-brain public runtime truth reporting where `latest_cycle.json` had drifted back to older symbolic governance language while `runtime_truth_snapshot.json` reflected the newer truth schema.

### Fixes
- upgrades latest_cycle schema to v0.4
- replaces stale symbolic_dependency / ethereonic_attachment language
- restores explicit runtime_truth summary block
- aligns symbolic boundary semantics with current public truth model

### Why
Public truth surfaces should not contradict each other.
