### PR TITLE
DryDock: harden Lumina doctor readiness checks

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_doctor.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_doctor.py
@@ -11,6 +11,7 @@ import argparse
 import importlib.util
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List
@@ -43,8 +44,15 @@ OPTIONAL_FILES = [
 
 PYTHON_IMPORT_CHECKS = [
     "runtime/runtime_runner_r1_merged.py",
+    "runtime/runtime_runner_auto_snapshot_r1.py",
     "studio/lumina_cli.py",
     "studio/lumina_state_browser.py",
+]
+
+COMMAND_SMOKE_CHECKS = [
+    ["bin/lumina", "--help"],
+    ["bin/lumina", "doctor", "--json"],
+    ["studio/lumina_cli.py", "--help"],
 ]
 
 
@@ -64,11 +72,39 @@ def import_check(path_text: str) -> Dict[str, Any]:
     if not path.exists():
         return {"path": path_text, "ok": False, "reason": "missing file"}
     try:
-        spec = importlib.util.spec_from_file_location("lumina_doctor_probe", path)
-        ok = spec is not None and spec.loader is not None
-        return {"path": path_text, "ok": bool(ok), "reason": "loadable spec" if ok else "no import spec"}
+        module_name = "lumina_doctor_probe_" + path.stem
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        if spec is None or spec.loader is None:
+            return {"path": path_text, "ok": False, "reason": "no import spec"}
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return {"path": path_text, "ok": True, "reason": "import executed"}
     except Exception as exc:
         return {"path": path_text, "ok": False, "reason": str(exc)}
+
+
+def command_smoke_check(command: List[str]) -> Dict[str, Any]:
+    resolved = [str(BOOTSTRAP_ROOT / command[0]), *command[1:]]
+    if command[0].endswith(".py"):
+        resolved = [sys.executable, str(BOOTSTRAP_ROOT / command[0]), *command[1:]]
+    try:
+        proc = subprocess.run(
+            resolved,
+            cwd=str(BOOTSTRAP_ROOT),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=12,
+        )
+        return {
+            "command": " ".join(command),
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "stdout_tail": proc.stdout[-600:],
+            "stderr_tail": proc.stderr[-600:],
+        }
+    except Exception as exc:
+        return {"command": " ".join(command), "ok": False, "reason": str(exc)}
 
 
 def capability_registry_check() -> Dict[str, Any]:
@@ -104,12 +140,14 @@ def run_doctor() -> Dict[str, Any]:
     required = [file_check(path, required=True) for path in REQUIRED_FILES]
     optional = [file_check(path, required=False) for path in OPTIONAL_FILES]
     imports = [import_check(path) for path in PYTHON_IMPORT_CHECKS]
+    commands = [command_smoke_check(command) for command in COMMAND_SMOKE_CHECKS]
     registry = capability_registry_check()
     missing_required = [item["path"] for item in required if not item["exists"] or not item["is_file"]]
     failed_imports = [item for item in imports if not item["ok"]]
-    ok = not missing_required and not failed_imports and bool(registry.get("ok"))
+    failed_commands = [item for item in commands if not item["ok"]]
+    ok = not missing_required and not failed_imports and not failed_commands and bool(registry.get("ok"))
     return {
-        "schema_version": "lumina-doctor-v0.1",
+        "schema_version": "lumina-doctor-v0.2",
         "ok": ok,
         "bootstrap_root": str(BOOTSTRAP_ROOT),
         "repo_root": str(REPO_ROOT),
@@ -117,10 +155,12 @@ def run_doctor() -> Dict[str, Any]:
         "required_files": required,
         "optional_files": optional,
         "import_checks": imports,
+        "command_smoke_checks": commands,
         "capability_registry": registry,
         "state": state_path_check(),
         "missing_required_files": missing_required,
         "failed_imports": failed_imports,
+        "failed_commands": failed_commands,
     }
 
 
@@ -139,7 +179,11 @@ def print_human(payload: Dict[str, Any]) -> None:
         print("  failed imports:")
         for item in payload["failed_imports"]:
             print(f"    - {item['path']}: {item['reason']}")
-    if not payload["missing_required_files"] and not payload["failed_imports"]:
+    if payload["failed_commands"]:
+        print("  failed command smoke checks:")
+        for item in payload["failed_commands"]:
+            print(f"    - {item['command']}: {item.get('reason') or item.get('returncode')}")
+    if not payload["missing_required_files"] and not payload["failed_imports"] and not payload["failed_commands"]:
         print("  start command:   bin/lumina run")
         print("  observe command: bin/lumina observe")
         print("  state command:   bin/lumina state")


### PR DESCRIPTION
## Doctor truthfulness upgrade

The Lumina doctor previously checked file presence and import specs, but could still report healthy when real command paths or runtime imports were broken.

### Upgrades
- executes actual module imports instead of spec-only checks
- adds command smoke checks for host entry surfaces
- includes auto snapshot runner in import checks
- bumps doctor schema to `lumina-doctor-v0.2`

### Why
A system doctor should detect fake-green states.
