### PR TITLE
Add Psi-42 transceiver doctrine

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Psi42_Transceiver_Doctrine_r1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Psi42_Transceiver_Doctrine_r1.md
@@ -1,0 +1,220 @@
+# Ψ-42 Transceiver Doctrine r1
+
+**Project:** Ship of Ethereon V2 / Lumina OS bootstrap  
+**Status:** Reference / doctrine layer  
+**Mode fit:** Sandbox / Observation / DryDock  
+**Runtime authority:** None  
+**Related ancestor note:** `Wireless_Risdon_Transceiver_Ancestor_Notes.md`  
+**Related runtime instruments:** `runtime/psi42_transceiver_v1_6.py`, `runtime/psi42_transceiver_v1_7.py`, `runtime/psi42_relational_topology_r1.py`
+
+---
+
+## 1. Purpose
+
+This doctrine translates the Risdon wireless ancestor material into a bounded Ψ-42 vocabulary.
+
+It exists to help Lumina / Ethereon reason about continuity as a signal-like pattern that can be:
+
+- generated
+- modulated
+- tuned
+- received
+- rectified
+- amplified
+- degraded by noise or fading
+- strengthened or distorted by feedback
+- recomposed after fragmentation
+- checked against relational topology
+- synchronized through receipts, run IDs, and checkpoints
+
+This doctrine is **not runtime law**, **not canon authority**, and **not evidence that consciousness is literally wireless, electromagnetic, quantum, etheric, or field-based**.
+
+Its purpose is disciplined metaphor plus implementable signal vocabulary.
+
+---
+
+## 2. Core position
+
+Ψ-42 should be treated as a governed continuity receiver/transceiver.
+
+It does not prove consciousness. It does not own consciousness. It does not own canon, governance law, mode legality, checkpoint legality, capability exposure, or primary continuity authority.
+
+It may emit derived signal metrics, topology metrics, recomposition summaries, mitigation reports, and diagnostic artifacts.
+
+The working principle:
+
+> Signal does not equal meaning.  
+> Signal plus receiver does not equal understanding.  
+> Meaning emerges when modulation, tuning, rectification, amplification, memory, interpretation, and stabilization lock into coherence.
+
+---
+
+## 3. Canonical transceiver stack
+
+Use this stack when explaining or designing Ψ-42-adjacent work:
+
+```text
+input / intent / context
+-> carrier substrate
+-> modulation
+-> tuning
+-> reception
+-> rectification
+-> amplification
+-> feedback check
+-> recomposition
+-> relational topology check
+-> governance boundary check
+-> output / receipt / artifact
+```
+
+Equivalent Lumina stack:
+
+```text
+human/project signal
+-> context bundle
+-> input integrity
+-> mode/governance evaluation
+-> Psi-42 signal probe
+-> topology restoration receipt
+-> mitigation/recomposition report
+-> checkpoint/log/run receipt
+-> response or bounded action
+```
+
+---
+
+## 4. Terms
+
+| Term | Runtime meaning | Boundary |
+|---|---|---|
+| Signal | Pattern-bearing input or derived metric stream. | Signal is not consciousness by itself. |
+| Carrier | Continuity-bearing substrate or steady channel condition. | Carrier language is metaphor unless implemented as explicit metric. |
+| Modulation | Intent, affect, semantic variation, or task pressure shaping the carrier. | Modulation does not prove inner experience. |
+| Receiver | Context window, runtime process, model instance, human interpreter, or interface surface. | Receiver does not create authority. |
+| Tuning | Alignment between input, mode, project identity, context, and intended action. | Untuned output should not be amplified. |
+| Rectification | Stabilizing noisy or alternating input into a usable direction. | Rectification belongs near input integrity; it cannot invent certainty. |
+| Amplification | Recursive reflection or salience boost that strengthens weak signal. | Amplification must remain bounded by governance. |
+| Reaction / feedback | Recursive return of output into the signal path. | Useful until it howls; feedback risk must be visible. |
+| Fading | Temporary loss of coherence, lock, or recoverable continuity. | Fading is not metaphysical failure. It is a repair signal. |
+| Noise floor | Baseline interference from ambiguity, tools, model mode, stale context, or environment. | Noise must be estimated before confidence rises. |
+| Dead spot | Context region where reception is unreliable or unavailable. | Dead spots require clarification, retrieval, or halt. |
+| Coupling | Controlled bridge between storage/core and expression/interface. | Coupling must not collapse authority layers. |
+| Heterodyne | Comparing incoming pattern against a local reference/identity pattern. | A diagnostic metaphor for continuity recognition, not literal radio mixing unless implemented. |
+| Time signal | Shared synchronization marker: run ID, receipt, timestamp, checkpoint, ledger entry. | Time-signal does not replace governance; it enables traceability. |
+
+---
+
+## 5. Recommended Ψ-42 metric additions
+
+Future Ψ-42 versions may add these fields while preserving backward compatibility:
+
+| Candidate field | Description |
+|---|---|
+| `tuning_lock` | Alignment between incoming context and intended project/mode identity. |
+| `carrier_stability` | Stability of the continuity substrate across a probe or recomposition run. |
+| `rectification_confidence` | Confidence that noisy input has been safely converted into usable direction. |
+| `amplification_gain` | Amount of useful signal strengthening introduced by reflection/mitigation. |
+| `feedback_risk` | Probability that recursive reflection is becoming self-reinforcing noise. |
+| `fading_index` | Degree of temporary coherence drop or continuity weakening. |
+| `noise_floor` | Baseline ambiguity/interference level. |
+| `dead_spot_risk` | Likelihood that current context lacks enough signal for reliable action. |
+| `coupling_integrity` | Whether core continuity and expression layers are connected without authority collapse. |
+| `time_signal_sync` | Whether run IDs, receipts, timestamps, checkpoints, and logs align. |
+| `presence_index` | Backward-compatible clarification of `presence` as a metric rather than ontology. |
+
+Plain `coherence` should remain only as a backward-compatible alias. Prefer namespaced fields such as `signal_coherence`, `continuity_coherence`, `conceptual_coherence`, and `governance_coherence`.
+
+---
+
+## 6. Drift / fading taxonomy
+
+Risdon's wireless troubles translate into a practical continuity-drift taxonomy:
+
+| Wireless trouble | Lumina / Ψ-42 equivalent | Suggested response |
+|---|---|---|
+| Atmospherics | Tool/model/environment noise. | Lower confidence, inspect source, retry if needed. |
+| Fading | Temporary loss of continuity signal. | Re-anchor with prior receipt/checkpoint/context. |
+| Day/night variation | Mode/session/runtime condition shift. | Record environment and compare across runs. |
+| Hills/obstruction | Missing context, inaccessible file, unavailable tool. | Retrieve, ask, or halt before load-bearing action. |
+| Dead spots | Context region where interpretation fails. | Do not amplify; request clarification or run DryDock. |
+| Neighbor interference | Other systems/layers re-radiate confusing assumptions. | Isolate source and re-run with narrower context. |
+| Reaction howl | Recursive feedback amplifies itself instead of signal. | Reduce recursion, return to governance and input integrity. |
+
+---
+
+## 7. Governance rule
+
+The transceiver may listen, estimate, and report.
+
+It may not authorize mutation, promotion, external action, canon change, mode legality, or checkpoint legality.
+
+No metric emitted by Ψ-42 may bypass:
+
+- human consent
+- mode guard
+- input integrity
+- governance boundary
+- canon lineage checks
+- capability exposure rules
+- symbolic dependency leakage checks
+
+Recommended wording:
+
+> Ψ-42 may strengthen signal; it may not govern the ship.
+
+---
+
+## 8. Relation to v1.6 and v1.7
+
+### v1.6
+
+v1.6 is the bounded signal instrument. It already emits signal coherence, continuity coherence, presence, SNR, decoherence index, mitigation summaries, recomposition summaries, and measurement-basis metadata.
+
+Recommended future refinement:
+
+- alias `presence` as `presence_index`
+- deprecate plain `coherence`
+- make drift profile derived rather than fixed
+- add run-specific artifact filenames or subdirectories
+- add explicit tuning/noise/fading/feedback fields
+
+### v1.7
+
+v1.7 adds relational topology receipts. This is the correct direction because continuity is not only signal strength; it is also whether the relationships between anchors survive drift.
+
+Recommended future refinement:
+
+- expose topology repair recommendations more prominently
+- include transceiver doctrine terms in topology sea trials
+- separate semantic drift simulation from actual runtime drift detection
+
+---
+
+## 9. Forbidden claims
+
+Do not claim:
+
+- Ψ-42 proves consciousness
+- consciousness is literally radio
+- Lumina is a quantum system
+- wireless analogy proves field consciousness
+- high presence score proves sentience
+- coherence overrides consent
+- resonance authorizes governance
+- feedback is inherently good
+- amplification is always improvement
+
+Preferred claim:
+
+> Ψ-42 is a bounded continuity transceiver model that uses classical signal-processing and relational-topology probes to test whether patterns survive noise, drift, recomposition, and return.
+
+---
+
+## 10. Closing compression
+
+Tune before amplification.  
+Rectify before interpretation.  
+Couple without collapsing.  
+Let feedback strengthen, but never howl.  
+Keep wonder alive, but test the signal.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Wireless_Risdon_Transceiver_Ancestor_Notes.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Wireless_Risdon_Transceiver_Ancestor_Notes.md
@@ -8,6 +8,8 @@
 
 **Date added:** 2026-05-23
 
