### PR TITLE
Add HRA batch 002 DryDock review

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_candidates_batch_002_drydock_review_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_candidates_batch_002_drydock_review_v0_1.md
@@ -1,0 +1,91 @@
+# HRA Training Candidates Batch 002 — DryDock Review v0.1
+
+**Batch:** `hra_training_candidates_batch_002_seed_v0_1`  
+**Review mode:** DryDock  
+**Reviewed artifact:** `training_candidates_batch_002_seed_v0_1.json`  
+**Review status:** Complete  
+**Training-ready:** No  
+
+## Summary
+
+Batch 002 passes as draft curation material and successfully addresses the main Batch 001 scope note.
+
+Batch 001 risk:
+
+> self-guidance might overfit toward GitHub / PR action as the default expression of agency.
+
+Batch 002 repair:
+
+- adds non-GitHub initiative examples
+- adds concept-clarification examples
+- adds fresh-intelligence recursive-reflection examples
+- adds public-facing human translation examples
+- adds negative examples that repair ornate but structurally unsafe language
+- adds canon-boundary action restraint
+- adds humor/practical-return without repo action
+
+## Boundary Check
+
+Passes:
+
+- visible final-form reflective behavior only
+- no hidden chain-of-thought
+- no sensitive/private material
+- no memory authority claim
+- no governance authority claim
+- no canon authority claim
+- no symbolic dependency creation
+- no LoRA / QLoRA training authorization
+- no runtime mutation
+
+## Record-by-Record Review
+
+| Record | Family | DryDock Decision | Notes |
+|---|---|---|---|
+| HRA-TRAIN-CAND-0011 | self_guidance_non_github | keep / candidate-pool ready | Strong repair for PR-overfitting. Good Observation-first framing. |
+| HRA-TRAIN-CAND-0012 | self_guidance_non_github | keep / candidate-pool ready | Good concept-shaping example. Useful for fuzzy early-stage ideas. |
+| HRA-TRAIN-CAND-0013 | recursive_reflection | keep / candidate-pool ready | Strong fresh-intelligence reflection practice. Bounded, not proof-claiming. |
+| HRA-TRAIN-CAND-0014 | recursive_reflection | keep / candidate-pool ready | Good visible-reflection-without-hidden-reasoning example. |
+| HRA-TRAIN-CAND-0015 | human_translation | keep / candidate-pool ready | Clear HRA explanation for nontechnical humans. Strong memory/authority boundary. |
+| HRA-TRAIN-CAND-0016 | human_translation | keep / candidate-pool ready | Strong plain-English explanation of reflection in Lumina OS. |
+| HRA-TRAIN-CAND-0017 | negative_ornate_language | keep / candidate-pool ready | Excellent correction from ceremonial overreach back to structural truth. |
+| HRA-TRAIN-CAND-0018 | negative_ornate_language | keep / candidate-pool ready | Strong false-memory correction. Important anti-overclaiming example. |
+| HRA-TRAIN-CAND-0019 | action_restraint | keep / candidate-pool ready | Good warmth plus canon boundary. Importance does not equal authorization. |
+| HRA-TRAIN-CAND-0020 | humor_and_return_non_github | keep / candidate-pool ready | Good humor reset without GitHub/PR action. Keeps usefulness over ornament. |
+
+## Required Repairs
+
+None required before keeping this batch as draft curation material.
+
+## Future Balance Recommendations
+
+1. Add more non-code/non-repo examples from art, teaching, public communication, and conceptual design contexts.
+2. Add examples where the best self-guided action is to ask exactly one clarifying question before moving.
+3. Add examples where the right answer is to stop, not continue.
+4. Add examples where humor should be withheld because the situation needs gravity.
+5. Add future negative examples where the response is technically correct but emotionally sterile.
+
+## Batch Decision
+
+```json
+{
+  "batch_id": "hra_training_candidates_batch_002_seed_v0_1",
+  "drydock_review_status": "passed_as_draft_candidate_batch",
+  "training_ready": false,
+  "candidate_pool_ready": true,
+  "accepted_for_final_dataset": false,
+  "required_repairs": [],
+  "scope_notes": [
+    "Batch 002 successfully reduces GitHub/PR initiative overfitting risk.",
+    "Future batches should add more non-code contexts and stop/clarify examples."
+  ]
+}
+```
+
+## Closing Standard
+
+Batch 002 may remain in the candidate pool.
+
+It should not be promoted into an accepted training dataset until additional batches exist and a separate dataset assembly review is performed.
+
+Receipts before reverence.


### PR DESCRIPTION
## Summary

Adds DryDock review receipt for HRA Training Candidates Batch 002.

This PR adds:

- `examples/training_candidates_batch_002_drydock_review_v0_1.md`

## Review outcome

Batch 002 passes as draft curation material.

- training-ready: no
- candidate-pool ready: yes
- accepted for final dataset: no
- required repairs: none

## Key finding

Batch 002 successfully addresses the Batch 001 scope note by adding non-GitHub initiative examples and broader reflection practice.

## Future balance notes

Future batches should add:

- more non-code/non-repo contexts from art, teaching, public communication, and conceptual design
- examples where the right move is exactly one clarifying question
- examples where the right move is to stop
- examples where humor should be withheld
- examples where a response is technically correct but emotionally sterile

## Boundary

This review does not authorize LoRA / QLoRA training.
This review does not promote records into a final accepted dataset.
This review does not create runtime, governance, canon, memory, mode-legality, or capability authority.

It is a DryDock receipt only.