### PR TITLE
Polish footer and mobile bottom spacing

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -88,9 +88,9 @@ body::before {
 .site-header .nav-links { display: flex; flex: 1 1 auto; min-width: 0; flex-wrap: nowrap; white-space: nowrap; overflow-x: auto; overflow-y: hidden; scrollbar-width: none; position: relative; z-index: 1; }
 .site-header .nav-links::-webkit-scrollbar { display: none; }
 .site-header .nav-links a { flex: 0 0 auto; }
-.footer-secondary-links { max-width: 1120px; margin: 0.8rem auto 0; padding: 0 1.25rem; color: rgba(210,222,255,0.62); font-size: 0.78rem; line-height: 1.9; }
-.footer-secondary-links a { color: rgba(226,236,255,0.76); text-decoration: none; }
-.footer-secondary-links a:hover { color: rgba(255,255,255,0.98); }
+.footer-secondary-links { max-width: 1120px; margin: 0.9rem auto 0; padding: 0 1.1rem; color: rgba(210,222,255,0.62); font-size: 0.78rem; line-height: 1.9; display: flex; flex-wrap: wrap; gap: 0.45rem; align-items: center; }
+.footer-secondary-links a { color: rgba(226,236,255,0.76); text-decoration: none; border: 1px solid rgba(140,170,255,0.14); background: rgba(255,255,255,0.025); border-radius: 999px; padding: 0.34rem 0.62rem; line-height: 1.2; }
+.footer-secondary-links a:hover { color: rgba(255,255,255,0.98); border-color: rgba(126,240,209,0.34); background: rgba(126,240,209,0.055); }
 .icon-button { appearance: none; border: 1px solid var(--line); background: rgba(255,255,255,0.03); color: var(--text); min-height: 38px; min-width: 38px; border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; cursor: pointer; }
 .nav-links a, .icon-button, .button, .card, .timeline, .feature-callout, .status-banner { transition: transform 160ms ease, box-shadow 180ms ease, border-color 180ms ease, background 180ms ease, color 180ms ease; }
 .button { display: inline-flex; align-items: center; justify-content: center; gap: 0.65rem; text-decoration: none; border-radius: 999px; padding: 0.95rem 1.35rem; border: 1px solid var(--line); color: var(--text); background: rgba(255,255,255,0.03); font-weight: 600; cursor: pointer; }
@@ -120,8 +120,12 @@ h1, h2, h3 { margin: 0; line-height: 1.04; }
 .poster-section { padding-top: 0.4rem; padding-bottom: 4rem; }
 .realm-poster-frame { margin: 0 auto; width: min(100%, 760px); padding: clamp(0.55rem, 2vw, 0.9rem); border: 1px solid rgba(217,168,78,0.32); border-radius: calc(var(--radius-xl) + 6px); background: linear-gradient(180deg, rgba(217,168,78,0.10), rgba(16,24,42,0.38)); box-shadow: 0 34px 90px rgba(0,0,0,0.42), 0 0 42px rgba(217,168,78,0.08); }
 .realm-poster-frame img { display: block; width: 100%; height: auto; border-radius: var(--radius-xl); box-shadow: 0 20px 70px rgba(0,0,0,0.40); }
-.footer { padding: 2rem 0 2.5rem; color: var(--muted); border-top: 1px solid rgba(255,255,255,0.06); }
-.footer-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+.footer { padding: clamp(1.35rem, 4vw, 2.4rem) 0 clamp(1.7rem, 5vw, 3rem); color: var(--muted); border-top: 1px solid rgba(255,255,255,0.06); background: linear-gradient(180deg, rgba(5,9,18,0.18), rgba(5,9,18,0.58)); }
+.footer-row { width: min(var(--max-width), calc(100% - 2rem)); margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 0.9rem; border: 1px solid rgba(140,170,255,0.14); border-radius: 24px; background: rgba(8,13,27,0.64); box-shadow: 0 18px 52px rgba(0,0,0,0.22); padding: 1rem; }
+.footer-row > div:first-child { font-size: 0; display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.45rem; }
+.footer-row > div:first-child::before { content: "EthereonLabs"; color: var(--text); font-size: 0.92rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
+.footer-row > div:first-child::after { content: "Adaptive continuity workspaces for returning to complex work."; color: rgba(210,222,255,0.68); font-size: 0.84rem; line-height: 1.45; }
+.footer-row > div:last-child { justify-self: end; color: rgba(210,222,255,0.66); font-size: 0.82rem; }
 .footer a { color: var(--text); text-decoration: none; }
 .footer a:hover { color: var(--accent-2); }
 @keyframes drift {
@@ -183,6 +187,10 @@ body::after { content: ""; position: fixed; inset: 0; pointer-events: none; z-in
 @media (max-width: 760px) {
   .hero { padding-top: 2.35rem; }
   .container { width: min(var(--max-width), calc(100% - 1.1rem)); }
+  .section { padding: 1rem 0 3rem; }
+  .status-banner { gap: 0.85rem; padding: 1rem; border-radius: 22px; }
+  .status-banner h3 { font-size: clamp(1.34rem, 7vw, 1.85rem); line-height: 1.12; }
+  .status-banner .section-copy { font-size: 0.96rem; line-height: 1.65; }
   .nav-wrap { min-height: auto; padding: 0.42rem 0; flex-direction: column; align-items: stretch; gap: 0.38rem; }
   .brand { width: 100%; gap: 0.7rem; }
   .site-header .nav-wrap { flex-direction: column; align-items: stretch; gap: 0.55rem; }
@@ -200,4 +208,12 @@ body::after { content: ""; position: fixed; inset: 0; pointer-events: none; z-in
   .poster-section { padding-bottom: 2.8rem; }
   .realm-poster-frame { border-radius: var(--radius-lg); }
   .realm-poster-frame img { border-radius: calc(var(--radius-lg) - 4px); }
+  .footer { padding: 1.15rem 0 1.9rem; }
+  .footer-row { width: min(var(--max-width), calc(100% - 1.1rem)); grid-template-columns: 1fr; gap: 0.55rem; padding: 0.9rem; border-radius: 20px; }
+  .footer-row > div:first-child { display: grid; gap: 0.32rem; }
+  .footer-row > div:first-child::before { font-size: 0.78rem; letter-spacing: 0.09em; }
+  .footer-row > div:first-child::after { font-size: 0.78rem; line-height: 1.42; max-width: 32ch; }
+  .footer-row > div:last-child { justify-self: start; font-size: 0.78rem; }
+  .footer-secondary-links { width: min(var(--max-width), calc(100% - 1.1rem)); margin: 0.65rem auto 0; padding: 0; gap: 0.38rem; line-height: 1.3; }
+  .footer-secondary-links a { font-size: 0.72rem; padding: 0.32rem 0.52rem; }
 }


### PR DESCRIPTION
## Summary

Small follow-up PR for the footer/bottom-section polish that landed after the navigation restoration PR merged.

### Changes
- Converts the footer from loose text/link spillover into a contained footer panel.
- Replaces the oversized footer text line with a cleaner brand + short orientation statement.
- Turns secondary footer links into compact pill-style links.
- Tightens mobile bottom spacing for the status banner and footer.
- Improves footer readability on narrow screens while preserving the useful deeper links.

### Keeps footer links
- Principles
- Realm
- Dashboard
- Harmonics
- RSE
- Specimen
- Lexicon
- FAQ
- Updates

## Intent

The public clarity pass made the site easier to understand, but the lower mobile section still looked cluttered. This PR keeps the links while making the bottom of the site feel intentional and easier to scan.