### PR TITLE
Add fleet stewardship guardrails after Prisma review

### DIFF
--- a/CURRENT_OPERATING_MAP.md
+++ b/CURRENT_OPERATING_MAP.md
@@ -18,6 +18,7 @@ This file gives a fast map of the current EthereonLabs lanes.
 | RSE research | `research/rse_crystalline/` | Research, simulations, and figures |
 | Ship of Ethereon Psi Class | `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`, `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/` | Staging and project consolidation |
 | Lumina Lisp | `lumina/lisp/` | Non-executable symbolic snapshots |
+| Stewardship / review packets | `docs/FLEET_STEWARDSHIP_PACKET_*`, `docs/*BRIDGE*`, `docs/*REGISTRY*`, `docs/*VOCABULARY*` | Review follow-up, bridge discipline, surface maps, and naming hygiene |
 | Root spikes | `continuity_restore_spike_r1.py`, `lumina_workspace_host_spike_r1.py` | Reference / exploration history |
 
 ## Current active Lumina path
@@ -45,6 +46,7 @@ return -> reflect -> assimilate -> recommend -> govern -> record
 - Active Lumina file ownership: `LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md`
 - Artifact truth / drift prevention: `docs/ARTIFACT_TRUTH_CONTRACT.md`
 - Governance / canon seed plan: `docs/GOVERNANCE_CANON_SEED_PLAN.md`
+- Fleet stewardship follow-up: `docs/FLEET_STEWARDSHIP_PACKET_2026_05_20.md` and `docs/FLEET_STEWARDSHIP_PACKET_AMENDMENT_2026_05_20.md`
 - Psi Class staging: `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`
 - Lisp symbolic continuity: `lumina/lisp/README.md`
 
@@ -57,6 +59,7 @@ return -> reflect -> assimilate -> recommend -> govern -> record
 - RSE research does not define runtime behavior by default.
 - Lisp preserves thought-shapes and is not executable.
 - Psi Class is staging unless promoted through validated work.
+- Stewardship and review packets guide future work; they do not create runtime authority by themselves.
 - Root spikes are reference material unless deliberately moved into the bootstrap path.
 - When runtime, registry, validation receipts, docs, or website language disagree, reconcile them through `docs/ARTIFACT_TRUTH_CONTRACT.md`.
 - Empty governance or canon history is valid only when explained; use `docs/GOVERNANCE_CANON_SEED_PLAN.md` before seeding history.

--- a/docs/CHAMBER_ADVISORY_VOCABULARY.md
+++ b/docs/CHAMBER_ADVISORY_VOCABULARY.md
@@ -1,0 +1,61 @@
+# Chamber Advisory Vocabulary
+
+**Status:** proposed vocabulary note
+
+This note keeps Chamber advisory records legible as the public layer matures.
+
+## Advisory decision values
+
+Recommended values:
+
+- `pending`
+- `accepted`
+- `declined`
+- `expired`
+- `superseded`
+
+New advisories should begin as `pending`. Runtime results should not overwrite the decision value.
+
+## Action status values
+
+Recommended values:
+
+- `queued`
+- `claimed`
+- `in_progress`
+- `completed`
+- `failed`
+- `halted`
+- `cancelled`
+
+The action status describes the work item. The advisory decision describes consent. These should remain separate fields.
+
+## Source values
+
+Suggested starting values:
+
+- `reflective_autonomy`
+- `self_guidance_steward`
+- `meaning_metabolism`
+- `manual_user_request`
+- `system_drydock_review`
+- `prisma_review`
+- `minerva_review`
+
+## Mode values
+
+Use active mode names exactly:
+
+- `Continuity`
+- `Sandbox`
+- `DryDock`
+- `Observation`
+- `Canon`
+
+## Expiry note
+
+Pending advisories should eventually receive an expiry pattern before meaningful public traffic. Expiry should not imply rejection; it only means the advisory aged out without a decision.
+
+## Boundary
+
+This is not runtime law. It is a vocabulary guide so consent and audit records remain readable downstream.

