### PR TITLE
DryDock: remove deprecated header normalizer stub

### DIFF
--- a/assets/js/header-normalizer.js
+++ b/assets/js/header-normalizer.js
@@ -1,3 +1,0 @@
-// Deprecated after PR #274 canonicalized baked site headers.
-// Intentionally retained temporarily as inert stub for compatibility.
-(()=>{})();


### PR DESCRIPTION
## Final header cleanup

Verification showed no remaining references to `header-normalizer.js`.

This PR removes the deprecated inert compatibility stub now that:
- baked canonical headers are source of truth
- `site.js` no longer loads the normalizer
- `brand-sigil.js` owns the visual sigil enhancement
- documentation reflects current architecture

This is the actual final exorcism.
