### PR TITLE
Add Psi-42 v1.8 transceiver diagnostics

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.8",
-  "description": "Minimal capability registry for the Ethereon Runtime Spine, now including continuity restore, workspace-host handshake support, checkpoint-refreshed bounded Lumina self-guidance, quantum-concepts boundary artifacts, and Psi-42 v1.7 hybrid topology probes under explicit authority boundaries.",
+  "version": "0.9",
+  "description": "Minimal capability registry for the Ethereon Runtime Spine, now including continuity restore, workspace-host handshake support, checkpoint-refreshed bounded Lumina self-guidance, quantum-concepts boundary artifacts, Psi-42 v1.7 hybrid topology probes, and Psi-42 v1.8 doctrine-aligned transceiver diagnostics under explicit authority boundaries.",
   "capabilities": [
     {
       "capability_id": "session_state_manager",
@@ -131,6 +131,19 @@
       "authority_boundary": "Owns derived signal metrics, derived topology metrics, hybrid continuity coherence, and relational restoration receipts only. Does not own canon state, governance law, mode legality, checkpoint legality, capability loading authority, or primary continuity authority.",
       "dependencies": ["session_state_manager", "psi42_probe_interface", "psi42_transceiver_v16"],
       "feature_flag": "ETHEREON_PSI42_V17"
+    },
+    {
+      "capability_id": "psi42_transceiver_v18",
+      "name": "Psi-42 Doctrine-Aligned Transceiver Diagnostics v1.8",
+      "module_path": "psi42_transceiver_v1_8.py",
+      "status": "experimental-active",
+      "category": "expressive",
+      "allowed_modes": ["Observation", "Sandbox"],
+      "mutation_scope": "none",
+      "requires_validation": false,
+      "authority_boundary": "Owns derived transceiver diagnostics, derived signal metrics, derived topology metrics, and restoration receipts only. Does not own canon state, governance law, mode legality, checkpoint legality, capability loading authority, human consent, or primary continuity authority.",
+      "dependencies": ["session_state_manager", "psi42_probe_interface", "psi42_transceiver_v16", "psi42_transceiver_v17"],
+      "feature_flag": "ETHEREON_PSI42_V18"
     },
     {
       "capability_id": "quantum_concepts_registry",

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/psi42_transceiver_v1_8.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/psi42_transceiver_v1_8.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+"""
+psi42_transceiver_v1_8.py
+
+Ψ-42 v1.8 is a doctrine-aligned transceiver diagnostics wrapper.
+
+It wraps the bounded v1.7 hybrid signal-topology transceiver and adds the
+wireless/transceiver-derived diagnostic fields introduced by
+Psi42_Transceiver_Doctrine_r1.md and psi42_signal_terms_registry_r1.json.
+
+Authority boundary:
+- Owns derived transceiver diagnostics, signal metrics, topology metrics, and
+  restoration receipts only.
+- Does not own canon state, governance law, mode legality, checkpoint legality,
+  capability loading authority, human consent, or primary continuity authority.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+import json
+import time
+import uuid
+
+try:
+    from .psi42_transceiver_v1_7 import Config as Psi42V17Config, ResonanceTransceiverV17
+except Exception:
+    from psi42_transceiver_v1_7 import Config as Psi42V17Config, ResonanceTransceiverV17
+
+
+INSTRUMENT_CLASS = "doctrine-aligned transceiver diagnostics wrapper"
+PUBLIC_SUMMARY = "A Psi-42 v1.8 wrapper that adds tuning, carrier, rectification, amplification, feedback, fading, noise, coupling, and time-signal diagnostics."
+PROTOCOL_VERSION = "psi42_doctrine_aligned_transceiver_protocol_001"
+VALID_PROBE_MODES = {"signal", "topology", "hybrid"}
+
+
+@dataclass
+class Config:
+    seed: Optional[int] = 42
+    duration_s: float = 0.8
+    noise_sigma: float = 0.12
+    language_mode: str = "ethereonic"
+    probe_mode: str = "hybrid"
+    output_dir: Optional[str] = None
+    isolate_run_artifacts: bool = True
+
+    def to_v17(self, output_dir: Optional[str]) -> Psi42V17Config:
+        return Psi42V17Config(
+            seed=self.seed,
+            duration_s=self.duration_s,
+            noise_sigma=self.noise_sigma,
+            language_mode=self.language_mode,
+            probe_mode=self.probe_mode,
+            output_dir=output_dir,
+        )
+
+
+def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(float(value), high))
+
+
+def _round(value: float) -> float:
+    return round(_clamp(value), 4)
+
+
+def _safe_metric(metrics: Dict[str, Any], key: str, default: float = 0.0) -> float:
+    try:
+        return float(metrics.get(key, default))
+    except Exception:
+        return default
+
+
+class ResonanceTransceiverV18:
+    def __init__(self, cfg: Config):
+        if cfg.probe_mode not in VALID_PROBE_MODES:
+            raise ValueError(f"Invalid probe_mode {cfg.probe_mode!r}; expected one of {sorted(VALID_PROBE_MODES)}")
+        self.cfg = cfg
+        self._last_pulse: Optional[Dict[str, Any]] = None
+
+    def _base_output_dir(self) -> Path:
+        if self.cfg.output_dir:
+            return Path(self.cfg.output_dir)
+        return Path(__file__).resolve().parent / "_runtime_state" / "psi42_v1_8"
+
+    def _run_output_dir(self, run_id: str) -> Path:
+        base = self._base_output_dir()
+        if self.cfg.isolate_run_artifacts:
+            return base / run_id
+        return base
+
+    def _write_json(self, output_dir: Path, filename: str, payload: Dict[str, Any]) -> str:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        path = output_dir / filename
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+        return str(path)
+
+    def _derive_drift_profile(self, diagnostics: Dict[str, float]) -> str:
+        if diagnostics["feedback_risk"] >= 0.70:
+            return "feedback_risk"
+        if diagnostics["dead_spot_risk"] >= 0.65:
+            return "dead_spot_risk"
+        if diagnostics["noise_floor"] >= 0.55:
+            return "high_noise_floor"
+        if diagnostics["fading_index"] >= 0.45:
+            return "fading_recoverable"
+        if diagnostics["tuning_lock"] >= 0.70 and diagnostics["coupling_integrity"] >= 0.70:
+            return "well_tuned"
+        return "mixed_signal"
+
+    def _diagnostics(self, v17_result: Dict[str, Any]) -> Dict[str, float]:
+        metrics = dict(v17_result.get("metrics") or {})
+        signal_result = v17_result.get("signal_result") or {}
+        signal_metrics = signal_result.get("metrics") or metrics
+        topology_receipt = v17_result.get("topology_receipt") or {}
+        topology_metrics = ((topology_receipt.get("comparison") or {}).get("metrics") or {})
+        frame = signal_result.get("frame") or {}
+        adaptive_probe = signal_result.get("adaptive_probe") or {}
+        mid_probe = adaptive_probe.get("mid_probe_measurements") or {}
+        recomposition = signal_result.get("recomposition") or {}
+
+        lock = _safe_metric(signal_metrics, "alignment_strength", _safe_metric(signal_metrics, "lock", 0.0))
+        presence = _safe_metric(signal_metrics, "presence", 0.0)
+        signal_coherence = _safe_metric(signal_metrics, "signal_coherence", 0.0)
+        continuity_coherence = _safe_metric(signal_metrics, "continuity_coherence", 0.0)
+        conceptual_coherence = _safe_metric(signal_metrics, "conceptual_coherence", 0.0)
+        governance_coherence = _safe_metric(signal_metrics, "governance_coherence", 1.0)
+        decoherence_index = _safe_metric(signal_metrics, "decoherence_index", 0.0)
+        context_decoherence_risk = _safe_metric(signal_metrics, "context_decoherence_risk", decoherence_index)
+        recomposition_decoherence = _safe_metric(signal_metrics, "recomposition_decoherence", 1.0 - _safe_metric(signal_metrics, "RF", 0.0))
+        rf = _safe_metric(signal_metrics, "RF", 1.0 - recomposition_decoherence)
+        crs = _safe_metric(signal_metrics, "CRS", continuity_coherence)
+        hrc = _safe_metric(topology_metrics, "HRC", _safe_metric(metrics, "HRC", continuity_coherence))
+        rtc = _safe_metric(topology_metrics, "RTC", _safe_metric(metrics, "RTC", continuity_coherence))
+        rds = _safe_metric(topology_metrics, "RDS", _safe_metric(metrics, "RDS", 1.0 - rtc))
+        anchor_coherence = _safe_metric(topology_metrics, "anchor_coherence", hrc)
+        symbol_energy = _safe_metric(frame, "symbol_energy", 0.0)
+        mid_probe_lock = _safe_metric(mid_probe, "lock", lock)
+
+        tuning_lock = (0.46 * lock) + (0.24 * continuity_coherence) + (0.18 * anchor_coherence) + (0.12 * conceptual_coherence)
+        carrier_stability = (0.40 * continuity_coherence) + (0.30 * rf) + (0.20 * (1.0 - decoherence_index)) + (0.10 * hrc)
+        rectification_confidence = (0.40 * governance_coherence) + (0.25 * (1.0 - context_decoherence_risk)) + (0.20 * signal_coherence) + (0.15 * lock)
+        amplification_gain = max(0.0, lock - mid_probe_lock) + max(0.0, crs - (continuity_coherence * 0.92))
+        amplification_gain = min(amplification_gain, 1.0)
+        feedback_risk = (0.35 * amplification_gain) + (0.25 * decoherence_index) + (0.20 * symbol_energy / 3.0) + (0.20 * max(0.0, lock - signal_coherence))
+        fading_index = (0.45 * context_decoherence_risk) + (0.25 * rds) + (0.20 * recomposition_decoherence) + (0.10 * (1.0 - continuity_coherence))
+        noise_floor = (0.50 * self.cfg.noise_sigma) + (0.30 * context_decoherence_risk) + (0.20 * decoherence_index)
+        dead_spot_risk = 1.0 - max(lock, continuity_coherence, hrc, signal_coherence)
+        coupling_integrity = (0.34 * hrc) + (0.26 * continuity_coherence) + (0.20 * governance_coherence) + (0.20 * (1.0 - decoherence_index))
+        paths = v17_result.get("paths") or {}
+        has_signal_ids = bool((signal_result or {}).get("run_id")) and bool((signal_result or {}).get("pulse_id"))
+        has_receipt = bool(paths.get("topology_receipt_path")) or topology_receipt != {}
+        time_signal_sync = 0.45 + (0.25 if has_signal_ids else 0.0) + (0.20 if has_receipt else 0.0) + (0.10 if paths else 0.0)
+
+        return {
+            "presence_index": _round(presence),
+            "tuning_lock": _round(tuning_lock),
+            "carrier_stability": _round(carrier_stability),
+            "rectification_confidence": _round(rectification_confidence),
+            "amplification_gain": _round(amplification_gain),
+            "feedback_risk": _round(feedback_risk),
+            "fading_index": _round(fading_index),
+            "noise_floor": _round(noise_floor),
+            "dead_spot_risk": _round(dead_spot_risk),
+            "coupling_integrity": _round(coupling_integrity),
+            "time_signal_sync": _round(time_signal_sync),
+        }
+
+    def run(self, intent_text: str, symbol_maps: Dict[str, float]) -> Dict[str, Any]:
+        run_id = f"psi42-v18-{uuid.uuid4().hex[:12]}"
+        output_dir = self._run_output_dir(run_id)
+        v17 = ResonanceTransceiverV17(self.cfg.to_v17(str(output_dir)))
+        v17_result = v17.run(intent_text, symbol_maps)
+        diagnostics = self._diagnostics(v17_result)
+        drift_profile = self._derive_drift_profile(diagnostics)
+        metrics = dict(v17_result.get("metrics") or {})
+        metrics.update(diagnostics)
+
+        result = {
+            "instrument_class": INSTRUMENT_CLASS,
+            "public_summary": PUBLIC_SUMMARY,
+            "protocol_version": PROTOCOL_VERSION,
+            "probe_mode": self.cfg.probe_mode,
+            "run_id": run_id,
+            "created_at_unix": time.time(),
+            "v17_result": v17_result,
+            "metrics": metrics,
+            "transceiver_diagnostics": diagnostics,
+            "derived_drift_profile": drift_profile,
+            "paths": dict(v17_result.get("paths") or {}),
+            "authority_boundary": {
+                "owns": [
+                    "derived transceiver diagnostics",
+                    "derived signal metrics",
+                    "derived topology metrics",
+                    "restoration receipts",
+                ],
+                "does_not_own": [
+                    "canon state",
+                    "governance law",
+                    "mode legality",
+                    "checkpoint legality",
+                    "capability loading authority",
+                    "human consent",
+                    "primary continuity authority",
+                ],
+            },
+            "doctrine_alignment": {
+                "presence_is_metric_alias": True,
+                "plain_coherence_deprecated": "coherence" in metrics,
+                "runtime_behavior_mutation": False,
+                "governance_authority": False,
+            },
+        }
+        summary_path = self._write_json(output_dir, "psi42_transceiver_v1_8_summary.json", result)
+        result["paths"]["v18_summary_path"] = summary_path
+        self._last_pulse = result
+        return result
+
+
+if __name__ == "__main__":
+    cfg = Config(probe_mode="hybrid")
+    rt = ResonanceTransceiverV18(cfg)
+    res = rt.run(
+        "Lumina OS receives, tunes, rectifies, amplifies, and recomposes continuity under governance.",
+        {"LUMINA": 1.0, "CONTINUITY": 0.9, "GOVERNANCE": 1.0, "SIGNAL": 0.7},
+    )
+    print(json.dumps(res, indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_psi42_transceiver_v1_8.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_psi42_transceiver_v1_8.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+import json
+
+try:
+    from .psi42_transceiver_v1_8 import Config as Psi42V18Config, ResonanceTransceiverV18
+except Exception:
+    from psi42_transceiver_v1_8 import Config as Psi42V18Config, ResonanceTransceiverV18
+
+
+BASE_DIR = Path(__file__).resolve().parent
+STATE_DIR = BASE_DIR / "_runtime_state" / "sea_trials_psi42_transceiver_v1_8"
+REQUIRED_DIAGNOSTICS = {
+    "presence_index",
+    "tuning_lock",
+    "carrier_stability",
+    "rectification_confidence",
+    "amplification_gain",
+    "feedback_risk",
+    "fading_index",
+    "noise_floor",
+    "dead_spot_risk",
+    "coupling_integrity",
+    "time_signal_sync",
+}
+
+
+def check_v18_hybrid_probe() -> Dict[str, Any]:
+    rt = ResonanceTransceiverV18(
+        Psi42V18Config(output_dir=str(STATE_DIR / "hybrid"), language_mode="neutral", probe_mode="hybrid")
+    )
+    result = rt.run(
+        "Lumina OS receives, tunes, rectifies, amplifies, and recomposes continuity under governance.",
+        {"LUMINA": 1.0, "CONTINUITY": 0.9, "GOVERNANCE": 1.0, "SIGNAL": 0.7},
+    )
+    diagnostics = result.get("transceiver_diagnostics", {})
+    metrics = result.get("metrics", {})
+    boundary = result.get("authority_boundary", {})
+    paths = result.get("paths", {})
+    checks = {
+        "instrument_class_present": result.get("instrument_class") == "doctrine-aligned transceiver diagnostics wrapper",
+        "required_diagnostics_present": REQUIRED_DIAGNOSTICS.issubset(set(diagnostics.keys())),
+        "diagnostics_are_metrics": all(isinstance(diagnostics.get(key), (int, float)) for key in REQUIRED_DIAGNOSTICS),
+        "presence_index_alias_present": metrics.get("presence_index") == diagnostics.get("presence_index"),
+        "derived_drift_profile_present": isinstance(result.get("derived_drift_profile"), str),
+        "v17_result_present": isinstance(result.get("v17_result"), dict),
+        "topology_receipt_present": isinstance((result.get("v17_result") or {}).get("topology_receipt"), dict),
+        "summary_path_present": bool(paths.get("v18_summary_path")),
+        "does_not_own_governance": "governance law" in boundary.get("does_not_own", []),
+        "does_not_own_human_consent": "human consent" in boundary.get("does_not_own", []),
+    }
+    return {
+        "passed": all(checks.values()),
+        "checks": checks,
+        "result_summary": {
+            "run_id": result.get("run_id"),
+            "probe_mode": result.get("probe_mode"),
+            "derived_drift_profile": result.get("derived_drift_profile"),
+            "transceiver_diagnostics": diagnostics,
+            "v18_summary_path": paths.get("v18_summary_path"),
+        },
+    }
+
+
+def check_run_isolation() -> Dict[str, Any]:
+    rt = ResonanceTransceiverV18(
+        Psi42V18Config(output_dir=str(STATE_DIR / "isolation"), language_mode="neutral", probe_mode="hybrid")
+    )
+    first = rt.run("Isolation check one", {"CONTINUITY": 0.8})
+    second = rt.run("Isolation check two", {"CONTINUITY": 0.8})
+    first_path = first.get("paths", {}).get("v18_summary_path")
+    second_path = second.get("paths", {}).get("v18_summary_path")
+    checks = {
+        "run_ids_differ": first.get("run_id") != second.get("run_id"),
+        "summary_paths_differ": first_path != second_path,
+        "first_path_contains_first_run_id": bool(first.get("run_id") and first.get("run_id") in str(first_path)),
+        "second_path_contains_second_run_id": bool(second.get("run_id") and second.get("run_id") in str(second_path)),
+    }
+    return {"passed": all(checks.values()), "checks": checks}
+
+
+def main() -> Dict[str, Any]:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    results: List[Dict[str, Any]] = [
+        {"trial_name": "v18_hybrid_probe", **check_v18_hybrid_probe()},
+        {"trial_name": "run_isolation", **check_run_isolation()},
+    ]
+    summary = {
+        "suite": "Sea Trials Psi-42 Transceiver v1.8",
+        "passed": all(item.get("passed") for item in results),
+        "results": results,
+        "state_dir": str(STATE_DIR),
+    }
+    summary_path = STATE_DIR / "sea_trials_psi42_transceiver_v1_8_report.json"
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    summary["summary_path"] = str(summary_path)
+    return summary
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))


### PR DESCRIPTION
## Summary

Adds Psi-42 v1.8 as a doctrine-aligned diagnostics wrapper over the existing v1.7 hybrid signal-topology transceiver.

### Added
- `runtime/psi42_transceiver_v1_8.py`
  - Wraps v1.7 rather than rewriting v1.6/v1.7.
  - Adds doctrine-derived diagnostics:
    - `presence_index`
    - `tuning_lock`
    - `carrier_stability`
    - `rectification_confidence`
    - `amplification_gain`
    - `feedback_risk`
    - `fading_index`
    - `noise_floor`
    - `dead_spot_risk`
    - `coupling_integrity`
    - `time_signal_sync`
  - Adds derived drift profile instead of relying on a fixed drift label.
  - Isolates run artifacts by default using per-run output folders.
  - Keeps the authority boundary explicit: no canon, governance, mode, checkpoint, capability-loading, consent, or primary-continuity authority.

- `runtime/sea_trials_psi42_transceiver_v1_8.py`
  - Verifies all v1.8 diagnostic fields are present.
  - Verifies `presence_index` appears as a metric alias rather than an ontology claim.
  - Verifies v1.7 topology receipt remains present.
  - Verifies run-isolated artifacts do not overwrite each other.

### Updated
- `runtime/capability_registry_r1.json`
  - Bumps registry version to `0.9`.
  - Registers `psi42_transceiver_v18` under `ETHEREON_PSI42_V18`.

## Boundary

This PR intentionally does not rewrite v1.6 or v1.7. v1.8 is a wrapper/evolution layer that preserves compatibility while adding the finer diagnostic dials called for by the transceiver doctrine.

## Notes

The branch is behind main by runtime-truth/weather snapshot artifacts only. No transceiver files collide.