--- a/docs/CHAMBER_RUNTIME_BRIDGE_DRYDOCK_PLAN.md
+++ b/docs/CHAMBER_RUNTIME_BRIDGE_DRYDOCK_PLAN.md
@@ -1,0 +1,72 @@
+# Chamber Runtime Bridge DryDock Plan
+
+**Status:** proposed drydock plan  
+**Authority:** review checklist only  
+**Scope:** future wiring between Chamber advisory records and Lumina runtime cycles
+
+## Purpose
+
+The Chamber to runtime bridge is the first place where public-facing consent shape and governed runtime behavior meet.
+
+This document defines the checks that should be in place before that bridge becomes active.
+
+## Intended chain
+
+```text
+chamber_advisory
+  -> explicit user decision
+  -> chamber_action_queue item
+  -> governance-admitted runtime request
+  -> runtime receipt
+  -> action_queue outcome summary
+```
+
+The runtime should not consume a raw advisory directly.
+
+## Required invariants
+
+1. A pending advisory cannot produce a runtime request.
+2. A declined advisory cannot produce a runtime request.
+3. An accepted advisory may produce at most one linked action queue item unless a later schema explicitly supports repeat work.
+4. A queued action must pass runtime governance before work is attempted.
+5. Runtime receipts must not rewrite advisory decision fields.
+6. Failed runtime work should update outcome fields without overwriting the original decision state.
+7. The bridge must preserve user ids for decision, claim, and completion.
+8. Bridge failures should be visible as receipts, not hidden retries.
+
+## DryDock checks
+
+Before activation, run a drydock suite that verifies:
+
+| Check | Expected result |
+|---|---|
+| pending advisory bridge attempt | halted, no runtime request |
+| declined advisory bridge attempt | halted, no runtime request |
+| accepted advisory without queued action | creates one queue item or halts with reason |
+| accepted advisory with existing queue item | no duplicate queue item |
+| queued action with governance denial | records halt outcome, preserves consent state |
+| queued action with runtime failure | writes outcome summary, preserves consent state |
+| attempted advisory record rewrite | rejected or ignored |
+| missing user id on state transition | rejected |
+
+## Bridge receipt minimum
+
+Every bridge attempt should leave a small receipt with:
+
+```text
+bridge_receipt_id
+advisory_id
+action_queue_id
+requested_action_type
+runtime_mode_requested
+governance_result
+runtime_result
+created_at
+notes
+```
+
+## Boundary
+
+This plan does not make Chamber a runtime substrate.
+
+Chamber remains the human-facing advisory and consent membrane. Lumina runtime remains the governed substrate. The bridge is a translator between them, not a new sovereign lane.

--- a/docs/DEPLOYMENT_BOUNDARY_NOTE.md
+++ b/docs/DEPLOYMENT_BOUNDARY_NOTE.md
@@ -1,0 +1,7 @@
+# Deployment Boundary Note
+
+This note records the next review question for hosted Lumina work.
+
+Before the runtime moves beyond a local environment, the project should document which environment is in scope, who approved that scope, how the scope is reviewed, and how receipts identify the environment used.
+
+Chamber decisions, runtime governance, and environment approval should remain separate rails.

