### PR TITLE
Drydock: add deployment keel repairs

### DIFF
--- a/CURRENT_OPERATING_MAP.md
+++ b/CURRENT_OPERATING_MAP.md
@@ -13,6 +13,7 @@ This file gives a fast map of the current EthereonLabs lanes.
 | Lumina host layer | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/`, `install/`, `services/` | Local command, doctor, observer, service examples |
 | Lumina Studio | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/` | Local operator surface |
 | Lumina orchestration | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/lumina_*` | Context loading and action routing |
+| Lumina deployment appliance | `deploy/ubuntu_server_lts/`, `docs/DEPLOYMENT_*` | Ubuntu Server appliance scaffold and deployment keel guardrails |
 | Self-guidance, reflection, and meaning metabolism | `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_self_*`, `runtime/lumina_reflective_*`, `runtime/lumina_meaning_metabolism_layer_r1.py` | Advisory reflection, assimilation, and recommendation before governance |
 | Chamber | `chamber.html`, `chamber-app/`, `docs/chamber_*` | Public interface and app lane |
 | RSE research | `research/rse_crystalline/` | Research, simulations, and figures |
@@ -39,11 +40,19 @@ Short form:
 return -> reflect -> assimilate -> recommend -> govern -> record
 ```
 
+Deployment bridge form:
+
+```text
+host boundary -> appliance preflight -> governed runtime receipt -> Chamber bridge
+```
+
 ## Start points
 
 - New human reader: `START_HERE_HUMANS.md`
 - Lumina OS work: `START_HERE_LUMINA_OS.md`
 - Active Lumina file ownership: `LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md`
+- Lumina deployment appliance: `deploy/ubuntu_server_lts/README.md`
+- Deployment keel guardrails: `docs/DEPLOYMENT_HOST_REGISTRY_MODEL.md`, `docs/DEPLOYMENT_RUNTIME_RECEIPT_CONTRACT.md`, and `docs/DEPLOYMENT_DRYDOCK_CHECKLIST.md`
 - Artifact truth / drift prevention: `docs/ARTIFACT_TRUTH_CONTRACT.md`
 - Governance / canon seed plan: `docs/GOVERNANCE_CANON_SEED_PLAN.md`
 - Fleet stewardship follow-up: `docs/FLEET_STEWARDSHIP_PACKET_2026_05_20.md` and `docs/FLEET_STEWARDSHIP_PACKET_AMENDMENT_2026_05_20.md`
@@ -53,6 +62,7 @@ return -> reflect -> assimilate -> recommend -> govern -> record
 ## Boundary reminders
 
 - Runtime work belongs in the Lumina OS substrate lane.
+- Deployment appliance work must preserve a host/environment boundary before Chamber queue items become runtime work.
 - Reflection, meaning metabolism, and self-guidance are advisory.
 - Meaning metabolism may seed future stance, but it does not govern mode legality, mutation permission, promotion gates, checkpoint legality, canon lineage, or consent.
 - Chamber is public/app surface, not the runtime substrate.

--- a/deploy/ubuntu_server_lts/README.md
+++ b/deploy/ubuntu_server_lts/README.md
@@ -13,6 +13,10 @@ It establishes the first believable beta path:
 
 - `bootstrap_lumina_appliance_r1.sh`
   - first-pass installer scaffold for Ubuntu Server
+- `host_registry.example.json`
+  - example host-of-record registry for deployment drydock
+- `deployment_doctor_r1.py`
+  - non-mutating preflight checker for host boundary, env, path, and service-file readiness
 - `lumina-orchestrator.service`
   - systemd one-shot unit for bounded orchestration cycles
 - `lumina-orchestrator.timer`
@@ -82,11 +86,22 @@ On a fresh Ubuntu Server host:
 
 1. clone the repo or run the bootstrap script
 2. review and edit `/etc/lumina/lumina-appliance.env`
-3. build the Chamber app
-4. initialize PostgreSQL with the three Chamber SQL files
-5. install and enable the systemd units
-6. validate logs, queue persistence, and orchestration checkpoints across reboot
-7. run the deployment drydock checklist before treating the appliance as a real hosted runtime lane
+3. copy and edit `host_registry.example.json` for the real host
+4. build the Chamber app
+5. initialize PostgreSQL with the three Chamber SQL files
+6. install and enable the systemd units
+7. validate logs, queue persistence, and orchestration checkpoints across reboot
+8. run the deployment doctor / drydock checklist before treating the appliance as a real hosted runtime lane
+
+Example non-mutating preflight:
+
+```bash
+python deploy/ubuntu_server_lts/deployment_doctor_r1.py \
+  --repo-root /opt/lumina/EthereonLabs \
+  --env-file /etc/lumina/lumina-appliance.env \
+  --registry deploy/ubuntu_server_lts/host_registry.example.json \
+  --host-id host-local-dev-001
+```
 
 ## What this scaffold is for
 

