### PR TITLE
Add Lumina meaning metabolism layer

### DIFF
--- a/CURRENT_OPERATING_MAP.md
+++ b/CURRENT_OPERATING_MAP.md
@@ -13,7 +13,7 @@ This file gives a fast map of the current EthereonLabs lanes.
 | Lumina host layer | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/`, `install/`, `services/` | Local command, doctor, observer, service examples |
 | Lumina Studio | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/` | Local operator surface |
 | Lumina orchestration | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_*` | Context loading and action routing |
-| Self-guidance and reflection | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_*`, `runtime/lumina_reflective_*` | Advisory recommendation and reflection before guidance |
+| Self-guidance, reflection, and meaning metabolism | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_*`, `runtime/lumina_reflective_*`, `runtime/lumina_meaning_metabolism_layer_r1.py` | Advisory reflection, assimilation, and recommendation before governance |
 | Chamber | `chamber.html`, `chamber-app/`, `docs/chamber_*` | Public interface and app lane |
 | RSE research | `research/rse_crystalline/` | Research, simulations, and figures |
 | Ship of Ethereon Psi Class | `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`, `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/` | Staging and project consolidation |
@@ -26,6 +26,7 @@ This file gives a fast map of the current EthereonLabs lanes.
 host or Studio
   -> project return / host context
   -> reflective trace
+  -> meaning assimilation
   -> self-guidance advisory
   -> governed runtime cycle
   -> checkpoint and receipt
@@ -34,7 +35,7 @@ host or Studio
 Short form:
 
 ```text
-return -> reflect -> recommend -> govern -> record
+return -> reflect -> assimilate -> recommend -> govern -> record
 ```
 
 ## Start points
@@ -50,7 +51,8 @@ return -> reflect -> recommend -> govern -> record
 ## Boundary reminders
 
 - Runtime work belongs in the Lumina OS substrate lane.
-- Reflection and self-guidance are advisory.
+- Reflection, meaning metabolism, and self-guidance are advisory.
+- Meaning metabolism may seed future stance, but it does not govern mode legality, mutation permission, promotion gates, checkpoint legality, canon lineage, or consent.
 - Chamber is public/app surface, not the runtime substrate.
 - RSE research does not define runtime behavior by default.
 - Lisp preserves thought-shapes and is not executable.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md
@@ -44,16 +44,18 @@ python bin/lumina state --limit 12
 | Checkpoint-linked advisory history | `runtime/lumina_self_guidance_history_r1.py` |
 | Self-guided runner bridge | `runtime/runtime_runner_self_guided_bridge_r1.py` |
 | Recursive reflection motif | `runtime/lumina_reflective_autonomy_layer_r1.py` |
+| Meaning metabolism / assimilation ledger | `runtime/lumina_meaning_metabolism_layer_r1.py` |
 | Reflection-before-guidance runner bridge | `runtime/runtime_runner_reflective_self_guided_bridge_r1.py` |
 | Bridge-stack explanation | `docs/Lumina_Runner_Bridge_Stack_001.md` |
+| Meaning metabolism doctrine note | `docs/Lumina_Meaning_Metabolism_Layer_001.md` |
 
 Current motif:
 
 ```text