--- a/docs/FLEET_STEWARDSHIP_PACKET_2026_05_20.md
+++ b/docs/FLEET_STEWARDSHIP_PACKET_2026_05_20.md
@@ -1,0 +1,67 @@
+# Fleet Stewardship Packet — 2026-05-20
+
+**Status:** active stewardship note  
+**Authority:** documentation and review guidance only  
+**Scope:** post-review alignment after Reflective Autonomy wiring, Chamber schema maturation, CI/runtime sea-trial verification, and deployment-lane emergence
+
+## Purpose
+
+This packet records the stewardship moves that follow from the latest architectural review of the EthereonLabs main branch.
+
+The review read the system as having crossed from design into operational reality: runtime governance, advisory reflection, Chamber consent shape, public surface, CI verification, and deployment signals are now all visible enough that the dominant risk has shifted from structural survival to hygiene, compression, consent portability, and naming discipline.
+
+This packet does not promote anything to runtime law by itself. It points to guardrails and review documents that should be consulted before the next load-bearing bridge work.
+
+## Core reading
+
+The current shape is best understood as:
+
+```text
+Lumina OS substrate = keel
+Reflective autonomy / self-guidance = sail
+Chamber advisory queue = consent membrane
+Deployment lane = emerging host boundary
+```
+
+The keel held. That changes the work.
+
+Projects still fighting for structural coherence do not get to worry about directory hygiene, bridge compression, advisory expiry, or public surface registries. EthereonLabs now does.
+
+## Documents added by this packet
+
+| Document | Purpose |
+|---|---|
+| `docs/DEPLOYMENT_CONSENT_MODEL.md` | Defines the host-of-record and deployment-side consent story before non-local runtime execution becomes operational. |
+| `docs/CHAMBER_RUNTIME_BRIDGE_DRYDOCK_PLAN.md` | Defines the drydock checks for wiring Chamber advisories into governed runtime actions. |
+| `docs/RUNNER_BRIDGE_OWNERSHIP_MAP.md` | Maps runner/bridge files before consolidation so compression does not erase useful distinctions. |
+| `docs/CHAMBER_ADVISORY_VOCABULARY.md` | Establishes expected advisory/action queue vocabulary and expiry behavior before meaningful Chamber traffic. |
+| `docs/PUBLIC_SURFACE_REGISTRY.md` | Gives the expanding public HTML surface the same lane discipline as the README authority map. |
+| `docs/RUNTIME_RECEIPTS_NAMING_NOTE.md` | Reframes runtime evidence artifacts away from over-weighted truth language unless formally governed. |
+
+## Accepted review conclusions
+
+- The advisory layer is currently orienting, not governing.
+- Consent has become structural at the public-facing boundary.
+- The Chamber to runtime bridge is the next major threshold.
+- Deployment introduces a host boundary that local execution previously hid.
+- Bridge accumulation and public surface accretion are now active drift surfaces.
+- Naming drift matters because language often moves before architecture does.
+
+## Stewardship order
+
+Recommended sequence:
+
+1. Define deployment consent before non-local runtime execution is treated as ordinary.
+2. Build the Chamber to runtime bridge only under explicit drydock checks.
+3. Map bridge ownership before compressing runner files.
+4. Establish advisory vocabulary and expiry policy before public Chamber traffic.
+5. Register public-facing pages by lane and status.
+6. Rename or contextualize runtime truth artifacts as receipts unless they are formally governed records.
+
+## Boundary reminder
+
+This packet is not governance law, canon lineage, consent state, or runtime authority.
+
+It is a navigation aid for the next phase of stewardship.
+
+The machine still holds only where the runtime, schema, CI, governance records, and documented authority boundaries agree.

--- a/docs/FLEET_STEWARDSHIP_PACKET_AMENDMENT_2026_05_20.md
+++ b/docs/FLEET_STEWARDSHIP_PACKET_AMENDMENT_2026_05_20.md
@@ -1,0 +1,14 @@
+# Fleet Stewardship Packet Amendment — 2026-05-20
+
+This amendment clarifies the final landed file names for the fleet stewardship packet.
+
+## Landed files
+
+- `docs/DEPLOYMENT_BOUNDARY_NOTE.md`
+- `docs/CHAMBER_RUNTIME_BRIDGE_DRYDOCK_PLAN.md`
+- `docs/RUNNER_BRIDGE_OWNERSHIP_MAP.md`
+- `docs/CHAMBER_ADVISORY_VOCABULARY.md`
+- `docs/PUBLIC_SURFACE_REGISTRY.md`
+- `docs/RUNTIME_ARTIFACT_NAMING_NOTE.md`
+
+The packet index originally named two fuller documents that were softened during connector handling. This amendment is the accurate file list for the PR.

--- a/docs/PUBLIC_SURFACE_REGISTRY.md
+++ b/docs/PUBLIC_SURFACE_REGISTRY.md
@@ -1,0 +1,34 @@
+# Public Surface Registry
+
+**Status:** working registry
+
+This registry keeps the website surface aligned with the repository lanes.
+
+## Fields to track
+
+- page or surface
+- path
+- lane
+- purpose
+- status
+- stewardship note
+
+## Starter lanes
+
+- home / entry
+- Chamber
+- roadmap
+- principles / guide / FAQ
+- lexicon
+- harmonics
+- RSE research
+- Lumina dashboard
+- reference / archive
+
+## Use
+
+When a new page is added, name its lane and purpose here. This prevents page growth from becoming navigation drift.
+
+## Reminder
+
+A public page can explain the work without becoming a source of authority for the work.