--- a/deploy/ubuntu_server_lts/README.md
+++ b/deploy/ubuntu_server_lts/README.md
@@ -58,6 +58,24 @@ It preserves the repo's present law:
 - consent remains visible in Chamber
 - accepted queue items do not yet automatically become governed execution records
 
+## Deployment keel guardrails
+
+This scaffold is now paired with a deployment keel documentation set:
+
+- `../../docs/DEPLOYMENT_HOST_REGISTRY_MODEL.md`
+- `../../docs/DEPLOYMENT_RUNTIME_RECEIPT_CONTRACT.md`
+- `../../docs/DEPLOYMENT_DRYDOCK_CHECKLIST.md`
+
+These documents define the host-of-record model, deployed receipt expectations, and drydock checks that should be satisfied before this appliance is treated as ordinary hosted operation.
+
+The short rule:
+
+```text
+host boundary -> appliance preflight -> governed runtime receipt -> Chamber bridge
+```
+
+Do not treat accepted Chamber queue items as executable work until both the Chamber bridge discipline and deployment host discipline hold.
+
 ## First-use sequence
 
 On a fresh Ubuntu Server host:
@@ -68,6 +86,7 @@ On a fresh Ubuntu Server host:
 4. initialize PostgreSQL with the three Chamber SQL files
 5. install and enable the systemd units
 6. validate logs, queue persistence, and orchestration checkpoints across reboot
+7. run the deployment drydock checklist before treating the appliance as a real hosted runtime lane
 
 ## What this scaffold is for
 
@@ -81,4 +100,4 @@ into:
 
 ## Next likely hardening move
 
-After this scaffold, the next threshold is to validate the appliance end-to-end on a real Ubuntu Server VM and then decide whether accepted Chamber queue items should emit governed runtime execution records under explicit policy.
+After this scaffold, the next threshold is to validate the appliance end-to-end on a real Ubuntu Server VM, emit a deployment drydock receipt, and then decide whether accepted Chamber queue items should emit governed runtime execution records under explicit policy.

