### PR TITLE
Restore essential header links after clarity pass

### DIFF
--- a/assets/js/site-navigation-data.js
+++ b/assets/js/site-navigation-data.js
@@ -2,21 +2,22 @@ window.ETHEREON_SITE_NAVIGATION = {
   primary: [
     ['index.html', 'Home'],
     ['lumina.html', 'Lumina'],
-    ['continuity.html', 'Continuity'],
+    ['build.html', 'What we\'re building'],
+    ['prototype.html', 'Prototype'],
     ['roadmap.html', 'Roadmap'],
-    ['harmonics.html', 'Harmonics'],
-    ['rse.html', 'RSE'],
+    ['continuity.html', 'Continuity'],
     ['rse-whitepaper.html', 'The Spiral'],
-    ['explore.html', 'Explore'],
     ['chamber.html', 'Chamber'],
     ['about.html', 'About'],
-    ['contact.html', 'Contact']
+    ['contact.html', 'Contact'],
+    ['explore.html', 'Research']
   ],
   secondaryFooter: [
     ['principles.html', 'Principles'],
     ['realm.html', 'Realm'],
     ['lumina-dashboard.html', 'Dashboard'],
-    ['build.html', 'Build'],
+    ['harmonics.html', 'Harmonics'],
+    ['rse.html', 'RSE'],
     ['specimen.html', 'Specimen'],
     ['lexicon.html', 'Lexicon'],
     ['faq.html', 'FAQ'],

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -19,8 +19,27 @@ const loadBrandSigil = () => {
   document.head.appendChild(script);
 };
 
+const normalizePath = (href) => {
+  const anchor = document.createElement('a');
+  anchor.href = href;
+  return anchor.pathname.split('/').pop() || 'index.html';
+};
+
+const enhancePrimaryNav = () => {
+  const navLinks = window.ETHEREON_SITE_NAVIGATION && window.ETHEREON_SITE_NAVIGATION.primary;
+  if (!navLinks) return;
+  const current = normalizePath(window.location.href);
+  document.querySelectorAll('.nav-links[aria-label="Primary"]').forEach((nav) => {
+    nav.innerHTML = navLinks.map(([href, label]) => {
+      const isCurrent = normalizePath(href) === current;
+      return `<a href="${href}"${isCurrent ? ' aria-current="page"' : ''}>${label}</a>`;
+    }).join('');
+  });
+};
+
 const enhanceSite = () => {
   loadBrandSigil();
+  enhancePrimaryNav();
 
   const fallbackFooterLinks = [
     ['principles.html', 'Principles'],


### PR DESCRIPTION
## Summary

Follow-up to the public clarity pass. The first pass made the site more human-friendly, but it over-corrected by removing needed header links such as **The Spiral**.

### Changes
- Updates `assets/js/site-navigation-data.js` so the primary nav keeps the clearer public path while restoring essential doors:
  - Home
  - Lumina
  - What we’re building
  - Prototype
  - Roadmap
  - Continuity
  - The Spiral
  - Chamber
  - About
  - Contact
  - Research
- Keeps deeper/supporting links in the footer:
  - Principles
  - Realm
  - Dashboard
  - Harmonics
  - RSE
  - Specimen
  - Lexicon
  - FAQ
  - Updates
- Updates `assets/js/site.js` so primary headers are generated from the shared nav data, rather than hand-maintained separately on every page.

## Intent

Human-friendly navigation should sequence the visitor journey, not amputate important project artifacts. This restores The Spiral and other needed doors while keeping Research/Explore as the deeper-system map.