### PR TITLE
DryDock: allow same-mode no-op transitions

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_spine_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_spine_r1.py
@@ -307,6 +307,18 @@ class ModeGuard:
     """Enforces lawful transitions, mutation limits, promotion gates, and symbolic separation."""
 
     def validate_transition(self, current_mode: str, new_mode: str) -> GovernanceDecision:
+        if current_mode == new_mode:
+            return GovernanceDecision(
+                allowed=True,
+                reason="no-op transition; mode unchanged",
+                audit_event={
+                    "type": "mode_transition",
+                    "current_mode": current_mode,
+                    "new_mode": new_mode,
+                    "allowed": True,
+                    "no_op": True,
+                },
+            )
         allowed = new_mode in ALLOWED_TRANSITIONS.get(current_mode, [])
         reason = "transition allowed" if allowed else f"illegal transition: {current_mode} -> {new_mode}"
         return GovernanceDecision(


### PR DESCRIPTION
## ModeGuard hardening

Allows explicit same-mode no-op transitions in ModeGuard so the law object is safe for standalone callers, not only the current RuntimeRunner path.

### Change
- permits `current_mode == new_mode`
- records a governance audit event with `no_op: true`
- preserves existing transition legality rules for real mode changes

### Why
Remaining in the same mode should be lawful, while still not granting mutation authority.