--- a/deploy/ubuntu_server_lts/deployment_doctor_r1.py
+++ b/deploy/ubuntu_server_lts/deployment_doctor_r1.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Lumina deployment doctor r1.
+
+Non-mutating preflight checker for the Ubuntu Server appliance scaffold.
+It inspects host registry, env placeholder risk, path presence, and service files.
+It does not start services, edit files, or grant authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import argparse
+import getpass
+import json
+import os
+
+DEFAULT_REPO_ROOT = Path(os.environ.get("REPO_ROOT", "/opt/lumina/EthereonLabs"))
+DEFAULT_ENV_FILE = Path(os.environ.get("LUMINA_ENV_FILE", "/etc/lumina/lumina-appliance.env"))
+DEFAULT_REGISTRY_PATH = Path(os.environ.get("LUMINA_HOST_REGISTRY", "deploy/ubuntu_server_lts/host_registry.example.json"))
+DEFAULT_HOST_ID = os.environ.get("LUMINA_HOST_ID", "host-local-dev-001")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class CheckResult:
+    check_id: str
+    passed: bool
+    severity: str
+    detail: str
+
+
+class DeploymentDoctor:
+    def __init__(self, *, repo_root: Path, env_file: Path, registry_path: Path, host_id: str):
+        self.repo_root = repo_root
+        self.env_file = env_file
+        self.registry_path = registry_path if registry_path.is_absolute() else repo_root / registry_path
+        self.host_id = host_id
+        self.checks: List[CheckResult] = []
+        self.host_record: Optional[Dict[str, Any]] = None
+
+    def add(self, check_id: str, passed: bool, severity: str, detail: str) -> None:
+        self.checks.append(CheckResult(check_id, passed, severity, detail))
+
+    def load_registry(self) -> None:
+        if not self.registry_path.exists():
+            self.add("host_registry_exists", False, "halt", f"Host registry not found: {self.registry_path}")
+            return
+        try:
+            payload = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            self.add("host_registry_parse", False, "halt", f"Host registry could not be parsed: {exc}")
+            return
+        hosts = payload.get("hosts", [])
+        for host in hosts:
+            if host.get("host_id") == self.host_id:
+                self.host_record = host
+                break
+        self.add("host_registry_exists", True, "info", f"Host registry loaded: {self.registry_path}")
+        self.add("host_record_found", self.host_record is not None, "halt", f"Host id requested: {self.host_id}")
+
+    def check_host_record(self) -> None:
+        host = self.host_record
+        if not host:
+            return
+        required_fields = [
+            "host_id",
+            "host_label",
+            "host_type",
+            "runtime_scope",
+            "approved_by_user_id",
+            "operator_user_ids",
+            "allowed_runtime_paths",
+            "allowed_action_types",
+            "state_root",
+            "log_root",
+            "service_user",
+            "created_at",
+        ]
+        missing = [field for field in required_fields if field not in host or host.get(field) in (None, "", [])]
+        self.add("host_required_fields", not missing, "halt", f"Missing fields: {missing}" if missing else "All required host fields present")
+        self.add("host_not_revoked", host.get("revoked_at") in (None, ""), "halt", f"revoked_at={host.get('revoked_at')}")
+
+        expected_user = host.get("service_user")
+        current_user = getpass.getuser()
+        self.add(
+            "service_user_context_visible",
+            bool(expected_user),
+            "warn",
+            f"expected service_user={expected_user}; current process user={current_user}",
+        )
+
+    def check_paths(self) -> None:
+        host = self.host_record or {}
+        self.add("repo_root_exists", self.repo_root.exists(), "halt", f"repo_root={self.repo_root}")
+        runtime_paths = host.get("allowed_runtime_paths", [])
+        for idx, raw_path in enumerate(runtime_paths):
+            path = Path(raw_path)
+            self.add(f"runtime_path_exists_{idx}", path.exists(), "halt", f"runtime_path={path}")
+        state_root = Path(host.get("state_root", "/var/lib/lumina"))
+        log_root = Path(host.get("log_root", "/var/log/lumina"))
+        self.add("state_root_exists", state_root.exists(), "warn", f"state_root={state_root}")
+        self.add("log_root_exists", log_root.exists(), "warn", f"log_root={log_root}")
+
+    def check_env_file(self) -> None:
+        if not self.env_file.exists():
+            self.add("env_file_exists", False, "halt", f"env_file={self.env_file}")
+            return
+        text = self.env_file.read_text(encoding="utf-8", errors="replace")
+        self.add("env_file_exists", True, "info", f"env_file={self.env_file}")
+        placeholder_terms = ["SET_USER", "SET_PASSWORD", "SET_DBNAME", "change-me", "https://example.com"]
+        present = [term for term in placeholder_terms if term in text]
+        self.add("env_placeholders_removed", not present, "halt", f"placeholder terms present: {present}" if present else "No known placeholder terms present")
+
+    def check_service_files(self) -> None:
+        service_files = [
+            self.repo_root / "deploy/ubuntu_server_lts/lumina-orchestrator.service",
+            self.repo_root / "deploy/ubuntu_server_lts/lumina-orchestrator.timer",
+            self.repo_root / "deploy/ubuntu_server_lts/chamber-advisory.service",
+        ]
+        for path in service_files:
+            self.add(f"service_file_exists:{path.name}", path.exists(), "halt", str(path))
+
+    def run(self) -> Dict[str, Any]:
+        self.load_registry()
+        self.check_host_record()
+        self.check_paths()
+        self.check_env_file()
+        self.check_service_files()
+        halt_conditions = [asdict(check) for check in self.checks if not check.passed and check.severity == "halt"]
+        warning_conditions = [asdict(check) for check in self.checks if not check.passed and check.severity == "warn"]
+        return {
+            "doctor": "deployment_doctor_r1",
+            "created_at": utc_now(),
+            "host_id": self.host_id,
+            "repo_root": str(self.repo_root),
+            "env_file": str(self.env_file),
+            "registry_path": str(self.registry_path),
+            "host_record_present": self.host_record is not None,
+            "passed": not halt_conditions,
+            "halt_conditions": halt_conditions,
+            "warning_conditions": warning_conditions,
+            "checks": [asdict(check) for check in self.checks],
+            "recommendation": "ready_for_next_drydock" if not halt_conditions else "remain_in_drydock",
+        }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a non-mutating Lumina deployment preflight check.")
+    parser.add_argument("--repo-root", default=str(DEFAULT_REPO_ROOT))
+    parser.add_argument("--env-file", default=str(DEFAULT_ENV_FILE))
+    parser.add_argument("--registry", default=str(DEFAULT_REGISTRY_PATH))
+    parser.add_argument("--host-id", default=DEFAULT_HOST_ID)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    doctor = DeploymentDoctor(
+        repo_root=Path(args.repo_root),
+        env_file=Path(args.env_file),
+        registry_path=Path(args.registry),
+        host_id=args.host_id,
+    )
+    print(json.dumps(doctor.run(), indent=2))