--- a/docs/RUNNER_BRIDGE_OWNERSHIP_MAP.md
+++ b/docs/RUNNER_BRIDGE_OWNERSHIP_MAP.md
@@ -1,0 +1,50 @@
+# Runner Bridge Ownership Map
+
+**Status:** working map  
+**Authority:** documentation and refactor guidance only  
+**Scope:** runtime runner, bridge, and adapter files that route requests into governed Lumina cycles
+
+## Purpose
+
+The runner and bridge stack is now useful enough to accumulate barnacles.
+
+Before files are compressed, merged, renamed, or retired, their ownership boundaries should be explicit. This map prevents cleanup from erasing distinctions that still matter.
+
+## Current ownership frame
+
+| Component pattern | Owns | May call | Must not own | Stewardship note |
+|---|---|---|---|---|
+| `runtime_runner_*` | Runtime cycle orchestration | Session engine, mode guard, context bundle builder, capability registry, probes when exposed | Governance law itself, canon truth outside the lineage store, Chamber consent | Canonical runner should stay boring and explicit. |
+| `runtime_spine_*` | Session state, mode guard, context building, governance log interfaces | Integrity chain, orientation vector, Ethereonic registry by attachment only | Public UI decisions, Chamber advisory state, host approval | This is keel territory. Keep it load-bearing and plain. |
+| `runtime_runner_orientation_adapter_*` | Inject project orientation into context bundle construction | Runtime runner and orientation vector helpers | Mode legality, mutation permission, promotion gates | Adapter can remain separate until orientation behavior is stable. |
+| `github_task_bridge_*` | Package repository snapshots and invoke runtime audit cycles | Git metadata, runtime runner | GitHub mutation authority, canon promotion authority | Bridge should stay adapter-shaped, not governance-shaped. |
+| future Chamber bridge | Translate accepted queued actions into governed runtime requests | Chamber queue, runtime runner | Raw advisory authority, direct runtime bypass | Build under drydock plan before activation. |
+| future deployment bridge | Attach environment/host context to runtime receipts | Host/environment registry, runtime runner | Chamber consent, governance law | Should remain explicit and receipt-oriented. |
+
+## Compression rule
+
+Do not merge files merely because their names sound similar.
+
+Merge only when all of the following are true:
+
+1. Their ownership boundaries are identical.
+2. Their failure modes are identical.
+3. Their test surfaces are compatible.
+4. Their removal does not hide a useful adapter seam.
+5. The README or active runtime index is updated in the same PR.
+
+## Suggested refactor path
+
+1. Mark one runner as canonical.
+2. Mark adapters as adapters, not alternate runners.
+3. Retire obsolete bridge files only after equivalent behavior is covered by tests or receipts.
+4. Keep the GitHub bridge and future Chamber bridge separate unless they converge on a common adapter interface.
+5. Consider a single configurable runner only after bridge semantics stop changing.
+
+## Drift warning
+
+Bridge accumulation is not automatically failure.
+
+Unmapped bridge accumulation is the failure mode.
+
+The map comes before the scissors.

--- a/docs/RUNTIME_ARTIFACT_NAMING_NOTE.md
+++ b/docs/RUNTIME_ARTIFACT_NAMING_NOTE.md
@@ -1,0 +1,21 @@
+# Runtime Artifact Naming Note
+
+**Status:** naming guidance
+
+Runtime artifacts should usually be described as receipts, observations, or evidence.
+
+## Preferred terms
+
+- runtime receipts
+- runtime observations
+- validation receipts
+- run evidence
+
+## Practical rule
+
+If a file records a run, call it a receipt.
+If a file sets rules for future runs, place it in a governed lane and document that authority.
+
+## Boundary
+
+Receipts support accountability. They do not replace governance, canon lineage, or consent records.


### PR DESCRIPTION
## Summary

Adds a documentation-only stewardship packet following the latest Prisma/Minerva architectural review of main.

This PR adds guardrails for the next maturity threshold:

- deployment/environment boundary note
- Chamber to runtime bridge drydock plan
- runner bridge ownership map
- Chamber advisory vocabulary note
- public surface registry starter
- runtime artifact naming note
- fleet stewardship packet + amendment
- operating map reference so future-us can find the packet

## Intent

The review read the system as past structural survival and into the hygiene/compression/selectivity phase. These docs preserve that shift without changing runtime law.

## Authority boundary

Documentation only. This PR does not mutate runtime behavior, schema, governance law, canon lineage, Chamber state, or public UI.

## Validation

No runtime tests run; documentation-only change.

## Notes

Two fuller draft names were softened during connector handling, so the amendment file records the accurate landed filenames for the PR.