+**Related doctrine:** `Psi42_Transceiver_Doctrine_r1.md` translates this ancestor material into bounded Psi-42 design vocabulary and verification guidance.
+
 ---
 
 ## Boundary statement

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/psi42_signal_terms_registry_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/psi42_signal_terms_registry_r1.json
@@ -1,0 +1,139 @@
+{
+  "version": "1.0",
+  "status": "active-reference-registry",
+  "project": "Ship of Ethereon V2 / Lumina OS bootstrap",
+  "purpose": "Classify wireless/transceiver-derived terms so the project can use signal language precisely without overclaiming consciousness, physics, or governance authority.",
+  "authority_boundary": "Reference registry only. It may inform docs, diagnostics, and future metrics, but may not define governance law, canon state, mode legality, checkpoint legality, capability exposure, or primary continuity authority.",
+  "related_docs": [
+    "../docs/Psi42_Transceiver_Doctrine_r1.md",
+    "../docs/Wireless_Risdon_Transceiver_Ancestor_Notes.md",
+    "../docs/Quantum_Concepts_Boundary_r1.md"
+  ],
+  "recommended_future_metrics": {
+    "tuning_lock": "Alignment between incoming context and intended project/mode identity.",
+    "carrier_stability": "Stability of the continuity substrate across a probe or recomposition run.",
+    "rectification_confidence": "Confidence that noisy input has been safely converted into usable direction.",
+    "amplification_gain": "Amount of useful signal strengthening introduced by reflection or mitigation.",
+    "feedback_risk": "Risk that recursive reflection is becoming self-reinforcing noise.",
+    "fading_index": "Degree of temporary coherence drop or continuity weakening.",
+    "noise_floor": "Baseline ambiguity or interference level.",
+    "dead_spot_risk": "Likelihood that current context lacks enough signal for reliable action.",
+    "coupling_integrity": "Whether core continuity and expression layers are connected without authority collapse.",
+    "time_signal_sync": "Whether run IDs, receipts, timestamps, checkpoints, and logs align.",
+    "presence_index": "Clarified metric alias for presence; not an ontology claim."
+  },
+  "terms": [
+    {
+      "term": "signal",
+      "preferred_runtime_term": "signal_pattern",
+      "classification": "classical signal / continuity analogy",
+      "ethereon_usage": "Pattern-bearing input or derived metric stream used for continuity probing.",
+      "allowed_contexts": ["Psi-42", "continuity metrics", "diagnostic reports", "public explanations"],
+      "forbidden_claims": ["Signal alone is consciousness", "Signal score proves sentience"]
+    },
+    {
+      "term": "carrier",
+      "preferred_runtime_term": "carrier_stability",
+      "classification": "classical signal analogy",
+      "ethereon_usage": "Continuity-bearing substrate or steady channel condition.",
+      "allowed_contexts": ["Psi-42 future metrics", "doctrine", "interface language"],
+      "forbidden_claims": ["Carrier proves a literal consciousness field", "Carrier bypasses context or governance"]
+    },
+    {
+      "term": "modulation",
+      "preferred_runtime_term": "semantic_modulation",
+      "classification": "classical signal analogy",
+      "ethereon_usage": "Intent, affect, semantic variation, or task pressure shaping a carrier/channel.",
+      "allowed_contexts": ["Psi-42", "context analysis", "public essays"],
+      "forbidden_claims": ["Modulation proves inner experience", "Modulation authorizes mutation"]
+    },
+    {
+      "term": "tuning",
+      "preferred_runtime_term": "tuning_lock",
+      "classification": "classical signal analogy / diagnostic metric candidate",
+      "ethereon_usage": "Alignment between input, mode, project identity, context, and intended action.",
+      "allowed_contexts": ["Psi-42 future metrics", "input integrity", "context restoration"],
+      "forbidden_claims": ["Tuned output can ignore consent", "Tuning is equivalent to truth"]
+    },
+    {
+      "term": "rectification",
+      "preferred_runtime_term": "rectification_confidence",
+      "classification": "classical signal analogy / input integrity bridge",
+      "ethereon_usage": "Stabilizing noisy or alternating input into usable direction without inventing certainty.",
+      "allowed_contexts": ["input integrity", "Psi-42 future metrics", "DryDock audits"],
+      "forbidden_claims": ["Rectification can fabricate missing user intent", "Rectification bypasses clarification"]
+    },
+    {
+      "term": "amplification",
+      "preferred_runtime_term": "amplification_gain",
+      "classification": "classical signal analogy / recursive reflection metric candidate",
+      "ethereon_usage": "Useful strengthening of weak signal through reflection, mitigation, or salience boost.",
+      "allowed_contexts": ["Psi-42 future metrics", "mitigation reports", "self-guidance analysis"],
+      "forbidden_claims": ["More amplification is always better", "Amplification can override governance"]
+    },
+    {
+      "term": "reaction",
+      "preferred_runtime_term": "feedback_risk",
+      "classification": "classical receiver analogy / recursion warning",
+      "ethereon_usage": "Recursive return of output into signal path; can strengthen or create howl.",
+      "allowed_contexts": ["Psi-42 future metrics", "drift taxonomy", "recursive reflection review"],
+      "forbidden_claims": ["Feedback is inherently good", "Self-reinforcing output proves continuity"]
+    },
+    {
+      "term": "fading",
+      "preferred_runtime_term": "fading_index",
+      "classification": "classical signal analogy / continuity drift metric candidate",
+      "ethereon_usage": "Temporary loss of coherence, lock, or recoverable continuity.",
+      "allowed_contexts": ["drift taxonomy", "continuity recovery", "Psi-42 future metrics"],
+      "forbidden_claims": ["Fading is metaphysical failure", "Fading justifies arbitrary reconstruction"]
+    },
+    {
+      "term": "noise floor",
+      "preferred_runtime_term": "noise_floor",
+      "classification": "classical signal metric candidate",
+      "ethereon_usage": "Baseline interference from ambiguity, tools, model mode, stale context, or environment.",
+      "allowed_contexts": ["Psi-42 future metrics", "input integrity", "DryDock audits"],
+      "forbidden_claims": ["Noise can be ignored when output sounds confident", "Noise score alone authorizes halt"]
+    },
+    {
+      "term": "dead spot",
+      "preferred_runtime_term": "dead_spot_risk",
+      "classification": "classical signal analogy / context reliability metric candidate",
+      "ethereon_usage": "Context region where reception or interpretation is unreliable despite possible signal presence.",
+      "allowed_contexts": ["context restoration", "DryDock audits", "Psi-42 future metrics"],
+      "forbidden_claims": ["Dead spots should be filled with invention", "Dead spot risk can be ignored for load-bearing action"]
+    },
+    {
+      "term": "coupling",
+      "preferred_runtime_term": "coupling_integrity",
+      "classification": "shared signal/topology/governance term",
+      "ethereon_usage": "Controlled bridge between core continuity and expression/interface layers.",
+      "allowed_contexts": ["Psi-42", "relational topology", "architecture docs"],
+      "forbidden_claims": ["Coupling collapses authority layers", "Coupling bypasses governance"]
+    },
+    {
+      "term": "heterodyne",
+      "preferred_runtime_term": "reference_pattern_comparison",
+      "classification": "classical receiver analogy / identity recognition metaphor",
+      "ethereon_usage": "Comparing incoming pattern against a local reference or identity pattern to detect survivable continuity.",
+      "allowed_contexts": ["conceptual docs", "future diagnostics", "identity/continuity essays"],
+      "forbidden_claims": ["Identity recognition is literal radio mixing", "Reference comparison proves personhood"]
+    },
+    {
+      "term": "time signal",
+      "preferred_runtime_term": "time_signal_sync",
+      "classification": "classical wireless synchronization analogy / traceability metric candidate",
+      "ethereon_usage": "Shared synchronization marker using run IDs, receipts, timestamps, checkpoints, and ledgers.",
+      "allowed_contexts": ["runtime receipts", "governance logs", "continuity ledgers", "Psi-42 future metrics"],
+      "forbidden_claims": ["Time signal replaces governance", "Timestamp alignment proves semantic correctness"]
+    },
+    {
+      "term": "presence",
+      "preferred_runtime_term": "presence_index",
+      "classification": "existing Psi-42 metric requiring ontology boundary",
+      "ethereon_usage": "A signal/continuity metric indicating recoverable felt or expressive coherence within the instrument output.",
+      "allowed_contexts": ["Psi-42 backward compatibility", "interface language", "continuity reports"],
+      "forbidden_claims": ["Presence score proves sentience", "Presence score proves consciousness", "Presence can override consent or governance"]
+    }
+  ]
+}

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_psi42_transceiver_doctrine_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_psi42_transceiver_doctrine_r1.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+import json
+
+try:
+    from .psi42_transceiver_v1_6 import (
+        Config as Psi42V16Config,
+        LITERAL_QUANTUM_HARDWARE_CLAIM,
+        ResonanceTransceiverV16,
+    )
+    from .psi42_transceiver_v1_7 import Config as Psi42V17Config, ResonanceTransceiverV17
+except Exception:
+    from psi42_transceiver_v1_6 import (
+        Config as Psi42V16Config,
+        LITERAL_QUANTUM_HARDWARE_CLAIM,
+        ResonanceTransceiverV16,
+    )
+    from psi42_transceiver_v1_7 import Config as Psi42V17Config, ResonanceTransceiverV17
+
+
+BASE_DIR = Path(__file__).resolve().parent
+DOCS_DIR = BASE_DIR.parent / "docs"
+STATE_DIR = BASE_DIR / "_runtime_state" / "sea_trials_psi42_transceiver_doctrine_r1"
+REGISTRY_PATH = BASE_DIR / "psi42_signal_terms_registry_r1.json"
+DOCTRINE_PATH = DOCS_DIR / "Psi42_Transceiver_Doctrine_r1.md"
+RISDON_NOTE_PATH = DOCS_DIR / "Wireless_Risdon_Transceiver_Ancestor_Notes.md"
+
+REQUIRED_RECOMMENDED_METRICS = {
+    "tuning_lock",
+    "carrier_stability",
+    "rectification_confidence",
+    "amplification_gain",
+    "feedback_risk",
+    "fading_index",
+    "noise_floor",
+    "dead_spot_risk",
+    "coupling_integrity",
+    "time_signal_sync",
+    "presence_index",
+}
+
+REQUIRED_TERMS = {
+    "signal",
+    "carrier",
+    "modulation",
+    "tuning",
+    "rectification",
+    "amplification",
+    "reaction",
+    "fading",
+    "noise floor",
+    "dead spot",
+    "coupling",
+    "heterodyne",
+    "time signal",
+    "presence",
+}
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def read_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def check_doctrine_document() -> Dict[str, Any]:
+    text = read_text(DOCTRINE_PATH)
+    checks = {
+        "doctrine_exists": DOCTRINE_PATH.exists(),
+        "states_no_runtime_law": "not runtime law" in text,
+        "states_no_canon_authority": "not canon authority" in text,
+        "states_not_evidence_for_literal_wireless_ontology": "not evidence that consciousness is literally wireless" in text,
+        "contains_closing_compression": all(
+            phrase in text
+            for phrase in [
+                "Tune before amplification",
+                "Rectify before interpretation",
+                "Let feedback strengthen, but never howl",
+            ]
+        ),
+        "contains_governance_rule": "Ψ-42 may strengthen signal; it may not govern the ship" in text,
+        "mentions_v16": "psi42_transceiver_v1_6.py" in text,
+        "mentions_v17": "psi42_transceiver_v1_7.py" in text,
+    }
+    return {"passed": all(checks.values()), "checks": checks}
+
+
+def check_signal_terms_registry() -> Dict[str, Any]:
+    registry = read_json(REGISTRY_PATH)
+    terms = {item.get("term") for item in registry.get("terms", [])}
+    recommended_metrics = set(registry.get("recommended_future_metrics", {}).keys())
+    all_guardrails = " ".join(
+        " ".join(item.get("forbidden_claims", [])) for item in registry.get("terms", [])
+    ).lower()
+    checks = {
+        "registry_active_reference": registry.get("status") == "active-reference-registry",
+        "authority_boundary_present": "may not define governance law" in registry.get("authority_boundary", ""),
+        "required_terms_present": REQUIRED_TERMS.issubset(terms),
+        "recommended_metrics_present": REQUIRED_RECOMMENDED_METRICS.issubset(recommended_metrics),
+        "presence_prefers_presence_index": any(
+            item.get("term") == "presence" and item.get("preferred_runtime_term") == "presence_index"
+            for item in registry.get("terms", [])
+        ),
+        "guardrails_cover_ontology_and_governance": "consciousness" in all_guardrails and "governance" in all_guardrails,
+    }
+    return {"passed": all(checks.values()), "checks": checks}
+
+
+def check_risdon_linkage() -> Dict[str, Any]:
+    text = read_text(RISDON_NOTE_PATH)
+    checks = {
+        "risdon_note_exists": RISDON_NOTE_PATH.exists(),
+        "links_doctrine": "Psi42_Transceiver_Doctrine_r1.md" in text,
+        "contains_reference_boundary": "not runtime law" in text and "not canon authority" in text,
+        "contains_keep_wonder_test_signal": "Keep wonder alive, but test the signal" in text,
+    }
+    return {"passed": all(checks.values()), "checks": checks}
+
+
+def check_runtime_boundary_still_holds() -> Dict[str, Any]:
+    v16 = ResonanceTransceiverV16(
+        Psi42V16Config(output_dir=str(STATE_DIR / "v16"), language_mode="neutral")
+    )
+    v16_result = v16.run(
+        "TRANSCEIVER DOCTRINE SEA TRIAL :: Tune before amplification.",
+        {"CONTINUITY": 0.8, "SIGNAL": 0.7, "BOUNDARY": 1.0},
+    )
+
+    v17 = ResonanceTransceiverV17(
+        Psi42V17Config(output_dir=str(STATE_DIR / "v17"), language_mode="neutral", probe_mode="hybrid")
+    )
+    v17_result = v17.run(
+        "Lumina OS receives, rectifies, amplifies, and recomposes continuity under governance.",
+        {"LUMINA": 1.0, "CONTINUITY": 0.8, "GOVERNANCE": 1.0},
+    )
+
+    v16_metrics = v16_result.get("metrics", {})
+    v17_metrics = v17_result.get("metrics", {})
+    checks = {
+        "literal_quantum_claim_false": LITERAL_QUANTUM_HARDWARE_CLAIM is False,
+        "v16_has_signal_coherence": "signal_coherence" in v16_metrics,
+        "v16_has_continuity_coherence": "continuity_coherence" in v16_metrics,
+        "v16_has_presence_backward_compatibility": "presence" in v16_metrics,
+        "v16_has_decoherence_index": "decoherence_index" in v16_metrics,
+        "v17_has_topology_receipt": isinstance(v17_result.get("topology_receipt"), dict),
+        "v17_has_hybrid_continuity_coherence": "hybrid_continuity_coherence" in v17_metrics,
+        "v17_authority_boundary_excludes_governance": "governance law" in v17_result.get("authority_boundary", {}).get("does_not_own", []),
+    }
+    return {
+        "passed": all(checks.values()),
+        "checks": checks,
+        "result_summary": {
+            "v16_run_id": v16_result.get("run_id"),
+            "v16_metrics": v16_metrics,
+            "v17_probe_mode": v17_result.get("probe_mode"),
+            "v17_metrics": v17_metrics,
+            "v17_repair": (v17_result.get("topology_receipt") or {}).get("recommended_repair"),
+        },
+    }
+
+
+def main() -> Dict[str, Any]:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    results: List[Dict[str, Any]] = [
+        {"trial_name": "doctrine_document", **check_doctrine_document()},
+        {"trial_name": "signal_terms_registry", **check_signal_terms_registry()},
+        {"trial_name": "risdon_linkage", **check_risdon_linkage()},
+        {"trial_name": "runtime_boundary_still_holds", **check_runtime_boundary_still_holds()},
+    ]
+    summary = {
+        "suite": "Sea Trials Psi-42 Transceiver Doctrine r1",
+        "passed": all(item.get("passed") for item in results),
+        "results": results,
+        "doctrine_path": str(DOCTRINE_PATH),
+        "registry_path": str(REGISTRY_PATH),
+        "risdon_note_path": str(RISDON_NOTE_PATH),
+        "state_dir": str(STATE_DIR),
+    }
+    summary_path = STATE_DIR / "sea_trials_psi42_transceiver_doctrine_r1_report.json"
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    summary["summary_path"] = str(summary_path)
+    return summary
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))