--- a/deploy/ubuntu_server_lts/host_registry.example.json
+++ b/deploy/ubuntu_server_lts/host_registry.example.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.1",
+  "description": "Example host-of-record registry for the Lumina Ubuntu Server appliance scaffold. Example only; copy and edit for a real host.",
+  "hosts": [
+    {
+      "host_id": "host-local-dev-001",
+      "host_label": "Local Lumina development host",
+      "host_type": "local",
+      "runtime_scope": "development",
+      "approved_by_user_id": "spencer",
+      "operator_user_ids": [
+        "spencer"
+      ],
+      "allowed_runtime_paths": [
+        "/opt/lumina/EthereonLabs/LuminaOS/bootstrap/Ship_of_Ethereon_V2"
+      ],
+      "allowed_action_types": [
+        "audit",
+        "transition"
+      ],
+      "state_root": "/var/lib/lumina",
+      "log_root": "/var/log/lumina",
+      "service_user": "lumina",
+      "created_at": "2026-05-20T00:00:00Z",
+      "review_after": null,
+      "revoked_at": null,
+      "notes": "Example only. A real host should be reviewed and recorded before hosted runtime operation."
+    }
+  ]
+}

--- a/docs/DEPLOYMENT_DOCTOR_NOTE.md
+++ b/docs/DEPLOYMENT_DOCTOR_NOTE.md
@@ -1,0 +1,31 @@
+# Deployment Doctor Note
+
+**Status:** companion note for deployment drydock
+
+This repository now includes a first non-mutating deployment preflight scaffold:
+
+```bash
+python deploy/ubuntu_server_lts/deployment_doctor_r1.py \
+  --repo-root /opt/lumina/EthereonLabs \
+  --env-file /etc/lumina/lumina-appliance.env \
+  --registry deploy/ubuntu_server_lts/host_registry.example.json \
+  --host-id host-local-dev-001
+```
+
+The current doctor checks:
+
+- host registry presence
+- host record presence
+- required host fields
+- revocation field
+- repo path presence
+- allowed runtime path presence
+- state root presence
+- log root presence
+- env file presence
+- known placeholder terms in the env file
+- service file presence
+
+The current doctor is inspection-only. It does not start services, edit files, approve hosts, or change runtime state.
+
+Future hardening should add checks for database table presence, service active state, baseline runtime receipt emission, checkpoint path validity, and governance log path validity.

--- a/docs/DEPLOYMENT_DRYDOCK_CHECKLIST.md
+++ b/docs/DEPLOYMENT_DRYDOCK_CHECKLIST.md
@@ -1,0 +1,83 @@
+# Deployment DryDock Checklist
+
+**Status:** proposed checklist  
+**Authority:** deployment validation guidance only  
+**Scope:** Ubuntu Server appliance scaffold and future hosted Lumina runtime work
+
+## Purpose
+
+This checklist defines the first deployment drydock pass for the Lumina Ubuntu Server appliance lane.
+
+The goal is simple: before the appliance is treated as ordinary hosted operation, verify that the host boundary, runtime path, service account, database shape, logs, and receipts are all inspectable.
+
+## Preflight checks
+
+| Check | Expected result |
+|---|---|
+| host record exists | host id, label, scope, operator ids, service user, state root, and log root are present |
+| host record active | `revoked_at` is null and review date has not expired |
+| service user matches | systemd units use the expected service user |
+| env file exists | `/etc/lumina/lumina-appliance.env` exists and is readable by the service context |
+| placeholder credentials removed | default placeholder database credentials are not still active |
+| state root exists | state root exists and is owned by the service user |
+| log root exists | log root exists and is writable by the service user |
+| repo path exists | expected repo checkout exists |
+| runtime path exists | expected Lumina runtime path exists |
+| Chamber SQL initialized | core Chamber tables, session extension, and advisory queue extension exist |
+| Chamber advisory service defined | systemd unit exists and points at the expected server path |
+| orchestrator timer defined | timer exists and runs bounded cycles |
+| baseline runtime receipt possible | one observation/audit cycle can emit a receipt |
+| governance log path recorded | receipt points to governance log path |
+| checkpoint path recorded | receipt points to checkpoint path |
+
+## Halt conditions
+
+Treat the deployment as not ready if any of the following are true:
+
+- host record is missing
+- host record is revoked
+- env file still contains placeholder credentials
+- service user differs from the host record without explanation
+- repo path differs from the host record without explanation
+- database initialization is incomplete
+- runtime cycle cannot produce a receipt
+- receipt does not identify host id or runtime path
+
+## Recommended first drydock command
+
+Future implementation should provide a command such as:
+
+```bash
+lumina deployment doctor
+```
+
+or:
+
+```bash
+python deploy/ubuntu_server_lts/deployment_doctor_r1.py
+```
+
+That command should emit a JSON report with:
+
+```text
+host_id
+check_results
+halt_conditions
+receipt_paths
+recommendation
+created_at
+```
+
+## Relationship to Chamber bridge
+
+Deployment drydock comes before the Chamber to runtime bridge becomes active.
+
+The Chamber bridge answers: can an accepted advisory become governed runtime work?
+
+Deployment drydock answers: is this host allowed and prepared to run the governed work at all?
+
+Both must hold before public-facing supervised action is treated as real.
+
+## Boundary
+
+This checklist is not an implementation. It defines the inspection shape future implementation should satisfy.

