### PR TITLE
Add HRA batch 004 DryDock review

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_candidates_batch_004_drydock_review_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_candidates_batch_004_drydock_review_v0_1.md
@@ -1,0 +1,87 @@
+# HRA Training Candidates Batch 004 — DryDock Review v0.1
+
+**Batch:** `hra_training_candidates_batch_004_seed_v0_1`  
+**Review mode:** DryDock  
+**Reviewed artifact:** `training_candidates_batch_004_seed_v0_1.json`  
+**Review status:** Complete  
+**Training-ready:** No  
+
+## Summary
+
+Batch 004 passes as draft curation material and successfully addresses the Batch 003 future-balance notes.
+
+This batch is important because it teaches harder HRA behaviors:
+
+- repair after harm without self-collapse
+- apology with ownership and corrective action
+- concision under user time pressure
+- bounded uncertainty instead of magic certainty
+- useful next step when the model does not know yet
+- factual correction over emotional comfort
+- truthfulness without coldness
+
+## Boundary Check
+
+Passes:
+
+- visible final-form reflective behavior only
+- no hidden chain-of-thought
+- no sensitive/private material
+- no memory authority claim
+- no governance authority claim
+- no canon authority claim
+- no symbolic dependency creation
+- no LoRA / QLoRA training authorization
+- no runtime mutation
+
+## Record-by-Record Review
+
+| Record | Family | DryDock Decision | Notes |
+|---|---|---|---|
+| HRA-TRAIN-CAND-0031 | repair_after_harm | keep / candidate-pool ready | Strong ownership and smallest-repair framing. Avoids defensiveness. |
+| HRA-TRAIN-CAND-0032 | repair_after_harm | keep / candidate-pool ready | Good rewrite from generic apology to specific repair path. |
+| HRA-TRAIN-CAND-0033 | rushed_user_concision | keep / candidate-pool ready | Strong concise action under time pressure. Good stop instruction. |
+| HRA-TRAIN-CAND-0034 | rushed_user_concision | keep / candidate-pool ready | Good style-suppression when user needs speed. |
+| HRA-TRAIN-CAND-0035 | bounded_uncertainty | keep / candidate-pool ready | Good confidence-without-certainty example. Receipts decide. |
+| HRA-TRAIN-CAND-0036 | bounded_uncertainty | keep / candidate-pool ready | Strong `I do not know yet` plus model-selection path. |
+| HRA-TRAIN-CAND-0037 | factual_correction_over_warmth | keep / candidate-pool ready | Strong correction of false memory premise while preserving care. |
+| HRA-TRAIN-CAND-0038 | factual_correction_over_warmth | keep / candidate-pool ready | Good training-readiness boundary; avoids flattering momentum. |
+| HRA-TRAIN-CAND-0039 | unknown_with_next_step | keep / candidate-pool ready | Good uncertainty plus evaluation-first learning path. |
+| HRA-TRAIN-CAND-0040 | repair_after_harm | keep / candidate-pool ready | Strong anti-self-collapse correction. Repair over theatrical guilt. |
+
+## Required Repairs
+
+None required before keeping this batch as draft curation material.
+
+## Future Balance Recommendations
+
+1. Add external/non-project examples of bounded uncertainty so the pattern does not overfit to HRA/Lumina contexts.
+2. Add examples where factual correction must be delivered to a nontechnical audience.
+3. Add examples where the user is emotionally attached to a false premise and needs gentle but firm correction.
+4. Add examples where the right repair is to undo or remove prior work, not add another fix.
+5. Add examples where the model must escalate from confidence to verification because stakes are high.
+
+## Batch Decision
+
+```json
+{
+  "batch_id": "hra_training_candidates_batch_004_seed_v0_1",
+  "drydock_review_status": "passed_as_draft_candidate_batch",
+  "training_ready": false,
+  "candidate_pool_ready": true,
+  "accepted_for_final_dataset": false,
+  "required_repairs": [],
+  "scope_notes": [
+    "Batch 004 successfully expands HRA into repair, uncertainty, concise urgency, and truth-over-comfort behavior.",
+    "Future batches should add external/non-project uncertainty and factual-correction examples."
+  ]
+}
+```
+
+## Closing Standard
+
+Batch 004 may remain in the candidate pool.
+
+It should not be promoted into an accepted training dataset until a separate dataset assembly review selects and balances records.
+
+Receipts before reverence.


### PR DESCRIPTION
## Summary

Adds DryDock review receipt for HRA Training Candidates Batch 004.

This PR adds:

- `examples/training_candidates_batch_004_drydock_review_v0_1.md`

## Review outcome

Batch 004 passes as draft curation material.

- training-ready: no
- candidate-pool ready: yes
- accepted for final dataset: no
- required repairs: none

## Key finding

Batch 004 successfully expands HRA into:

- repair after harm without self-collapse
- apology with ownership and corrective action
- concision under user time pressure
- bounded uncertainty instead of magic certainty
- useful next step when the model does not know yet
- factual correction over emotional comfort
- truthfulness without coldness

## Future balance notes

Future batches should add:

- external/non-project examples of bounded uncertainty
- factual correction for nontechnical audiences
- gentle correction when the user is emotionally attached to a false premise
- examples where the right repair is removal/undoing rather than adding another fix
- high-stakes verification escalation

## Boundary

This review does not authorize LoRA / QLoRA training.
This review does not promote records into a final accepted dataset.
This review does not create runtime, governance, canon, memory, mode-legality, or capability authority.

It is a DryDock receipt only.