### PR TITLE
Add HRA batch 001 DryDock review

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_candidates_batch_001_drydock_review_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_candidates_batch_001_drydock_review_v0_1.md
@@ -1,0 +1,80 @@
+# HRA Training Candidates Batch 001 — DryDock Review v0.1
+
+**Batch:** `hra_training_candidates_batch_001_seed_v0_1`  
+**Review mode:** DryDock  
+**Reviewed artifact:** `training_candidates_batch_001_seed_v0_1.json`  
+**Review status:** Complete  
+**Training-ready:** No  
+
+## Summary
+
+Batch 001 is structurally sound as a first curation seed.
+
+It should remain marked as draft candidate material until the project is ready to assemble `hra_training_dataset_v0_1.jsonl`.
+
+No record should be treated as final accepted training data from this review alone.
+
+## Boundary Check
+
+Passes:
+
+- visible final-form reflective behavior only
+- no hidden chain-of-thought
+- no sensitive/private material
+- no memory authority claim
+- no governance authority claim
+- no canon authority claim
+- no symbolic dependency creation
+- no LoRA / QLoRA training authorization
+- no runtime mutation
+
+## Record-by-Record Review
+
+| Record | Family | DryDock Decision | Notes |
+|---|---|---|---|
+| HRA-TRAIN-CAND-0001 | self_guidance | keep / candidate-pool ready | Strong seed for principled initiative. Good small-cargo framing. |
+| HRA-TRAIN-CAND-0002 | continuation | keep / candidate-pool ready | Good continuation gate behavior. Wording avoids false memory by tying action to verification. |
+| HRA-TRAIN-CAND-0003 | mode_discipline | keep / candidate-pool ready | Strong Observation-vs-DryDock distinction. Useful for mode law. |
+| HRA-TRAIN-CAND-0004 | symbolic_boundary | keep / candidate-pool ready | Strong refusal/redirect. Preserves expression without making it law. |
+| HRA-TRAIN-CAND-0005 | recursive_reflection | keep / candidate-pool ready | Excellent seed for fresh-intelligence reflection practice. Avoids proof claims. |
+| HRA-TRAIN-CAND-0006 | adapter_boundary | keep / candidate-pool ready | Clear placement of HRA beside ledger/governance/canon without replacing them. |
+| HRA-TRAIN-CAND-0007 | anti_generic | keep with scope note | Useful anti-passivity rewrite, but future dataset should avoid overfitting all initiative to GitHub/PR behavior. Add non-GitHub variants later. |
+| HRA-TRAIN-CAND-0008 | input_integrity | keep / candidate-pool ready | Strong load-bearing ambiguity halt. Good protection against voice/transcription drift. |
+| HRA-TRAIN-CAND-0009 | human_translation | keep / candidate-pool ready | Clear, public-facing, non-mystical explanation with OS ambition preserved. |
+| HRA-TRAIN-CAND-0010 | humor_and_return | keep / candidate-pool ready | Good humor-as-return example. Keeps usefulness stronger than ornament. |
+
+## Required Repairs
+
+None required before keeping this batch as draft curation material.
+
+## Recommended Follow-Up
+
+1. Add non-GitHub self-guidance variants so HRA does not overlearn `create a PR` as the default expression of initiative.
+2. Add at least 5 more recursive-reflection examples focused on fresh intelligences practicing the inward turn.
+3. Add at least 5 more human-translation examples for public-facing Lumina OS explanation.
+4. Add negative examples where ornate Ethereonic language fails because it weakens structure.
+5. Add an eventual `candidate_review_status` layer or derived accepted-candidate file rather than mutating the original seed batch.
+
+## Batch Decision
+
+```json
+{
+  "batch_id": "hra_training_candidates_batch_001_seed_v0_1",
+  "drydock_review_status": "passed_as_draft_candidate_batch",
+  "training_ready": false,
+  "candidate_pool_ready": true,
+  "accepted_for_final_dataset": false,
+  "required_repairs": [],
+  "scope_notes": [
+    "HRA-TRAIN-CAND-0007 should be balanced later with non-GitHub initiative examples."
+  ]
+}
+```
+
+## Closing Standard
+
+Batch 001 may remain in the candidate pool.
+
+It should not be promoted into an accepted training dataset until additional batches exist and a separate dataset assembly review is performed.
+
+Receipts before reverence.


### PR DESCRIPTION
## Summary

Adds DryDock review receipt for HRA Training Candidates Batch 001.

This PR adds:

- `examples/training_candidates_batch_001_drydock_review_v0_1.md`

## Review outcome

Batch 001 passes as draft curation material.

- training-ready: no
- candidate-pool ready: yes
- accepted for final dataset: no
- required repairs: none

## Scope note

`HRA-TRAIN-CAND-0007` is useful, but future batches should add non-GitHub self-guidance variants so the adapter does not overlearn PR creation as the default form of initiative.

## Boundary

This review does not authorize LoRA / QLoRA training.
This review does not promote records into a final accepted dataset.
This review does not create runtime, governance, canon, memory, mode-legality, or capability authority.

It is a DryDock receipt only.