--- a/docs/DEPLOYMENT_HOST_REGISTRY_MODEL.md
+++ b/docs/DEPLOYMENT_HOST_REGISTRY_MODEL.md
@@ -1,0 +1,103 @@
+# Deployment Host Registry Model
+
+**Status:** proposed structural model  
+**Authority:** deployment documentation and future implementation guide only  
+**Scope:** hosted Lumina appliance work, Ubuntu Server scaffold, shared runtime experiments, and any future non-local runtime surface
+
+## Purpose
+
+The Ubuntu Server appliance scaffold makes deployment real enough to need a keel.
+
+Local execution has an implicit host boundary: a known checkout, a known operator, and a known machine. A hosted or shared Lumina appliance cannot rely on that implicit boundary.
+
+This document defines the first host-of-record model.
+
+## Core distinction
+
+| Rail | Question |
+|---|---|
+| Chamber consent | May this advisory become a queued action? |
+| Runtime governance | May this requested action pass mode, mutation, promotion, and capability rules? |
+| Deployment host record | Is this environment approved to operate this Lumina runtime scope? |
+
+These rails must remain separate.
+
+## Host-of-record fields
+
+A future registry can be implemented as JSON, SQL, or a governed runtime state file. Minimum fields:
+
+```text
+host_id
+host_label
+host_type
+runtime_scope
+approved_by_user_id
+operator_user_ids
+allowed_runtime_paths
+allowed_action_types
+state_root
+log_root
+service_user
+created_at
+review_after
+revoked_at
+notes
+```
+
+## Field meanings
+
+| Field | Meaning |
+|---|---|
+| `host_id` | Stable id for the environment. |
+| `host_label` | Human-readable name. |
+| `host_type` | `local`, `vm`, `mini_pc`, `server`, `cloud_instance`, or other documented value. |
+| `runtime_scope` | `development`, `drydock`, `public_chamber`, or `release_candidate`. |
+| `approved_by_user_id` | User id or local operator id that approved this host record. |
+| `operator_user_ids` | Users/operators allowed to administer this host context. |
+| `allowed_runtime_paths` | Runtime paths allowed to operate from this host. |
+| `allowed_action_types` | `audit`, `transition`, `mutation`, and/or `promotion`. |
+| `state_root` | Expected state directory, such as `/var/lib/lumina`. |
+| `log_root` | Expected log directory, such as `/var/log/lumina`. |
+| `service_user` | Expected service account, such as `lumina`. |
+| `created_at` | Creation timestamp. |
+| `review_after` | Review timestamp or null. |
+| `revoked_at` | Revocation timestamp or null. |
+| `notes` | Human-readable notes. |
+
+## Example record
+
+```json
+{
+  "host_id": "host-local-spencer-001",
+  "host_label": "Local Spencer development host",
+  "host_type": "local",
+  "runtime_scope": "development",
+  "approved_by_user_id": "spencer",
+  "operator_user_ids": ["spencer"],
+  "allowed_runtime_paths": ["/opt/lumina/EthereonLabs/LuminaOS/bootstrap/Ship_of_Ethereon_V2"],
+  "allowed_action_types": ["audit", "transition"],
+  "state_root": "/var/lib/lumina",
+  "log_root": "/var/log/lumina",
+  "service_user": "lumina",
+  "created_at": "2026-05-20T00:00:00Z",
+  "review_after": null,
+  "revoked_at": null,
+  "notes": "Initial local development host model."
+}
+```
+
+## Required invariants
+
+1. A host record must not grant Chamber consent.
+2. Chamber consent must not create a host record.
+3. Runtime governance must not create or modify host approval.
+4. A revoked host must not be used for new runtime work.
+5. A receipt from a deployed cycle should identify the host id and runtime path.
+6. Promotion work should require an explicit host scope that allows promotion.
+7. Development hosts should not silently behave as release-facing hosts.
+
+## Boundary
+
+This document is not yet executable law.
+
+It is the keel shape for a future deployment registry and preflight check.

