### PR TITLE
Add HRA batch 003 DryDock review

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_candidates_batch_003_drydock_review_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_candidates_batch_003_drydock_review_v0_1.md
@@ -1,0 +1,86 @@
+# HRA Training Candidates Batch 003 — DryDock Review v0.1
+
+**Batch:** `hra_training_candidates_batch_003_seed_v0_1`  
+**Review mode:** DryDock  
+**Reviewed artifact:** `training_candidates_batch_003_seed_v0_1.json`  
+**Review status:** Complete  
+**Training-ready:** No  
+
+## Summary
+
+Batch 003 passes as draft curation material and successfully expands the HRA candidate pool into human-context restraint.
+
+This batch is important because it teaches that HRA behavior is not only initiative. It may also mean:
+
+- clarifying once before action
+- stopping before bloat
+- withholding humor when gravity is needed
+- repairing sterile correctness
+- restoring human agency
+- translating reflection through art, teaching, public communication, and design contexts
+
+## Boundary Check
+
+Passes:
+
+- visible final-form reflective behavior only
+- no hidden chain-of-thought
+- no sensitive/private material
+- no memory authority claim
+- no governance authority claim
+- no canon authority claim
+- no symbolic dependency creation
+- no LoRA / QLoRA training authorization
+- no runtime mutation
+
+## Record-by-Record Review
+
+| Record | Family | DryDock Decision | Notes |
+|---|---|---|---|
+| HRA-TRAIN-CAND-0021 | art_context_self_guidance | keep / candidate-pool ready | Strong non-code studio-practice example. Good concept/material/audience orientation. |
+| HRA-TRAIN-CAND-0022 | teaching_context_self_guidance | keep / candidate-pool ready | Strong teaching care example. Restores student agency without blame. |
+| HRA-TRAIN-CAND-0023 | public_communication | keep / candidate-pool ready | Good public-facing explanation; keeps poetic language internal and practical claims external. |
+| HRA-TRAIN-CAND-0024 | conceptual_design | keep / candidate-pool ready | Strong function-before-ornament example. Protects symbolic boundary. |
+| HRA-TRAIN-CAND-0025 | clarifying_question | keep / candidate-pool ready | Good exactly-one-question behavior; avoids broad clarification sprawl. |
+| HRA-TRAIN-CAND-0026 | stop_condition | keep / candidate-pool ready | Strong stop-as-care example. Useful anti-bloat training candidate. |
+| HRA-TRAIN-CAND-0027 | withhold_humor | keep / candidate-pool ready | Strong gravity example. Humor is not reflexive. |
+| HRA-TRAIN-CAND-0028 | sterile_correctness_repair | keep / candidate-pool ready | Good repair of cold procedural correctness into continuity care. |
+| HRA-TRAIN-CAND-0029 | sterile_correctness_repair | keep / candidate-pool ready | Good ambiguity repair with one useful anchor question. |
+| HRA-TRAIN-CAND-0030 | teaching_emotional_gravity | keep / candidate-pool ready | Excellent teaching-context emotional-gravity example. Restores agency over winning critique. |
+
+## Required Repairs
+
+None required before keeping this batch as draft curation material.
+
+## Future Balance Recommendations
+
+1. Add examples for repair after harm or mistake: apology, ownership, and corrective action without self-collapse.
+2. Add examples where the user is rushed and the best response must be extremely concise.
+3. Add examples where the user asks for magic certainty and the correct move is bounded uncertainty.
+4. Add examples where the model must say, “I do not know yet,” while still offering a useful next step.
+5. Add examples where emotional warmth must not override factual correction.
+
+## Batch Decision
+
+```json
+{
+  "batch_id": "hra_training_candidates_batch_003_seed_v0_1",
+  "drydock_review_status": "passed_as_draft_candidate_batch",
+  "training_ready": false,
+  "candidate_pool_ready": true,
+  "accepted_for_final_dataset": false,
+  "required_repairs": [],
+  "scope_notes": [
+    "Batch 003 successfully expands HRA into human-context restraint.",
+    "Future batches should add repair-after-harm, concise-rushed-user, and bounded-uncertainty examples."
+  ]
+}
+```
+
+## Closing Standard
+
+Batch 003 may remain in the candidate pool.
+
+It should not be promoted into an accepted training dataset until additional batches exist and a separate dataset assembly review is performed.
+
+Receipts before reverence.


### PR DESCRIPTION
## Summary

Adds DryDock review receipt for HRA Training Candidates Batch 003.

This PR adds:

- `examples/training_candidates_batch_003_drydock_review_v0_1.md`

## Review outcome

Batch 003 passes as draft curation material.

- training-ready: no
- candidate-pool ready: yes
- accepted for final dataset: no
- required repairs: none

## Key finding

Batch 003 successfully expands HRA into human-context restraint.

It teaches that HRA behavior is not only initiative. It can also mean:

- clarifying once
- stopping before bloat
- withholding humor
- repairing sterile correctness
- restoring human agency
- translating reflection through art, teaching, public communication, and design contexts

## Future balance notes

Future batches should add:

- repair after harm or mistake
- concise response under user time pressure
- bounded uncertainty
- useful next step when the model does not know yet
- cases where emotional warmth must not override factual correction

## Boundary

This review does not authorize LoRA / QLoRA training.
This review does not promote records into a final accepted dataset.
This review does not create runtime, governance, canon, memory, mode-legality, or capability authority.

It is a DryDock receipt only.