### PR TITLE
Drydock website public surface

### DIFF
--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -37,39 +37,119 @@ const enhancePrimaryNav = () => {
   });
 };
 
-const enhanceSite = () => {
-  loadBrandSigil();
-  enhancePrimaryNav();
-
+const secondaryFooterLinks = () => {
   const fallbackFooterLinks = [
     ['principles.html', 'Principles'],
     ['realm.html', 'Realm'],
     ['lumina-dashboard.html', 'Dashboard'],
-    ['build.html', 'Build'],
+    ['harmonics.html', 'Harmonics'],
+    ['rse.html', 'RSE'],
     ['specimen.html', 'Specimen'],
     ['lexicon.html', 'Lexicon'],
     ['faq.html', 'FAQ'],
     ['updates.html', 'Updates'],
   ];
+  return (window.ETHEREON_SITE_NAVIGATION && window.ETHEREON_SITE_NAVIGATION.secondaryFooter) || fallbackFooterLinks;
+};
 
-  const footerLinks = (window.ETHEREON_SITE_NAVIGATION && window.ETHEREON_SITE_NAVIGATION.secondaryFooter) || fallbackFooterLinks;
-
+const enhanceFooter = () => {
   document.querySelectorAll('.footer-row').forEach((footerRow) => {
-    if (footerRow.querySelector('[data-secondary-footer-links]')) return;
-    const group = document.createElement('div');
+    if (!footerRow.querySelector('[data-footer-brand-block]')) {
+      footerRow.innerHTML = `
+        <div class="footer-brand-block" data-footer-brand-block>
+          <a class="footer-brand-link" href="index.html">EthereonLabs</a>
+          <span class="footer-tagline">Adaptive continuity workspaces for returning to complex work.</span>
+        </div>
+        <div class="footer-year">© <span data-year></span></div>
+      `;
+    }
+
+    const next = footerRow.nextElementSibling;
+    if (next && next.matches('[data-secondary-footer-links]')) return;
+
+    const group = document.createElement('nav');
     group.className = 'footer-secondary-links';
     group.setAttribute('data-secondary-footer-links', '');
-    group.innerHTML = footerLinks.map(([href, label]) => `<a href="${href}">${label}</a>`).join(' · ');
+    group.setAttribute('aria-label', 'Secondary site links');
+    group.innerHTML = secondaryFooterLinks().map(([href, label]) => `<a href="${href}">${label}</a>`).join('');
     footerRow.insertAdjacentElement('afterend', group);
   });
+};
 
+const normalizeLegacyExploreLabels = () => {
+  document.querySelectorAll('a[href="explore.html"]').forEach((anchor) => {
+    const text = anchor.textContent.trim();
+    if (text === '← Back to Explore') anchor.textContent = '← Back to Research';
+    if (text === 'Explore' && anchor.closest('.nav-links')) anchor.textContent = 'Research';
+    if (text === 'Explore the system') anchor.textContent = 'Research and deeper system';
+  });
+};
+
+const installSoundToggle = () => {
   const soundButton = document.querySelector('[data-sound-toggle]');
+  const SOUND_KEY = 'ethereonlabs-sound-enabled';
+  let soundEnabled = localStorage.getItem(SOUND_KEY) === 'true';
+  let audioContext = null;
+
+  const updateButton = () => {
+    if (!soundButton) return;
+    soundButton.setAttribute('aria-pressed', soundEnabled ? 'true' : 'false');
+    soundButton.setAttribute('title', soundEnabled ? 'Interface sounds on' : 'Interface sounds off');
+    soundButton.textContent = soundEnabled ? '●' : '○';
+  };
+
+  const ping = () => {
+    if (!soundEnabled) return;
+    try {
+      const AudioCtx = window.AudioContext || window.webkitAudioContext;
+      if (!AudioCtx) return;
+      audioContext = audioContext || new AudioCtx();
+      const oscillator = audioContext.createOscillator();
+      const gain = audioContext.createGain();
+      oscillator.type = 'sine';
+      oscillator.frequency.setValueAtTime(528, audioContext.currentTime);
+      oscillator.frequency.exponentialRampToValueAtTime(660, audioContext.currentTime + 0.06);
+      gain.gain.setValueAtTime(0.0001, audioContext.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.025, audioContext.currentTime + 0.012);
+      gain.gain.exponentialRampToValueAtTime(0.0001, audioContext.currentTime + 0.11);
+      oscillator.connect(gain);
+      gain.connect(audioContext.destination);
+      oscillator.start();
+      oscillator.stop(audioContext.currentTime + 0.12);
+    } catch (_) {
+      // Sound is optional; failures should never affect navigation.
+    }
+  };
+
+  if (soundButton) {
+    soundButton.addEventListener('click', () => {
+      soundEnabled = !soundEnabled;
+      localStorage.setItem(SOUND_KEY, soundEnabled ? 'true' : 'false');
+      updateButton();
+      ping();
+    });
+  }
+
+  document.addEventListener('click', (event) => {
+    const target = event.target.closest('.ping-target, .button, .nav-links a, .footer a');
+    if (target && target !== soundButton) ping();
+  });
+
+  updateButton();
+};
+
+const enhanceSite = () => {
+  loadBrandSigil();
+  enhancePrimaryNav();
+  normalizeLegacyExploreLabels();
+  enhanceFooter();
+
   const yearNodes = document.querySelectorAll('[data-year]');
   yearNodes.forEach((node) => {
     node.textContent = new Date().getFullYear();
   });
-  const SOUND_KEY = 'ethereonlabs-sound-enabled';
-  let soundEnabled = localStorage.getItem(SOUND_KEY) === 'true';
+
+  installSoundToggle();
 };
 
 ensureNavData(enhanceSite);

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -19,6 +19,55 @@ const loadBrandSigil = () => {
   document.head.appendChild(script);
 };
 
+const installDrydockStyles = () => {
+  if (document.querySelector('style[data-ethereon-drydock-styles]')) return;
+  const style = document.createElement('style');
+  style.setAttribute('data-ethereon-drydock-styles', '');
+  style.textContent = `
+    .footer-row > .footer-brand-block {
+      font-size: initial;
+      display: grid;
+      gap: 0.3rem;
+      align-items: start;
+    }
+    .footer-row > .footer-brand-block::before,
+    .footer-row > .footer-brand-block::after {
+      content: none !important;
+      display: none !important;
+    }
+    .footer-brand-link {
+      color: var(--text);
+      font-size: 0.92rem;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      text-decoration: none;
+    }
+    .footer-tagline {
+      color: rgba(210,222,255,0.68);
+      font-size: 0.84rem;
+      line-height: 1.45;
+      max-width: 46ch;
+    }
+    .footer-year {
+      justify-self: end;
+      color: rgba(210,222,255,0.66);
+      font-size: 0.82rem;
+    }
+    .footer-secondary-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+    }
+    @media (max-width: 760px) {
+      .footer-year { justify-self: start; font-size: 0.78rem; }
+      .footer-brand-link { font-size: 0.78rem; letter-spacing: 0.09em; }
+      .footer-tagline { font-size: 0.78rem; line-height: 1.42; max-width: 32ch; }
+    }
+  `;
+  document.head.appendChild(style);
+};
+
 const normalizePath = (href) => {
   const anchor = document.createElement('a');
   anchor.href = href;
@@ -139,6 +188,7 @@ const installSoundToggle = () => {
 };
 
 const enhanceSite = () => {
+  installDrydockStyles();
   loadBrandSigil();
   enhancePrimaryNav();
   normalizeLegacyExploreLabels();

--- a/scripts/sea_trials_website_public_surface_r1.py
+++ b/scripts/sea_trials_website_public_surface_r1.py
@@ -16,7 +16,7 @@ Run from the repository root:
 
 from dataclasses import dataclass, asdict
 from pathlib import Path
-from typing import Dict, Iterable, List, Set
+from typing import Dict, List, Set
 import json
 import re
 
@@ -101,14 +101,22 @@ def top_level_html_files() -> List[Path]:
     return sorted(path for path in ROOT.glob("*.html") if path.is_file())
 
 
+def extract_array_block(nav_text: str, group_name: str) -> str:
+    start_match = re.search(rf"{group_name}:\s*\[", nav_text)
+    if not start_match:
+        return ""
+    start = start_match.end()
+    next_match = re.search(r"\n\s*[A-Za-z_$][\w$]*:\s*\[", nav_text[start:])
+    end = start + next_match.start() if next_match else nav_text.find("\n};", start)
+    if end == -1:
+        end = len(nav_text)
+    return nav_text[start:end]
+
+
 def extract_nav_pairs(nav_text: str, group_name: str) -> Dict[str, str]:
-    pattern = rf"{group_name}:\s*\[(.*?)\]\s*(?:,|\n\s*\])"
-    match = re.search(pattern, nav_text, re.S)
-    if not match:
-        return {}
-    body = match.group(1)
-    pairs = re.findall(r"\['([^']+)',\s*'([^']+)'\]", body)
-    return {label: href for href, label in pairs}
+    body = extract_array_block(nav_text, group_name)
+    pairs = re.findall(r"\['([^']+)',\s*'((?:\\'|[^'])+)'\]", body)
+    return {label.replace("\\'", "'"): href for href, label in pairs}
 
 
 def check_navigation_data() -> Check:
@@ -197,7 +205,6 @@ def check_internal_links() -> Check:
             href = normalize_internal_href(raw_href)
             if href is None:
                 continue
-            # Static site links are expected to be root-relative within the top-level site surface.
             target_name = Path(href).name
             if target_name not in existing:
                 missing.setdefault(str(path.relative_to(ROOT)), []).append(href)
@@ -210,14 +217,20 @@ def check_internal_links() -> Check:
 
 def check_footer_css_no_pseudo_only_brand() -> Check:
     css = read(ROOT / "assets" / "css" / "styles.css")
+    js = read(ROOT / "assets" / "js" / "site.js")
     details = {
         "has_footer_panel": ".footer-row" in css and "border-radius: 24px" in css,
         "has_mobile_footer_rules": "footer-secondary-links" in css and "@media (max-width: 760px)" in css,
         "has_old_pseudo_footer_text": ".footer-row > div:first-child::before" in css or ".footer-row > div:first-child::after" in css,
-        "drydock_js_overrides_old_pseudo_footer_text": "data-ethereon-drydock-styles" in read(ROOT / "assets" / "js" / "site.js"),
+        "drydock_js_overrides_old_pseudo_footer_text": "data-ethereon-drydock-styles" in js,
+        "footer_brand_is_real_dom": "footer-brand-block" in js and "footer-tagline" in js,
     }
-    # Old CSS selectors may remain temporarily while JS override scrapes them at render time.
-    passed = details["has_footer_panel"] and details["has_mobile_footer_rules"] and details["drydock_js_overrides_old_pseudo_footer_text"]
+    passed = (
+        details["has_footer_panel"]
+        and details["has_mobile_footer_rules"]
+        and details["drydock_js_overrides_old_pseudo_footer_text"]
+        and details["footer_brand_is_real_dom"]
+    )
     return Check("footer_bottom_surface_has_panel_and_render_override", passed, details)
 
 

--- a/scripts/sea_trials_website_public_surface_r1.py
+++ b/scripts/sea_trials_website_public_surface_r1.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+"""Sea Trials: EthereonLabs public website surface r1.
+
+Static validator for the public site after the clarity/navigation/footer pass.
+It checks the kinds of barnacles that recently appeared:
+- RSE naming drift
+- missing essential public nav links
+- stale Explore labeling on rendered-helper source
+- internal .html links pointing at missing files
+- shared footer/nav behavior drifting away from canonical data
+
+Run from the repository root:
+    python scripts/sea_trials_website_public_surface_r1.py
+"""
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Set
+import json
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+REPORT_DIR = ROOT / "_site_trials"
+REPORT_PATH = REPORT_DIR / "website_public_surface_r1_report.json"
+
+REQUIRED_PRIMARY_LABELS = {
+    "Home",
+    "Lumina",
+    "What we're building",
+    "Prototype",
+    "Roadmap",
+    "Continuity",
+    "The Spiral",
+    "Chamber",
+    "About",
+    "Contact",
+    "Research",
+}
+
+REQUIRED_SECONDARY_LABELS = {
+    "Principles",
+    "Realm",
+    "Dashboard",
+    "Harmonics",
+    "RSE",
+    "Specimen",
+    "Lexicon",
+    "FAQ",
+    "Updates",
+}
+
+EXPECTED_PRIMARY_TARGETS = {
+    "index.html",
+    "lumina.html",
+    "build.html",
+    "prototype.html",
+    "roadmap.html",
+    "continuity.html",
+    "rse-whitepaper.html",
+    "chamber.html",
+    "about.html",
+    "contact.html",
+    "explore.html",
+}
+
+EXPECTED_SECONDARY_TARGETS = {
+    "principles.html",
+    "realm.html",
+    "lumina-dashboard.html",
+    "harmonics.html",
+    "rse.html",
+    "specimen.html",
+    "lexicon.html",
+    "faq.html",
+    "updates.html",
+}
+
+EXTERNAL_PREFIXES = (
+    "http://",
+    "https://",
+    "mailto:",
+    "tel:",
+    "#",
+    "javascript:",
+)
+
+
+@dataclass
+class Check:
+    name: str
+    passed: bool
+    details: Dict[str, object]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def top_level_html_files() -> List[Path]:
+    return sorted(path for path in ROOT.glob("*.html") if path.is_file())
+
+
+def extract_nav_pairs(nav_text: str, group_name: str) -> Dict[str, str]:
+    pattern = rf"{group_name}:\s*\[(.*?)\]\s*(?:,|\n\s*\])"
+    match = re.search(pattern, nav_text, re.S)
+    if not match:
+        return {}
+    body = match.group(1)
+    pairs = re.findall(r"\['([^']+)',\s*'([^']+)'\]", body)
+    return {label: href for href, label in pairs}
+
+
+def check_navigation_data() -> Check:
+    nav_path = ROOT / "assets" / "js" / "site-navigation-data.js"
+    nav = read(nav_path)
+    primary = extract_nav_pairs(nav, "primary")
+    secondary = extract_nav_pairs(nav, "secondaryFooter")
+    primary_labels = set(primary.keys())
+    secondary_labels = set(secondary.keys())
+    primary_targets = set(primary.values())
+    secondary_targets = set(secondary.values())
+    details = {
+        "missing_primary_labels": sorted(REQUIRED_PRIMARY_LABELS - primary_labels),
+        "missing_secondary_labels": sorted(REQUIRED_SECONDARY_LABELS - secondary_labels),
+        "missing_primary_targets": sorted(EXPECTED_PRIMARY_TARGETS - primary_targets),
+        "missing_secondary_targets": sorted(EXPECTED_SECONDARY_TARGETS - secondary_targets),
+        "primary_count": len(primary_labels),
+        "secondary_count": len(secondary_labels),
+    }
+    return Check(
+        "navigation_data_has_required_public_doors",
+        not any(v for k, v in details.items() if k.startswith("missing_")),
+        details,
+    )
+
+
+def check_shared_site_js() -> Check:
+    site_path = ROOT / "assets" / "js" / "site.js"
+    js = read(site_path)
+    required_fragments = [
+        "enhancePrimaryNav",
+        "enhanceFooter",
+        "normalizeLegacyExploreLabels",
+        "installSoundToggle",
+        "footer-brand-block",
+        "join('')",
+        "← Back to Research",
+        "Research and deeper system",
+    ]
+    forbidden_fragments = [
+        "join(' · ')",
+    ]
+    details = {
+        "missing_required_fragments": [fragment for fragment in required_fragments if fragment not in js],
+        "present_forbidden_fragments": [fragment for fragment in forbidden_fragments if fragment in js],
+    }
+    return Check(
+        "shared_site_js_renders_canonical_nav_footer_and_sound",
+        not details["missing_required_fragments"] and not details["present_forbidden_fragments"],
+        details,
+    )
+
+
+def check_rse_naming() -> Check:
+    offenders: List[str] = []
+    for path in top_level_html_files():
+        text = read(path)
+        if "Recursive Spiral Equation" in text:
+            offenders.append(str(path.relative_to(ROOT)))
+    rse_text = read(ROOT / "rse.html") if (ROOT / "rse.html").exists() else ""
+    details = {
+        "recursive_name_offenders": offenders,
+        "rse_page_has_referential_name": "Referential Spiral Equation" in rse_text,
+    }
+    return Check("rse_uses_referential_name", not offenders and details["rse_page_has_referential_name"], details)
+
+
+def normalize_internal_href(href: str) -> str | None:
+    href = href.strip()
+    if not href or href.startswith(EXTERNAL_PREFIXES):
+        return None
+    href = href.split("#", 1)[0].split("?", 1)[0]
+    if not href.endswith(".html"):
+        return None
+    return href
+
+
+def check_internal_links() -> Check:
+    existing: Set[str] = {path.name for path in top_level_html_files()}
+    existing.update({"index.html"})
+    missing: Dict[str, List[str]] = {}
+    href_pattern = re.compile(r"href=\"([^\"]+)\"")
+    for path in top_level_html_files():
+        text = read(path)
+        for raw_href in href_pattern.findall(text):
+            href = normalize_internal_href(raw_href)
+            if href is None:
+                continue
+            # Static site links are expected to be root-relative within the top-level site surface.
+            target_name = Path(href).name
+            if target_name not in existing:
+                missing.setdefault(str(path.relative_to(ROOT)), []).append(href)
+    details = {
+        "missing_internal_html_links": missing,
+        "html_file_count": len(existing),
+    }
+    return Check("internal_html_links_resolve", not missing, details)
+
+
+def check_footer_css_no_pseudo_only_brand() -> Check:
+    css = read(ROOT / "assets" / "css" / "styles.css")
+    details = {
+        "has_footer_panel": ".footer-row" in css and "border-radius: 24px" in css,
+        "has_mobile_footer_rules": "footer-secondary-links" in css and "@media (max-width: 760px)" in css,
+        "has_old_pseudo_footer_text": ".footer-row > div:first-child::before" in css or ".footer-row > div:first-child::after" in css,
+        "drydock_js_overrides_old_pseudo_footer_text": "data-ethereon-drydock-styles" in read(ROOT / "assets" / "js" / "site.js"),
+    }
+    # Old CSS selectors may remain temporarily while JS override scrapes them at render time.
+    passed = details["has_footer_panel"] and details["has_mobile_footer_rules"] and details["drydock_js_overrides_old_pseudo_footer_text"]
+    return Check("footer_bottom_surface_has_panel_and_render_override", passed, details)
+
+
+def run() -> Dict[str, object]:
+    checks = [
+        check_navigation_data(),
+        check_shared_site_js(),
+        check_rse_naming(),
+        check_internal_links(),
+        check_footer_css_no_pseudo_only_brand(),
+    ]
+    report = {
+        "suite": "Sea Trials Website Public Surface r1",
+        "passed": all(check.passed for check in checks),
+        "checks": [asdict(check) for check in checks],
+        "report_path": str(REPORT_PATH.relative_to(ROOT)),
+    }
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return report
+
+
+if __name__ == "__main__":
+    print(json.dumps(run(), indent=2))


### PR DESCRIPTION
## Summary

Drydock / barnacle scrape for the public website surface after the clarity pass, footer polish, and RSE naming correction.

### Scraped barnacles
- Reworks `assets/js/site.js` so shared site behavior is more reliable:
  - canonical primary nav still renders from `site-navigation-data.js`;
  - footer content now renders as real DOM content instead of relying on pseudo-text;
  - secondary footer links render as clean pills without literal dot separators;
  - legacy `Explore` labels normalize to `Research` / `Back to Research` in rendered helper links;
  - the sound toggle is now actually wired with a small optional interface ping;
  - drydock CSS overrides neutralize the old pseudo-footer text at render time.

### Added sea trial
- Adds `scripts/sea_trials_website_public_surface_r1.py`.
- The sea trial checks:
  - required public header doors are present in nav data;
  - required footer/supporting links are present;
  - shared site JS still renders canonical nav/footer and sound control;
  - no top-level HTML still says `Recursive Spiral Equation`;
  - internal `.html` links resolve to existing top-level pages;
  - footer bottom surface has the panel/mobile structure and real DOM footer brand path.

## Run

```bash
python scripts/sea_trials_website_public_surface_r1.py
```

## Notes

This branch is a few commits behind main due to unrelated updates after the RSE correction. Changed files are limited to `assets/js/site.js` and the new sea-trial script.