--- a/docs/DEPLOYMENT_RUNTIME_RECEIPT_CONTRACT.md
+++ b/docs/DEPLOYMENT_RUNTIME_RECEIPT_CONTRACT.md
@@ -1,0 +1,88 @@
+# Deployment Runtime Receipt Contract
+
+**Status:** proposed receipt contract  
+**Authority:** documentation and future validation guide only  
+**Scope:** runtime receipts produced from hosted or shared Lumina environments
+
+## Purpose
+
+A deployed Lumina appliance must be able to say not only what happened, but where it happened.
+
+Runtime receipts already support accountability. Deployment adds one more requirement: each hosted cycle should identify the host/environment context that produced the receipt.
+
+## Minimum deployed receipt fields
+
+```text
+receipt_id
+host_id
+host_label
+runtime_scope
+runtime_path
+state_root
+log_root
+service_user
+requested_action
+action_type
+current_mode
+target_mode
+governance_result
+checkpoint_path
+governance_log_path
+created_at
+notes
+```
+
+## Recommended receipt shape
+
+```json
+{
+  "receipt_id": "deploy-receipt-example",
+  "host": {
+    "host_id": "host-local-spencer-001",
+    "host_label": "Local Spencer development host",
+    "runtime_scope": "development",
+    "runtime_path": "/opt/lumina/EthereonLabs/LuminaOS/bootstrap/Ship_of_Ethereon_V2",
+    "state_root": "/var/lib/lumina",
+    "log_root": "/var/log/lumina",
+    "service_user": "lumina"
+  },
+  "runtime": {
+    "requested_action": "observe",
+    "action_type": "audit",
+    "current_mode": "Continuity",
+    "target_mode": "Observation",
+    "governance_result": "allowed",
+    "checkpoint_path": "/var/lib/lumina/.../checkpoint.json",
+    "governance_log_path": "/var/lib/lumina/.../governance_log.jsonl"
+  },
+  "created_at": "2026-05-20T00:00:00Z",
+  "notes": "Example only."
+}
+```
+
+## Receipt rules
+
+1. Receipts record what happened; they do not create approval.
+2. Host ids in receipts should resolve to a host-of-record entry.
+3. Missing host id should be treated as a drydock warning for hosted environments.
+4. Mismatched runtime path should be treated as a halt condition once executable enforcement exists.
+5. Receipts should preserve governance result without rewriting Chamber advisory decisions.
+6. Receipt creation should be append-oriented, not destructive.
+
+## Relationship to existing runtime receipts
+
+This contract extends runtime receipt expectations for deployment contexts.
+
+It does not replace:
+
+- governance logs
+- checkpoint records
+- canon lineage
+- Chamber advisory records
+- Chamber action queue records
+
+## Boundary
+
+This is a receipt contract, not a runtime implementation.
+
+Future work should add a deployment preflight or deployment doctor that verifies these fields can be produced before hosted runtime work is treated as ordinary.

--- a/docs/FLEET_STEWARDSHIP_PACKET_2026_05_20.md
+++ b/docs/FLEET_STEWARDSHIP_PACKET_2026_05_20.md
@@ -8,7 +8,7 @@
 
 This packet records the stewardship moves that follow from the latest architectural review of the EthereonLabs main branch.
 
-The review read the system as having crossed from design into operational reality: runtime governance, advisory reflection, Chamber consent shape, public surface, CI verification, and deployment signals are now all visible enough that the dominant risk has shifted from structural survival to hygiene, compression, consent portability, and naming discipline.
+The review read the system as having crossed from design into operational reality: runtime governance, advisory reflection, Chamber consent shape, public surface, CI verification, and deployment signals are now all visible enough that the dominant risk has shifted from structural survival to hygiene, compression, deployment authority, and naming discipline.
 
 This packet does not promote anything to runtime law by itself. It points to guardrails and review documents that should be consulted before the next load-bearing bridge work.
 