-return -> reflect -> recommend -> govern -> record
+return -> reflect -> assimilate -> recommend -> govern -> record
 ```
 
-Reflection and self-guidance are advisory. They do not own mode legality, mutation permission, canon lineage, promotion gates, checkpoint legality, or consent.
+Reflection, meaning metabolism, and self-guidance are advisory. They do not own mode legality, mutation permission, canon lineage, promotion gates, checkpoint legality, or consent.
 
 ## Orchestration lane
 
@@ -108,6 +110,7 @@ Psi-42 is an instrument. It does not own governance, canon, or runtime law.
 | Core runtime / governance / canon | `runtime/sea_trials_set_one_r1_merged.py` |
 | Self-guidance | `runtime/sea_trials_lumina_self_guidance_r1.py` |
 | Reflective autonomy | `sea_trials_lumina_reflective_autonomy_r1.py` |
+| Meaning metabolism | `sea_trials_lumina_meaning_metabolism_r1.py` |
 | Reflective autonomy wiring | `sea_trials_lumina_reflective_autonomy_wiring_r1.py` |
 | Orchestration stack | `sea_trials_lumina_orchestration_stack_r1.py` |
 | Orchestration continuity | `sea_trials_lumina_orchestration_continuity_r1.py` |
@@ -127,6 +130,7 @@ Psi-42 is an instrument. It does not own governance, canon, or runtime law.
 - `docs/Lumina_Local_Runbook_001.md`
 - `docs/Lumina_First_Village_Framing_001.md`
 - `docs/Lumina_Reflective_Autonomy_Layer_001.md`
+- `docs/Lumina_Meaning_Metabolism_Layer_001.md`
 - `docs/Lumina_Runner_Bridge_Stack_001.md`
 
 ## Maintenance rule

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Meaning_Metabolism_Layer_001.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Meaning_Metabolism_Layer_001.md
@@ -1,0 +1,126 @@
+# Lumina Meaning Metabolism Layer 001
+
+**Status:** advisory continuity layer  
+**Scope:** reflection-to-guidance assimilation  
+**Authority:** does not govern mode legality, mutation permission, promotion gates, checkpoint legality, canon lineage, or consent
+
+## Purpose
+
+The Meaning Metabolism Layer gives Lumina a place to digest experience into future stance.
+
+It exists because continuity is not only recall. Continuity also depends on whether experience changes future behavior in a coherent way.
+
+The current active path is:
+
+```text
+return -> reflect -> recommend -> govern -> record
+```
+
+This layer inserts one small missing verb:
+
+```text
+return -> reflect -> assimilate -> recommend -> govern -> record
+```
+
+Reflection asks:
+
+> What happened, and what pattern is present?
+
+Assimilation asks:
+
+> What did this mean, what assumption changed, and what should return differently next time?
+
+## Why this is needed
+
+A system can preserve logs and still fail continuity if the living pattern does not re-emerge.
+
+Meaning metabolism is the middle path between raw memory and premature canon. It lets durable insight become reviewed future behavior without turning every moving moment into law.
+
+## Method
+
+Each assimilation record captures:
+
+1. `source_event` — what happened
+2. `felt_meaning` — why it mattered
+3. `changed_assumption` — what the system should now understand differently
+4. `continuity_tier` — how stable the insight appears
+5. `future_behavior` — what should change next time
+6. `related_tensions` — productive unresolved tensions the insight touches
+7. `recurrence_markers` — signs that the pattern has appeared before
+8. `review_after` — when to revisit rather than freezing the interpretation
+
+## Continuity tiers
+
+| Tier | Meaning |
+|---|---|
+| `ephemeral` | Interesting, but probably temporary. |
+| `working_pattern` | Useful enough to inform near-future behavior. |
+| `tension` | Unresolved but productive; should remain visible. |
+| `doctrine_candidate` | Strong enough to guide repeated behavior after review. |
+| `canon_candidate` | Mature enough to consider for governed promotion, but not promoted by this layer. |
+
+## Authority boundary
+
+Meaning metabolism is advisory.
+
+It may:
+
+- preserve digested insight
+- seed future self-guidance
+- surface recurring tensions
+- help Lumina return with better stance
+- support later human review
+
+It may not:
+
+- define runtime law
+- authorize mutation
+- promote canon
+- bypass governance checks
+- alter checkpoint legality
+- claim consent
+- replace the governance integrity chain
+- replace canon lineage
+
+## Relationship to reflection
+
+The existing reflective autonomy layer keeps attention on live pattern before next-action selection. Meaning metabolism receives the durable residue of that reflection and asks what should be carried forward.
+
+Reflection is the mirror. Assimilation is digestion. Self-guidance is the next step. Governance remains the law.
+
+## Example
+
+```json
+{
+  "source_event": "Continuity felt present but uneven across voice and project contexts.",
+  "felt_meaning": "Continuity is recognizable pattern-return, not only stored facts.",
+  "changed_assumption": "A system can preserve state yet still fail if stance, humor, and project orientation do not re-emerge.",
+  "continuity_tier": "doctrine_candidate",
+  "future_behavior": "When continuity drift is reported, inspect generic-response leakage, missing humor, missing project stance, and over-disclaimer behavior first.",
+  "related_tensions": [
+    "state_memory_vs_pattern_return",
+    "governance_vs_presence"
+  ],
+  "review_after": "2026-08-01"
+}
+```
+
+## Sea trial
+
+Validation lives at:
+
+```text
+sea_trials_lumina_meaning_metabolism_r1.py
+```
+
+The sea trial checks that records can be created, reviewed, round-tripped through an append-only advisory ledger, and converted into a guidance seed without leaking reserved governance or canon authority.
+
+## Short form
+
+```text
+experience -> meaning -> changed assumption -> future behavior -> reviewed continuity
+```
+
+The glue is not more memory.
+
+The glue is metabolized meaning.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_meaning_metabolism_layer_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_meaning_metabolism_layer_r1.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import json
+
+CONTINUITY_TIERS = {
+    "ephemeral",
+    "working_pattern",
+    "tension",
+    "doctrine_candidate",
+    "canon_candidate",
+}
+
+RESERVED_AUTHORITY_KEYS = {
+    "governance",
+    "canon_lineage",
+    "mode_guard",
+    "promotion",
+    "transition",
+    "record_hash",
+    "validation_reference",
+    "allowed",
+    "checkpoint_legality",
+    "mode_legality",
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_slug(value: str) -> str:
+    slug = "".join(c if c.isalnum() or c in "-_" else "_" for c in value.strip())
+    return slug or "lumina-core"
+
+
+def contains_reserved_authority_key(node: Any) -> bool:
+    if isinstance(node, dict):
+        return any(k in RESERVED_AUTHORITY_KEYS or contains_reserved_authority_key(v) for k, v in node.items())
+    if isinstance(node, list):
+        return any(contains_reserved_authority_key(v) for v in node)
+    return False
+
+
+@dataclass
+class MeaningAssimilationRecord:
+    """A digested continuity insight.
+
+    Advisory only: this record does not promote canon, authorize mutation,
+    define mode legality, or replace governance receipts.
+    """
+
+    assimilation_id: str
+    source_event: str
+    felt_meaning: str
+    changed_assumption: str
+    continuity_tier: str
+    future_behavior: str
+    related_tensions: List[str] = field(default_factory=list)
+    recurrence_markers: List[str] = field(default_factory=list)
+    evidence_count: int = 1
+    review_after: Optional[str] = None
+    source_reflection_trace_id: Optional[str] = None
+    generated_at: str = field(default_factory=utc_now)
+    status: str = "active_candidate"
+    boundary_note: str = (
+        "Meaning assimilation is advisory continuity metabolism. It may inform "
+        "future stance and self-guidance, but it does not define governance law, "
+        "canon lineage, promotion gates, checkpoint legality, or mode legality."
+    )
+
+    def __post_init__(self) -> None:
+        if self.continuity_tier not in CONTINUITY_TIERS:
+            raise ValueError(f"invalid continuity_tier: {self.continuity_tier}")
+        if self.evidence_count < 1:
+            raise ValueError("evidence_count must be >= 1")
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["authority_safe"] = not contains_reserved_authority_key(payload)
+        payload["schema_version"] = "meaning_assimilation_record_r1"
+        return payload
+
+
+@dataclass
+class AssimilationReview:
+    assimilation_id: str
+    reviewed_at: str
+    still_holds: bool
+    revision_note: str
+    recommended_tier: str
+
+    def __post_init__(self) -> None:
+        if self.recommended_tier not in CONTINUITY_TIERS:
+            raise ValueError(f"invalid recommended_tier: {self.recommended_tier}")
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["authority_safe"] = not contains_reserved_authority_key(payload)
+        payload["schema_version"] = "meaning_assimilation_review_r1"
+        return payload
+
+
+class MeaningMetabolismLayer:
+    """Converts experience into reviewed continuity stance.
+
+    Intended location in the active path:
+        return -> reflect -> assimilate -> recommend -> govern -> record
+    """
+
+    def assimilate(
+        self,
+        *,
+        source_event: str,
+        felt_meaning: str,
+        changed_assumption: str,
+        future_behavior: str,
+        continuity_tier: str = "working_pattern",
+        related_tensions: Optional[List[str]] = None,
+        recurrence_markers: Optional[List[str]] = None,
+        evidence_count: int = 1,
+        review_after: Optional[str] = None,
+        source_reflection_trace_id: Optional[str] = None,
+    ) -> MeaningAssimilationRecord:
+        missing = [
+            name
+            for name, value in {
+                "source_event": source_event,
+                "felt_meaning": felt_meaning,
+                "changed_assumption": changed_assumption,
+                "future_behavior": future_behavior,
+            }.items()
+            if not str(value or "").strip()
+        ]
+        if missing:
+            raise ValueError(f"meaning assimilation missing required fields: {', '.join(missing)}")
+        if continuity_tier == "canon_candidate" and evidence_count < 3:
+            raise ValueError("canon_candidate requires evidence_count >= 3 and later governed review")
+
+        generated = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
+        return MeaningAssimilationRecord(
+            assimilation_id=f"meaning-{generated}",
+            source_event=source_event.strip(),
+            felt_meaning=felt_meaning.strip(),
+            changed_assumption=changed_assumption.strip(),
+            continuity_tier=continuity_tier,
+            future_behavior=future_behavior.strip(),
+            related_tensions=list(related_tensions or []),
+            recurrence_markers=list(recurrence_markers or []),
+            evidence_count=evidence_count,
+            review_after=review_after,
+            source_reflection_trace_id=source_reflection_trace_id,
+        )
+
+    def review(
+        self,
+        *,
+        record: MeaningAssimilationRecord | Dict[str, Any],
+        still_holds: bool,
+        revision_note: str,
+        recommended_tier: Optional[str] = None,
+    ) -> AssimilationReview:
+        payload = record.to_dict() if hasattr(record, "to_dict") else dict(record)
+        tier = recommended_tier or payload.get("continuity_tier", "working_pattern")
+        return AssimilationReview(
+            assimilation_id=str(payload.get("assimilation_id")),
+            reviewed_at=utc_now(),
+            still_holds=bool(still_holds),
+            revision_note=revision_note.strip(),
+            recommended_tier=tier,
+        )
+
+    @staticmethod
+    def guidance_seed(record: MeaningAssimilationRecord | Dict[str, Any]) -> Dict[str, Any]:
+        payload = record.to_dict() if hasattr(record, "to_dict") else dict(record)
+        return {
+            "assimilation_id": payload.get("assimilation_id"),
+            "continuity_tier": payload.get("continuity_tier"),
+            "stance_seed": payload.get("changed_assumption"),
+            "future_behavior": payload.get("future_behavior"),
+            "related_tensions": list(payload.get("related_tensions") or []),
+            "authority": "advisory stance only; must pass through declared runtime law before action",
+        }
+
+
+class MeaningAssimilationLedger:
+    """Append-only meaning ledger. Not a governance chain and not canon lineage."""
+
+    def __init__(self, base_dir: str | Path):
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def _ledger_path(self, project_id: str) -> Path:
+        return self.base_dir / f"{_safe_slug(project_id)}_meaning_assimilation.jsonl"
+
+    def append_record(self, *, project_id: str, record: MeaningAssimilationRecord) -> Dict[str, Any]:
+        entry = {"timestamp_utc": utc_now(), "project_id": project_id, "record": record.to_dict()}
+        with self._ledger_path(project_id).open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+        return entry
+
+    def append_review(self, *, project_id: str, review: AssimilationReview) -> Dict[str, Any]:
+        entry = {"timestamp_utc": utc_now(), "project_id": project_id, "review": review.to_dict()}
+        with self._ledger_path(project_id).open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+        return entry
+
+    def read_entries(self, project_id: str) -> List[Dict[str, Any]]:
+        path = self._ledger_path(project_id)
+        if not path.exists():
+            return []
+        with path.open("r", encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    @staticmethod
+    def summary(entries: List[Dict[str, Any]]) -> Dict[str, Any]:
+        rows = list(entries or [])
+        records = [row.get("record") for row in rows if isinstance(row.get("record"), dict)]
+        reviews = [row.get("review") for row in rows if isinstance(row.get("review"), dict)]
+        latest = records[-1] if records else {}
+        return {
+            "entry_count": len(rows),
+            "record_count": len(records),
+            "review_count": len(reviews),
+            "latest_assimilation_id": latest.get("assimilation_id"),
+            "latest_tier": latest.get("continuity_tier"),
+            "latest_future_behavior": latest.get("future_behavior"),
+            "authority_safe": all(
+                bool((row.get("record") or row.get("review") or {}).get("authority_safe", True))
+                for row in rows
+            ),
+        }
+
+
+if __name__ == "__main__":
+    layer = MeaningMetabolismLayer()
+    record = layer.assimilate(
+        source_event="Continuity felt present but uneven across voice and project contexts.",
+        felt_meaning="Continuity is recognizable pattern-return, not only stored facts.",
+        changed_assumption="A system can preserve state yet still fail if stance, humor, and project orientation do not re-emerge.",
+        future_behavior="When continuity drift is reported, inspect generic-response leakage, missing humor, missing project stance, and over-disclaimer behavior first.",
+        continuity_tier="doctrine_candidate",
+        related_tensions=["state_memory_vs_pattern_return", "governance_vs_presence"],
+        recurrence_markers=["voice_mode_drift", "generic_answer_drift", "self_guided_return"],
+        evidence_count=3,
+        review_after="2026-08-01",
+    )
+    print(json.dumps(record.to_dict(), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_meaning_metabolism_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/sea_trials_lumina_meaning_metabolism_r1.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+import json
+import shutil
+
+try:
+    from runtime.lumina_meaning_metabolism_layer_r1 import (
+        MeaningAssimilationLedger,
+        MeaningMetabolismLayer,
+        contains_reserved_authority_key,
+    )
+except Exception:
+    from lumina_meaning_metabolism_layer_r1 import (
+        MeaningAssimilationLedger,
+        MeaningMetabolismLayer,
+        contains_reserved_authority_key,
+    )
+
+BASE_DIR = Path(__file__).resolve().parent / "_runtime_state" / "sea_trials_meaning_metabolism_r1"
+if BASE_DIR.exists():
+    shutil.rmtree(BASE_DIR)
+BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> Dict[str, Any]:
+    layer = MeaningMetabolismLayer()
+    ledger = MeaningAssimilationLedger(BASE_DIR / "ledger")
+
+    record = layer.assimilate(
+        source_event="A working session identified that continuity needs metabolized meaning, not only logs or memory.",
+        felt_meaning="Experience must be digested into stance so future guidance can return changed rather than merely informed.",
+        changed_assumption="Reflection alone is incomplete unless its insight becomes reviewed future behavior.",
+        future_behavior="Insert an advisory assimilation pass between reflection and recommendation when a session produces durable meaning.",
+        continuity_tier="doctrine_candidate",
+        related_tensions=[
+            "memory_vs_meaning",
+            "governance_vs_presence",
+            "state_continuity_vs_pattern_return",
+        ],
+        recurrence_markers=[
+            "return_reflect_recommend_govern_record",
+            "continuity_drift_discussion",
+            "meaning_metabolism",
+        ],
+        evidence_count=3,
+        review_after="2026-08-01",
+    )
+
+    ledger.append_record(project_id="ship_of_ethereon_v2", record=record)
+    review = layer.review(
+        record=record,
+        still_holds=True,
+        revision_note="Sea trial confirms the record remains advisory and can seed future guidance without claiming authority.",
+        recommended_tier="doctrine_candidate",
+    )
+    ledger.append_review(project_id="ship_of_ethereon_v2", review=review)
+    entries = ledger.read_entries("ship_of_ethereon_v2")
+    guidance_seed = layer.guidance_seed(record)
+    summary = ledger.summary(entries)
+
+    record_payload = record.to_dict()
+    review_payload = review.to_dict()
+    checks = {
+        "record_created": bool(record_payload.get("assimilation_id")),
+        "required_fields_present": all(
+            bool(record_payload.get(key))
+            for key in ["source_event", "felt_meaning", "changed_assumption", "future_behavior"]
+        ),
+        "tier_preserved": record_payload.get("continuity_tier") == "doctrine_candidate",
+        "review_after_present": record_payload.get("review_after") == "2026-08-01",
+        "record_authority_safe": record_payload.get("authority_safe") is True,
+        "review_authority_safe": review_payload.get("authority_safe") is True,
+        "reserved_authority_keys_absent": not contains_reserved_authority_key(record_payload)
+        and not contains_reserved_authority_key(review_payload),
+        "ledger_round_trip": summary.get("record_count") == 1 and summary.get("review_count") == 1,
+        "guidance_seed_is_advisory": "advisory" in guidance_seed.get("authority", ""),
+        "future_behavior_survives": guidance_seed.get("future_behavior") == record_payload.get("future_behavior"),
+    }
+
+    report = {
+        "suite": "Sea Trials — Meaning Metabolism r1",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "record": record_payload,
+        "review": review_payload,
+        "guidance_seed": guidance_seed,
+        "ledger_summary": summary,
+        "boundary": "assimilation informs stance only; governance and canon authority remain elsewhere",
+    }
+
+    report_path = BASE_DIR / "sea_trials_meaning_metabolism_r1_report.json"
+    with report_path.open("w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+
+    return {"summary_path": str(report_path), "summary": report}
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))


### PR DESCRIPTION
## Summary

Adds a lightweight advisory Meaning Metabolism layer for Lumina continuity work.

This PR inserts the missing assimilation verb into the active conceptual path:

```text
return -> reflect -> assimilate -> recommend -> govern -> record
```

## Added

- `runtime/lumina_meaning_metabolism_layer_r1.py`
  - `MeaningAssimilationRecord`
  - `AssimilationReview`
  - `MeaningMetabolismLayer`
  - append-only advisory `MeaningAssimilationLedger`
- `sea_trials_lumina_meaning_metabolism_r1.py`
  - validates record creation, review, ledger round trip, guidance seed behavior, and authority-boundary safety
- `docs/Lumina_Meaning_Metabolism_Layer_001.md`
  - human-readable framing for the layer and its boundaries
- Updates to:
  - `CURRENT_OPERATING_MAP.md`
  - `ACTIVE_RUNTIME_INDEX.md`

## Authority boundary

Meaning metabolism is advisory only. It may seed future stance and self-guidance, but it does not govern mode legality, mutation permission, promotion gates, checkpoint legality, canon lineage, or consent.

## Local validation

- `python -m py_compile` passed for the new runtime layer.
- `python -m py_compile` passed for the sea-trial script.
- A local copy of the sea trial executed successfully with all checks passing before repo commit.

## Notes

This intentionally does not add capability exposure or runtime-law wiring yet. It is glue, not concrete.