### PR TITLE
Wire Psi-42 v1.8 into Lumina runner

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/lumina
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/lumina
@@ -31,7 +31,7 @@ def _run(args: List[str], *, cwd: Optional[Path] = None) -> int:
 
 def cmd_run(args: argparse.Namespace) -> int:
     prompt = args.prompt or "Review Lumina OS progress and produce the next governed action receipt."
-    cmd = [_python(), str(STUDIO_DIR / "lumina_cli.py"), prompt]
+    cmd = [_python(), str(STUDIO_DIR / "lumina_cli_psi42_v18.py"), prompt]
     if args.receipt_json:
         cmd.append("--receipt-json")
     if args.full_json:
@@ -54,13 +54,15 @@ def cmd_run(args: argparse.Namespace) -> int:
 def cmd_observe(args: argparse.Namespace) -> int:
     cmd = [
         _python(),
-        str(RUNTIME_DIR / "runtime_runner_auto_snapshot_r1.py"),
+        str(RUNTIME_DIR / "runtime_runner_auto_snapshot_psi42_v18_r1.py"),
         "--current-mode", "Continuity",
         "--target-mode", "Observation",
         "--action", args.action,
         "--action-type", "audit",
         "--enable-flag", "ETHEREON_OBSERVATION",
         "--enable-flag", "ETHEREON_PSI42",
+        "--enable-flag", "ETHEREON_PSI42_V17",
+        "--enable-flag", "ETHEREON_PSI42_V18",
         "--enable-flag", "ETHEREON_RESONANCE",
         "--overlay-json", '{"active":true,"anchor_language":["english"],"continuity_phrase":"local observation cycle","harmonic_signature":[],"spiral_reference":null}',
         "--runtime-config-json", '{"toki_pona_required_for_resume":false,"binary_required_for_transition_validation":false,"light_language_required_for_capability_loading":false,"harmonic_frequency_required_for_mode_legality":false}',

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_auto_snapshot_psi42_v18_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_auto_snapshot_psi42_v18_r1.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+"""Auto-snapshot runner shim routed through the Psi-42 v1.8 adapter."""
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+import argparse
+import json
+
+try:
+    from .runtime_runner_psi42_v18_adapter_r1 import RuntimeRunner, VALID_ACTION_TYPES
+    from .runtime_ui_snapshot_emitter_r1 import build_ui_snapshot, write_snapshot, PUBLIC_SNAPSHOT_PATH, STATE_SNAPSHOT_PATH
+    from .runtime_truth_public_snapshot_r1 import build_public_runtime_truth_snapshot
+except Exception:
+    from runtime_runner_psi42_v18_adapter_r1 import RuntimeRunner, VALID_ACTION_TYPES
+    from runtime_ui_snapshot_emitter_r1 import build_ui_snapshot, write_snapshot, PUBLIC_SNAPSHOT_PATH, STATE_SNAPSHOT_PATH
+    from runtime_truth_public_snapshot_r1 import build_public_runtime_truth_snapshot
+
+
+class AutoSnapshotRuntimeRunner(RuntimeRunner):
+    """RuntimeRunner v1.8 wrapper that emits a Chamber-readable UI receipt.
+
+    The snapshot is display-only. It does not grant Chamber authority to execute
+    tools, alter governance, mutate canon, expose capabilities, or change mode
+    legality.
+    """
+
+    def run_cycle(self, *args: Any, emit_public_snapshot: bool = True, emit_state_snapshot: bool = True, **kwargs: Any):
+        result = super().run_cycle(*args, **kwargs)
+        payload = result.to_dict()
+        snapshot = build_ui_snapshot(payload)
+        paths = []
+        if emit_public_snapshot:
+            paths.append(PUBLIC_SNAPSHOT_PATH)
+        if emit_state_snapshot:
+            paths.append(STATE_SNAPSHOT_PATH)
+        write_snapshot(snapshot, paths)
+
+        runtime_truth_emitted = False
+        runtime_truth_error = None
+        try:
+            build_public_runtime_truth_snapshot()
+            runtime_truth_emitted = True
+        except Exception as exc:
+            runtime_truth_error = str(exc)
+
+        payload["runtime_truth_snapshot_emitted"] = runtime_truth_emitted
+        payload["runtime_truth_snapshot_error"] = runtime_truth_error
+        return result
+
+
+def _maybe_json(text: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not text:
+        return None
+    return json.loads(text)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one Lumina runtime cycle through Psi-42 v1.8 and emit the Chamber UI snapshot.")
+    parser.add_argument("--current-mode", default="Continuity")
+    parser.add_argument("--target-mode", default="Observation")
+    parser.add_argument("--action", default="chamber_observation_cycle")
+    parser.add_argument("--action-type", default="audit", choices=sorted(VALID_ACTION_TYPES))
+    parser.add_argument("--target-is-canonical", action="store_true")
+    parser.add_argument("--repo-path", default=None)
+    parser.add_argument("--enable-flag", action="append", dest="feature_flags", default=[])
+    parser.add_argument("--artifact", action="append", dest="artifacts", default=[])
+    parser.add_argument("--note", action="append", dest="notes", default=[])
+    parser.add_argument("--lineage", default=None)
+    parser.add_argument("--overlay-json", default=None)
+    parser.add_argument("--runtime-config-json", default=None)
+    parser.add_argument("--promotion-json", default=None)
+    parser.add_argument("--raw-user-input", default=None)
+    parser.add_argument("--project-id", default=None)
+    parser.add_argument("--context-overrides-json", default=None)
+    parser.add_argument("--no-public-snapshot", action="store_true")
+    parser.add_argument("--no-state-snapshot", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    runner = AutoSnapshotRuntimeRunner()
+    result = runner.run_cycle(
+        current_mode=args.current_mode,
+        target_mode=args.target_mode,
+        requested_action=args.action,
+        action_type=args.action_type,
+        artifacts=args.artifacts or None,
+        continuation_notes=args.notes or None,
+        canon_lineage_head=args.lineage,
+        ethereonic_overlay=_maybe_json(args.overlay_json),
+        enabled_feature_flags=args.feature_flags or None,
+        target_is_canonical=args.target_is_canonical,
+        promotion_payload=_maybe_json(args.promotion_json),
+        runtime_config=_maybe_json(args.runtime_config_json),
+        repo_path=args.repo_path,
+        raw_user_input=args.raw_user_input,
+        context_bundle_overrides=_maybe_json(args.context_overrides_json),
+        project_id=args.project_id,
+        emit_public_snapshot=not args.no_public_snapshot,
+        emit_state_snapshot=not args.no_state_snapshot,
+    )
+    print(json.dumps(result.to_dict(), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_psi42_v18_adapter_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_psi42_v18_adapter_r1.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+"""RuntimeRunner adapter that prefers Psi-42 v1.8 when available.
+
+This adapter avoids rewriting the core runner while giving local Studio / observe
+surfaces a clean route to the doctrine-aligned v1.8 transceiver diagnostics.
+It preserves the existing v1.7 and v1.6 fallbacks.
+"""
+
+from typing import Any, Dict, List, Optional
+
+try:
+    from .runtime_runner_r1_merged import RuntimeRunner as BaseRuntimeRunner, VALID_ACTION_TYPES
+except Exception:
+    from runtime_runner_r1_merged import RuntimeRunner as BaseRuntimeRunner, VALID_ACTION_TYPES
+
+try:
+    from .psi42_transceiver_v1_8 import Config as Psi42V18Config, ResonanceTransceiverV18
+except Exception:
+    try:
+        from psi42_transceiver_v1_8 import Config as Psi42V18Config, ResonanceTransceiverV18
+    except Exception:
+        Psi42V18Config = None
+        ResonanceTransceiverV18 = None
+
+try:
+    from .psi42_transceiver_v1_7 import Config as Psi42V17Config, ResonanceTransceiverV17
+except Exception:
+    try:
+        from psi42_transceiver_v1_7 import Config as Psi42V17Config, ResonanceTransceiverV17
+    except Exception:
+        Psi42V17Config = None
+        ResonanceTransceiverV17 = None
+
+try:
+    from .psi42_transceiver_v1_6 import Config as Psi42V16Config, ResonanceTransceiverV16
+except Exception:
+    try:
+        from psi42_transceiver_v1_6 import Config as Psi42V16Config, ResonanceTransceiverV16
+    except Exception:
+        Psi42V16Config = None
+        ResonanceTransceiverV16 = None
+
+
+PSI42_DEFAULT_FLAGS = [
+    "ETHEREON_PSI42",
+    "ETHEREON_PSI42_V17",
+    "ETHEREON_PSI42_V18",
+    "ETHEREON_RESONANCE",
+]
+
+
+class RuntimeRunner(BaseRuntimeRunner):
+    """RuntimeRunner variant that prefers Psi-42 v1.8 diagnostics.
+
+    Authority remains unchanged: this adapter only changes probe routing. It does
+    not alter governance law, mode legality, mutation rules, canon lineage, or
+    checkpoint legality.
+    """
+
+    def _resolve_enabled_feature_flags(self, enabled_feature_flags: Optional[List[str]]) -> List[str]:
+        merged = super()._resolve_enabled_feature_flags(enabled_feature_flags)
+        for flag in PSI42_DEFAULT_FLAGS:
+            if flag not in merged:
+                merged.append(flag)
+        return merged
+
+    def _psi42_language_mode(self, ethereonic_overlay: Optional[Dict[str, Any]]) -> str:
+        overlay = ethereonic_overlay or {}
+        anchors = overlay.get("anchor_language", ["english"])
+        return "ethereonic" if any(x in anchors for x in ["toki_pona", "binary", "light_language"]) else "neutral"
+
+    def _psi42_symbol_maps(self, target_mode: str) -> Dict[str, float]:
+        return {
+            "OBSERVATION": 1.0 if target_mode == "Observation" else 0.0,
+            "SANDBOX": 1.0 if target_mode == "Sandbox" else 0.0,
+            "CONTINUITY": 0.8,
+            "HABITAT": 0.7,
+            "SIGNAL": 0.7,
+            "GOVERNANCE": 0.6,
+        }
+
+    def _maybe_run_psi42_probe(
+        self,
+        *,
+        target_mode: str,
+        requested_action: str,
+        ethereonic_overlay: Optional[Dict[str, Any]],
+        exposed_capabilities: List[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        capability_ids = {cap.get("capability_id") for cap in exposed_capabilities}
+        has_any_psi42 = bool(
+            capability_ids
+            & {
+                "psi42_probe_interface",
+                "psi42_transceiver_v16",
+                "psi42_transceiver_v17",
+                "psi42_transceiver_v18",
+            }
+        )
+        if not has_any_psi42:
+            return None
+        if target_mode not in {"Observation", "Sandbox"}:
+            return None
+
+        language_mode = self._psi42_language_mode(ethereonic_overlay)
+        run_slug = "".join(c if c.isalnum() or c in "-_" else "_" for c in f"{requested_action}_{target_mode}")[:80]
+        output_dir = self.base_dir / "psi42_artifacts" / (self._active_session_id or "session") / run_slug
+        intent_text = f"{requested_action} :: {target_mode}"
+        symbol_maps = self._psi42_symbol_maps(target_mode)
+
+        if "psi42_transceiver_v18" in capability_ids and ResonanceTransceiverV18 is not None and Psi42V18Config is not None:
+            rt = ResonanceTransceiverV18(
+                Psi42V18Config(language_mode=language_mode, output_dir=str(output_dir), probe_mode="hybrid")
+            )
+            result = rt.run(intent_text, symbol_maps)
+            v17_result = result.get("v17_result") or {}
+            signal_result = v17_result.get("signal_result") or {}
+            return {
+                "instrument_version": "v1.8",
+                "instrument_class": result.get("instrument_class"),
+                "probe_mode": result.get("probe_mode"),
+                "metrics": result.get("metrics"),
+                "transceiver_diagnostics": result.get("transceiver_diagnostics"),
+                "derived_drift_profile": result.get("derived_drift_profile"),
+                "paths": result.get("paths"),
+                "topology_receipt": v17_result.get("topology_receipt"),
+                "signal_run_id": signal_result.get("run_id"),
+                "signal_pulse_id": signal_result.get("pulse_id"),
+                "run_id": result.get("run_id"),
+                "authority_boundary": result.get("authority_boundary"),
+                "doctrine_alignment": result.get("doctrine_alignment"),
+            }
+
+        if "psi42_transceiver_v17" in capability_ids and ResonanceTransceiverV17 is not None and Psi42V17Config is not None:
+            rt = ResonanceTransceiverV17(
+                Psi42V17Config(language_mode=language_mode, output_dir=str(output_dir), probe_mode="hybrid")
+            )
+            result = rt.run(intent_text, symbol_maps)
+            return {
+                "instrument_version": "v1.7",
+                "instrument_class": result.get("instrument_class"),
+                "probe_mode": result.get("probe_mode"),
+                "metrics": result.get("metrics"),
+                "paths": result.get("paths"),
+                "topology_receipt": result.get("topology_receipt"),
+                "signal_run_id": (result.get("signal_result") or {}).get("run_id"),
+                "signal_pulse_id": (result.get("signal_result") or {}).get("pulse_id"),
+                "authority_boundary": result.get("authority_boundary"),
+            }
+
+        if ResonanceTransceiverV16 is None or Psi42V16Config is None:
+            return None
+        rt = ResonanceTransceiverV16(Psi42V16Config(language_mode=language_mode, output_dir=str(output_dir)))
+        result = rt.run(intent_text, symbol_maps)
+        return {
+            "instrument_version": "v1.6",
+            "run_id": result.get("run_id"),
+            "pulse_id": result.get("pulse_id"),
+            "metrics": result.get("metrics"),
+            "paths": result.get("paths"),
+            "frame": result.get("frame"),
+        }

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_runtime_runner_psi42_v18_wiring_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_runtime_runner_psi42_v18_wiring_r1.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+import json
+import shutil
+
+try:
+    from .runtime_runner_psi42_v18_adapter_r1 import RuntimeRunner
+except Exception:
+    from runtime_runner_psi42_v18_adapter_r1 import RuntimeRunner
+
+
+BASE_DIR = Path(__file__).resolve().parent
+STATE_DIR = BASE_DIR / "_runtime_state" / "sea_trials_runtime_runner_psi42_v18_wiring_r1"
+
+REQUIRED_DIAGNOSTICS = {
+    "presence_index",
+    "tuning_lock",
+    "carrier_stability",
+    "rectification_confidence",
+    "amplification_gain",
+    "feedback_risk",
+    "fading_index",
+    "noise_floor",
+    "dead_spot_risk",
+    "coupling_integrity",
+    "time_signal_sync",
+}
+
+
+def check_runner_prefers_v18() -> Dict[str, Any]:
+    if STATE_DIR.exists():
+        shutil.rmtree(STATE_DIR)
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    runner = RuntimeRunner(base_dir=STATE_DIR / "runner")
+    result = runner.run_cycle(
+        current_mode="Continuity",
+        target_mode="Observation",
+        requested_action="psi42_v18_wiring_sea_trial",
+        action_type="audit",
+        enabled_feature_flags=[
+            "ETHEREON_OBSERVATION",
+            "ETHEREON_PSI42",
+            "ETHEREON_PSI42_V17",
+            "ETHEREON_PSI42_V18",
+            "ETHEREON_RESONANCE",
+        ],
+        ethereonic_overlay={
+            "active": True,
+            "anchor_language": ["english"],
+            "continuity_phrase": "v1.8 wiring sea trial",
+            "harmonic_signature": [],
+            "spiral_reference": None,
+        },
+        runtime_config={
+            "toki_pona_required_for_resume": False,
+            "binary_required_for_transition_validation": False,
+            "light_language_required_for_capability_loading": False,
+            "harmonic_frequency_required_for_mode_legality": False,
+        },
+        raw_user_input="Run a bounded Observation audit through Psi-42 v1.8 wiring.",
+        project_id="lumina-os",
+    ).to_dict()
+
+    probe = result.get("probe_artifacts") or {}
+    metrics = probe.get("metrics") or {}
+    diagnostics = probe.get("transceiver_diagnostics") or {}
+    exposed_ids = {cap.get("capability_id") for cap in result.get("exposed_capabilities", [])}
+    governance = result.get("governance") or {}
+    checks = {
+        "cycle_not_halted": result.get("halted") is False,
+        "governance_chain_valid": (result.get("governance_chain_status") or {}).get("valid") is True,
+        "v18_capability_exposed": "psi42_transceiver_v18" in exposed_ids,
+        "probe_executed_as_v18": probe.get("instrument_version") == "v1.8",
+        "diagnostics_present": REQUIRED_DIAGNOSTICS.issubset(set(diagnostics.keys())),
+        "metrics_include_presence_index": "presence_index" in metrics,
+        "metrics_include_tuning_lock": "tuning_lock" in metrics,
+        "derived_drift_profile_present": isinstance(probe.get("derived_drift_profile"), str),
+        "authority_boundary_excludes_governance": "governance law" in (probe.get("authority_boundary") or {}).get("does_not_own", []),
+        "capability_exposure_recorded": "capability_exposure" in governance,
+    }
+    return {
+        "passed": all(checks.values()),
+        "checks": checks,
+        "result_summary": {
+            "run_id": result.get("run_id"),
+            "probe_version": probe.get("instrument_version"),
+            "probe_run_id": probe.get("run_id"),
+            "derived_drift_profile": probe.get("derived_drift_profile"),
+            "diagnostics": diagnostics,
+            "exposed_capabilities": sorted(exposed_ids),
+            "log_path": result.get("log_path"),
+        },
+    }
+
+
+def main() -> Dict[str, Any]:
+    results: List[Dict[str, Any]] = [
+        {"trial_name": "runner_prefers_v18", **check_runner_prefers_v18()},
+    ]
+    summary = {
+        "suite": "Sea Trials Runtime Runner Psi-42 v1.8 Wiring r1",
+        "passed": all(item.get("passed") for item in results),
+        "results": results,
+        "state_dir": str(STATE_DIR),
+    }
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    summary_path = STATE_DIR / "sea_trials_runtime_runner_psi42_v18_wiring_r1_report.json"
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+    summary["summary_path"] = str(summary_path)
+    return summary
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_cli_psi42_v18.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_cli_psi42_v18.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Lumina Studio CLI shim that routes through the Psi-42 v1.8 runner adapter.
+
+The original `lumina_cli.py` remains the operator surface. This shim swaps its
+RuntimeRunner binding to the v1.8 adapter before delegating to its existing main.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_ROOT = BOOTSTRAP_ROOT / "runtime"
+STUDIO_ROOT = BOOTSTRAP_ROOT / "studio"
+for path in [str(RUNTIME_ROOT), str(STUDIO_ROOT)]:
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+try:
+    import lumina_cli as base_cli
+    from runtime_runner_psi42_v18_adapter_r1 import RuntimeRunner, VALID_ACTION_TYPES
+except Exception as exc:  # pragma: no cover - startup guard
+    raise RuntimeError("Lumina v1.8 CLI shim could not import its base CLI or runner adapter.") from exc
+
+base_cli.RuntimeRunner = RuntimeRunner
+base_cli.VALID_ACTION_TYPES = VALID_ACTION_TYPES
+
+# Keep the operator-facing defaults aligned with the v1.8 adapter/capability registry.
+for flag in ["ETHEREON_PSI42", "ETHEREON_PSI42_V17", "ETHEREON_PSI42_V18", "ETHEREON_RESONANCE"]:
+    if flag not in base_cli.DEFAULT_FEATURE_FLAGS:
+        base_cli.DEFAULT_FEATURE_FLAGS.append(flag)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    return int(base_cli.main(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Wires the merged Psi-42 v1.8 diagnostics layer into the normal Lumina host path without risky surgery on the base runner.

### Added
- `runtime/runtime_runner_psi42_v18_adapter_r1.py`
  - Subclasses the existing runner and prefers `psi42_transceiver_v18` when exposed.
  - Adds default Psi-42 feature flags for v1.8 routing.
  - Preserves fallback order: v1.8 -> v1.7 -> v1.6.
  - Does not alter governance law, mode legality, mutation rules, canon lineage, or checkpoint legality.

- `studio/lumina_cli_psi42_v18.py`
  - Studio CLI shim that routes through the v1.8 runner adapter while preserving the original CLI behavior.

- `runtime/runtime_runner_auto_snapshot_psi42_v18_r1.py`
  - Auto-snapshot runner shim routed through the v1.8 adapter for `lumina observe`.

- `runtime/sea_trials_runtime_runner_psi42_v18_wiring_r1.py`
  - Verifies an Observation audit exposes `psi42_transceiver_v18` and emits `instrument_version: v1.8` with v1.8 diagnostics.

### Updated
- `bin/lumina`
  - `lumina run` now calls `studio/lumina_cli_psi42_v18.py`.
  - `lumina observe` now calls `runtime/runtime_runner_auto_snapshot_psi42_v18_r1.py`.
  - Observation command includes `ETHEREON_PSI42_V17` and `ETHEREON_PSI42_V18` flags.

## Boundary

This PR routes the host/operator path to v1.8 but keeps the base runner intact. The adapter only changes probe selection and preserves the established authority boundaries.