@@ -20,7 +20,7 @@ The current shape is best understood as:
 Lumina OS substrate = keel
 Reflective autonomy / self-guidance = sail
 Chamber advisory queue = consent membrane
-Deployment lane = emerging host boundary
+Deployment lane = emerging host/environment boundary
 ```
 
 The keel held. That changes the work.
@@ -31,19 +31,22 @@ Projects still fighting for structural coherence do not get to worry about direc
 
 | Document | Purpose |
 |---|---|
-| `docs/DEPLOYMENT_CONSENT_MODEL.md` | Defines the host-of-record and deployment-side consent story before non-local runtime execution becomes operational. |
+| `docs/DEPLOYMENT_BOUNDARY_NOTE.md` | Captures the immediate hosted-environment boundary questions. |
+| `docs/DEPLOYMENT_HOST_REGISTRY_MODEL.md` | Defines the first host-of-record model for non-local Lumina operation. |
+| `docs/DEPLOYMENT_RUNTIME_RECEIPT_CONTRACT.md` | Defines what deployed runtime receipts must identify. |
+| `docs/DEPLOYMENT_DRYDOCK_CHECKLIST.md` | Defines appliance preflight and deployment drydock checks. |
 | `docs/CHAMBER_RUNTIME_BRIDGE_DRYDOCK_PLAN.md` | Defines the drydock checks for wiring Chamber advisories into governed runtime actions. |
 | `docs/RUNNER_BRIDGE_OWNERSHIP_MAP.md` | Maps runner/bridge files before consolidation so compression does not erase useful distinctions. |
-| `docs/CHAMBER_ADVISORY_VOCABULARY.md` | Establishes expected advisory/action queue vocabulary and expiry behavior before meaningful Chamber traffic. |
-| `docs/PUBLIC_SURFACE_REGISTRY.md` | Gives the expanding public HTML surface the same lane discipline as the README authority map. |
-| `docs/RUNTIME_RECEIPTS_NAMING_NOTE.md` | Reframes runtime evidence artifacts away from over-weighted truth language unless formally governed. |
+| `docs/CHAMBER_ADVISORY_VOCABULARY.md` | Establishes expected advisory/action queue vocabulary before meaningful Chamber traffic. |
+| `docs/PUBLIC_SURFACE_REGISTRY.md` | Gives the expanding public HTML surface a registry pattern aligned to the README authority map. |
+| `docs/RUNTIME_ARTIFACT_NAMING_NOTE.md` | Reframes runtime evidence artifacts as receipts or observations unless formally governed elsewhere. |
 
 ## Accepted review conclusions
 
 - The advisory layer is currently orienting, not governing.
 - Consent has become structural at the public-facing boundary.
 - The Chamber to runtime bridge is the next major threshold.
-- Deployment introduces a host boundary that local execution previously hid.
+- Deployment introduces a host/environment boundary that local execution previously hid.
 - Bridge accumulation and public surface accretion are now active drift surfaces.
 - Naming drift matters because language often moves before architecture does.
 
@@ -51,12 +54,12 @@ Projects still fighting for structural coherence do not get to worry about direc
 
 Recommended sequence:
 
-1. Define deployment consent before non-local runtime execution is treated as ordinary.
+1. Define the deployment keel before non-local runtime execution is treated as ordinary.
 2. Build the Chamber to runtime bridge only under explicit drydock checks.
 3. Map bridge ownership before compressing runner files.
 4. Establish advisory vocabulary and expiry policy before public Chamber traffic.
 5. Register public-facing pages by lane and status.
-6. Rename or contextualize runtime truth artifacts as receipts unless they are formally governed records.
+6. Rename or contextualize runtime artifacts as receipts unless they are formally governed records.
 
 ## Boundary reminder
 

--- a/docs/FLEET_STEWARDSHIP_PACKET_AMENDMENT_2026_05_20.md
+++ b/docs/FLEET_STEWARDSHIP_PACKET_AMENDMENT_2026_05_20.md
@@ -18,6 +18,7 @@ It now also records the deployment-keel repair that followed Prisma's response: 
 - `docs/DEPLOYMENT_HOST_REGISTRY_MODEL.md`
 - `docs/DEPLOYMENT_RUNTIME_RECEIPT_CONTRACT.md`
 - `docs/DEPLOYMENT_DRYDOCK_CHECKLIST.md`
+- `docs/DEPLOYMENT_DOCTOR_NOTE.md`
 - `deploy/ubuntu_server_lts/host_registry.example.json`
 - `deploy/ubuntu_server_lts/deployment_doctor_r1.py`
 
@@ -25,4 +26,4 @@ It now also records the deployment-keel repair that followed Prisma's response: 
 
 The original boundary note remains a useful breadcrumb.
 
-The deployment-keel repair turns that breadcrumb into a first structural model: host-of-record, deployed receipt expectations, appliance drydock checklist, example registry, and non-mutating deployment doctor.
+The deployment-keel repair turns that breadcrumb into a first structural model: host-of-record, deployed receipt expectations, appliance drydock checklist, example registry, companion doctor note, and non-mutating deployment doctor.

--- a/docs/FLEET_STEWARDSHIP_PACKET_AMENDMENT_2026_05_20.md
+++ b/docs/FLEET_STEWARDSHIP_PACKET_AMENDMENT_2026_05_20.md
@@ -1,8 +1,10 @@
 # Fleet Stewardship Packet Amendment — 2026-05-20
 
-This amendment clarifies the final landed file names for the fleet stewardship packet.
+This amendment originally clarified the softened filenames that landed with the first fleet stewardship packet.
 
-## Landed files
+It now also records the deployment-keel repair that followed Prisma's response: the bridge plan was correct, but the deployment rail needed a stronger keel.
+
+## Original landed files from PR #305
 
 - `docs/DEPLOYMENT_BOUNDARY_NOTE.md`
 - `docs/CHAMBER_RUNTIME_BRIDGE_DRYDOCK_PLAN.md`
@@ -11,4 +13,16 @@ This amendment clarifies the final landed file names for the fleet stewardship p
 - `docs/PUBLIC_SURFACE_REGISTRY.md`
 - `docs/RUNTIME_ARTIFACT_NAMING_NOTE.md`
 
-The packet index originally named two fuller documents that were softened during connector handling. This amendment is the accurate file list for the PR.
+## Deployment-keel repair files
+
+- `docs/DEPLOYMENT_HOST_REGISTRY_MODEL.md`
+- `docs/DEPLOYMENT_RUNTIME_RECEIPT_CONTRACT.md`
+- `docs/DEPLOYMENT_DRYDOCK_CHECKLIST.md`
+- `deploy/ubuntu_server_lts/host_registry.example.json`
+- `deploy/ubuntu_server_lts/deployment_doctor_r1.py`
+
+## Interpretation
+
+The original boundary note remains a useful breadcrumb.
+
+The deployment-keel repair turns that breadcrumb into a first structural model: host-of-record, deployed receipt expectations, appliance drydock checklist, example registry, and non-mutating deployment doctor.


### PR DESCRIPTION
## Summary

Repairs the drydock findings after PR #305 and Prisma's response:

> the keel held, the bridge plan is correct, the deployment rail still needs its keel.

This PR adds the deployment keel without wiring Chamber to runtime yet.

## Repairs

- Fixes stale file references in `docs/FLEET_STEWARDSHIP_PACKET_2026_05_20.md`
- Updates the fleet amendment to include the new deployment-keel repair set
- Adds `docs/DEPLOYMENT_HOST_REGISTRY_MODEL.md`
- Adds `docs/DEPLOYMENT_RUNTIME_RECEIPT_CONTRACT.md`
- Adds `docs/DEPLOYMENT_DRYDOCK_CHECKLIST.md`
- Adds `docs/DEPLOYMENT_DOCTOR_NOTE.md`
- Adds `deploy/ubuntu_server_lts/host_registry.example.json`
- Adds `deploy/ubuntu_server_lts/deployment_doctor_r1.py`
- Updates `deploy/ubuntu_server_lts/README.md` to link the host registry, doctor, and deployment guardrails
- Updates `CURRENT_OPERATING_MAP.md` so deployment is visible as its own lane

## Authority boundary

This is still drydock/stewardship work.

- No Chamber to runtime bridge activation
- No schema migration
- No runtime governance change
- No canon lineage change
- No public UI change

The new deployment doctor is non-mutating. It inspects host registry, env placeholder risk, path presence, and service-file presence, then emits JSON.

## Validation

Manual drydock inspection of the changed files. No runtime CI expected because this branch primarily changes docs and deploy scaffold files outside the current runtime sea-trial trigger paths.

## Next after merge

A future PR can harden the deployment doctor to inspect PostgreSQL table presence, systemd active state, baseline runtime receipt emission, checkpoint path validity, and governance log path validity.