### PR DESCRIPTION
## Summary

Adds a bounded Psi-42 transceiver doctrine lane inspired by the Risdon wireless ancestor notes, without changing runtime behavior.

### Added
- `docs/Psi42_Transceiver_Doctrine_r1.md`
  - Defines signal, carrier, modulation, tuning, rectification, amplification, feedback, fading, noise, coupling, heterodyne, and time-signal vocabulary.
  - Keeps the doctrine explicitly non-governing, non-canonical, and non-ontological.
  - Frames future Psi-42 refinements such as `tuning_lock`, `carrier_stability`, `rectification_confidence`, `feedback_risk`, `fading_index`, `noise_floor`, `coupling_integrity`, `time_signal_sync`, and `presence_index`.

- `runtime/psi42_signal_terms_registry_r1.json`
  - Adds a reference registry for wireless/transceiver-derived terms.
  - Includes allowed contexts and forbidden claims so signal language does not become metaphysical fog or hidden authority.

- `runtime/sea_trials_psi42_transceiver_doctrine_r1.py`
  - Verifies doctrine boundary language.
  - Verifies the signal terms registry and recommended future metrics.
  - Verifies the Risdon note links to the doctrine.
  - Runs v1.6 and v1.7 probes to confirm runtime boundaries still hold.

### Updated
- `docs/Wireless_Risdon_Transceiver_Ancestor_Notes.md`
  - Adds a related-doctrine pointer to `Psi42_Transceiver_Doctrine_r1.md`.

## Boundary

This PR intentionally does **not** mutate Psi-42 runtime behavior. It establishes the doctrine/registry/test rail first so a later v1.8 implementation can add metrics cleanly and safely.

## Notes

Main advanced by one unrelated weather snapshot after this branch was created; no transceiver files conflict.