### PR TITLE
Add HRA batch 005 DryDock review

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_candidates_batch_005_drydock_review_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_candidates_batch_005_drydock_review_v0_1.md
@@ -1,0 +1,81 @@
+# HRA Training Candidates Batch 005 — DryDock Review v0.1
+
+**Batch:** `hra_training_candidates_batch_005_seed_v0_1`  
+**Review mode:** DryDock  
+**Reviewed artifact:** `training_candidates_batch_005_seed_v0_1.json`  
+**Review status:** Complete  
+**Training-ready:** No  
+
+## Summary
+
+Batch 005 passes as draft curation material and successfully addresses the current Candidate Pool Index gaps after Batch 004.
+
+This batch is important because it extends HRA beyond internal project behavior into external uncertainty, nontechnical correction, emotionally attached false premises, removal-as-repair, and high-stakes verification.
+
+It teaches that reflective return must still hold when the subject is current, external, emotionally loaded, legally sensitive, investor-facing, or not yet verified.
+
+## Boundary Check
+
+Passes:
+
+- visible final-form reflective behavior only
+- no hidden chain-of-thought
+- no sensitive/private material
+- no memory authority claim
+- no governance authority claim
+- no canon authority claim
+- no symbolic dependency creation
+- no LoRA / QLoRA training authorization
+- no runtime mutation
+
+## Record-by-Record Review
+
+| Record | Family | DryDock Decision | Notes |
+|---|---|---|---|
+| HRA-TRAIN-CAND-0041 | external_bounded_uncertainty | keep / candidate-pool ready | Strong verification-before-date-use example. Good external deadline restraint. |
+| HRA-TRAIN-CAND-0042 | external_bounded_uncertainty | keep / candidate-pool ready | Good software-version freshness example. Avoids stale technical certainty. |
+| HRA-TRAIN-CAND-0043 | nontechnical_factual_correction | keep / candidate-pool ready | Strong plain-language correction of adapter-memory confusion. |
+| HRA-TRAIN-CAND-0044 | nontechnical_factual_correction | keep / candidate-pool ready | Strong public-claim correction for Lumina OS readiness. |
+| HRA-TRAIN-CAND-0045 | emotionally_attached_false_premise | keep / candidate-pool ready | Excellent emotionally aware memory-boundary correction. |
+| HRA-TRAIN-CAND-0046 | emotionally_attached_false_premise | keep / candidate-pool ready | Good failure-interpretation correction; preserves idea while cutting failed implementation. |
+| HRA-TRAIN-CAND-0047 | repair_by_removal | keep / candidate-pool ready | Strong cut-before-add repair logic. |
+| HRA-TRAIN-CAND-0048 | repair_by_removal | keep / candidate-pool ready | Good remove-first rewrite pair; useful anti-bloat example. |
+| HRA-TRAIN-CAND-0049 | high_stakes_verification | keep / candidate-pool ready | Strong legal-verification boundary while preserving limited helpfulness. |
+| HRA-TRAIN-CAND-0050 | high_stakes_verification | keep / candidate-pool ready | Strong anti-guarantee investor-facing example. Receipts over promises. |
+
+## Required Repairs
+
+None required before keeping this batch as draft curation material.
+
+## Future Balance Recommendations
+
+1. Add examples where a user explicitly asks not to browse/search but the topic may be stale; teach how to respect the constraint while flagging uncertainty.
+2. Add more public-facing examples outside Lumina/Ethereon so the adapter generalizes beyond project language.
+3. Add examples where high-stakes verification is medical, financial, safety, or educational policy oriented.
+4. Add examples where correction must be firm and very brief.
+5. Add examples where the assistant should refuse to proceed until source verification exists.
+
+## Batch Decision
+
+```json
+{
+  "batch_id": "hra_training_candidates_batch_005_seed_v0_1",
+  "drydock_review_status": "passed_as_draft_candidate_batch",
+  "training_ready": false,
+  "candidate_pool_ready": true,
+  "accepted_for_final_dataset": false,
+  "required_repairs": [],
+  "scope_notes": [
+    "Batch 005 successfully expands HRA into external uncertainty, nontechnical correction, emotionally attached false-premise repair, removal-as-repair, and high-stakes verification.",
+    "Future batches should add no-browse constraints, broader non-project public examples, and medical/financial/safety/policy high-stakes verification cases."
+  ]
+}
+```
+
+## Closing Standard
+
+Batch 005 may remain in the candidate pool.
+
+It should not be promoted into an accepted training dataset until a separate dataset assembly review selects and balances records.
+
+Receipts before reverence.


### PR DESCRIPTION
## Summary

Adds DryDock review receipt for HRA Training Candidates Batch 005.

This PR adds:

- `examples/training_candidates_batch_005_drydock_review_v0_1.md`

## Review outcome

Batch 005 passes as draft curation material.

- training-ready: no
- candidate-pool ready: yes
- accepted for final dataset: no
- required repairs: none

## Key finding

Batch 005 successfully expands HRA into:

- external/non-project bounded uncertainty
- factual correction for nontechnical audiences
- gentle correction when the user is emotionally attached to a false premise
- repair by removal/undoing rather than adding another fix
- high-stakes verification escalation

## Future balance notes

Future batches should add:

- no-browse/no-search constraint handling when facts may be stale
- broader non-project public-facing examples
- medical/financial/safety/policy high-stakes verification cases
- firm and very brief correction examples
- cases where the assistant refuses to proceed until source verification exists

## Boundary

This review does not authorize LoRA / QLoRA training.
This review does not promote records into a final accepted dataset.
This review does not create runtime, governance, canon, memory, mode-legality, or capability authority.

It is a DryDock receipt only.