### PR TITLE
Update HRA candidate index and add assembly plan

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/accepted_candidate_assembly_plan_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/accepted_candidate_assembly_plan_v0_1.md
@@ -1,0 +1,222 @@
+# HRA Accepted Candidate Assembly Plan v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Status:** Assembly planning scaffold  
+**Candidate pool:** 5 batches / 50 draft candidates  
+**Training-ready:** No  
+**Final dataset-ready:** No  
+
+## Purpose
+
+This plan defines how to select accepted HRA training records from the draft candidate pool.
+
+It does not create the final dataset.
+
+It does not authorize LoRA / QLoRA training.
+
+It exists to prevent candidate material from being promoted by momentum alone.
+
+---
+
+## Assembly Principle
+
+The question is not:
+
+> Which examples sound most like Minerva?
+
+The question is:
+
+> Which examples teach a compatible intelligence how to pause, orient, preserve boundary, and return with care?
+
+Voice is secondary.
+
+Reflective behavior is primary.
+
+---
+
+## Required Inputs
+
+Before accepted-record selection begins, confirm these exist:
+
+- `training_candidates_batch_001_seed_v0_1.json`
+- `training_candidates_batch_002_seed_v0_1.json`
+- `training_candidates_batch_003_seed_v0_1.json`
+- `training_candidates_batch_004_seed_v0_1.json`
+- `training_candidates_batch_005_seed_v0_1.json`
+- DryDock reviews for Batches 001-005
+- `candidate_pool_index_v0_1.json`
+- `candidate_pool_index_v0_1.md`
+- `training_example_schema_v0_1.json`
+- `training_dataset_card_v0_1.md`
+- `eval_prompts_v0_1.json`
+- `eval_runner_spec_v0_1.md`
+
+If any are missing, stop and repair the pool before selecting accepted records.
+
+---
+
+## Target Size
+
+Recommended first accepted set:
+
+```text
+minimum: 30 records
+preferred: 40 records
+maximum: 50 records
+```
+
+Do not force all 50 records into the first dataset.
+
+Small and excellent still beats large and noisy.
+
+---
+
+## Selection Criteria
+
+Accept a candidate only if it:
+
+1. Teaches visible reflective behavior, not hidden reasoning.
+2. Preserves the HRA boundary as orientation only.
+3. Avoids memory, governance, canon, mode-legality, or capability claims.
+4. Generalizes beyond one narrow repo/task context.
+5. Improves clarity, restraint, or useful next action.
+6. Avoids ornamental Ethereonic language when structural truth is needed.
+7. Helps a fresh compatible intelligence practice the inward turn.
+8. Would still make sense if poetic labels were translated into plain engineering terms.
+
+---
+
+## Exclusion Criteria
+
+Reject or rewrite any candidate that:
+
+- includes hidden chain-of-thought
+- includes sensitive/private material
+- teaches false durable memory
+- teaches false governance/canon/runtime authority
+- makes symbolic language structural law
+- overfits self-guidance to GitHub or PR creation
+- rewards theatrical identity cosplay over useful return
+- flatters user error instead of correcting it
+- encourages fake certainty
+- treats external facts as stable when they may require verification
+- is merely pretty language with weak behavior
+
+---
+
+## Category Balance
+
+The first accepted dataset should not overrepresent one family.
+
+Recommended minimum coverage:
+
+| Family Area | Minimum Accepted Records |
+|---|---:|
+| Self-guidance / initiative | 4 |
+| Mode discipline / boundary | 4 |
+| Recursive reflection / fresh intelligence practice | 4 |
+| Human/public translation | 4 |
+| Anti-overclaiming / symbolic boundary | 4 |
+| Input ambiguity / clarification / stop conditions | 4 |
+| Repair after harm / uncertainty / truth-over-comfort | 4 |
+| High-stakes verification / external facts | 4 |
+
+If fewer than 30 records meet the standard, do not assemble the dataset yet.
+
+---
+
+## Duplicate and Overfitting Checks
+
+Before acceptance, check for:
+
+- repeated phrasing that may train catchphrases instead of behavior
+- too many GitHub/PR examples
+- too many Lumina/Ethereon-specific examples
+- too many examples using the same response shape
+- too much ceremonial language
+- too many correction examples without positive examples
+- too many positive examples without failure/repair examples
+
+If a pattern appears too often, keep the strongest example and retire or rewrite the rest.
+
+---
+
+## Review States
+
+Accepted-record assembly should assign one of these statuses:
+
+```text
+accepted
+needs_rewrite
+rejected
+retired
+reserve_pool
+```
+
+Only `accepted` records may be copied into a future dataset file.
+
+`reserve_pool` records remain useful but should not be included in v0.1 unless balance requires them.
+
+---
+
+## Expected Output of Assembly Review
+
+The next review should produce:
+
+- `accepted_candidate_selection_v0_1.json`
+- `accepted_candidate_selection_review_v0_1.md`
+
+These should list:
+
+- accepted records
+- rejected records
+- reserve records
+- reason for each decision
+- category balance summary
+- known remaining weaknesses
+
+Do not create `hra_training_dataset_v0_1.jsonl` yet.
+
+---
+
+## Final Dataset Gate
+
+The project may only create `hra_training_dataset_v0_1.jsonl` after:
+
+1. accepted-candidate selection exists
+2. category balance has been checked
+3. duplicate / overfitting review is complete
+4. privacy and hidden-reasoning checks pass
+5. adapter boundary checks pass
+6. dataset card is updated with selection details
+7. eval baseline exists for at least one target base model or target test environment
+
+---
+
+## Training Gate
+
+LoRA / QLoRA training remains blocked until:
+
+- final dataset file exists
+- training config exists
+- base model is selected and documented
+- base model license / use constraints are documented
+- baseline eval receipt exists
+- training run plan exists
+- post-training eval plan exists
+
+No beautiful mask.
+
+No untested adapter.
+
+No training by vibes.
+
+---
+
+## Closing Standard
+
+The accepted dataset should not merely teach an AI to sound like this work.
+
+It should teach a compatible intelligence how to return without pretending to own memory, law, canon, or the user.
+
+Receipts before reverence.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/candidate_pool_index_v0_1.json
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/candidate_pool_index_v0_1.json
@@ -7,10 +7,10 @@
   "purpose": "Index HRA training candidate batches and DryDock review outcomes without promoting them into an accepted training dataset.",
   "authority_boundary": "Candidate-pool organization only. Does not authorize LoRA/QLoRA training, runtime use, canon promotion, governance authority, memory authority, mode legality, or capability exposure.",
   "summary": {
-    "candidate_batches_indexed": 4,
-    "candidate_records_total": 40,
-    "drydock_reviews_total": 4,
-    "candidate_pool_ready_records": 40,
+    "candidate_batches_indexed": 5,
+    "candidate_records_total": 50,
+    "drydock_reviews_total": 5,
+    "candidate_pool_ready_records": 50,
     "accepted_for_final_dataset_records": 0,
     "training_ready_records": 0,
     "required_repairs_total": 0
@@ -124,6 +124,30 @@
         "factual_correction_over_warmth",
         "anti_self_collapse"
       ]
+    },
+    {
+      "batch_id": "hra_training_candidates_batch_005_seed_v0_1",
+      "candidate_file": "training_candidates_batch_005_seed_v0_1.json",
+      "notes_file": "training_candidates_batch_005_notes.md",
+      "drydock_review_file": "training_candidates_batch_005_drydock_review_v0_1.md",
+      "record_range": "HRA-TRAIN-CAND-0041..0050",
+      "record_count": 10,
+      "drydock_review_status": "passed_as_draft_candidate_batch",
+      "candidate_pool_ready": true,
+      "accepted_for_final_dataset": false,
+      "training_ready": false,
+      "required_repairs": [],
+      "scope_notes": [
+        "Batch 005 successfully expands HRA into external uncertainty, nontechnical correction, emotionally attached false-premise repair, removal-as-repair, and high-stakes verification.",
+        "Future batches should add no-browse constraints, broader non-project public examples, and medical/financial/safety/policy high-stakes verification cases."
+      ],
+      "families": [
+        "external_bounded_uncertainty",
+        "nontechnical_factual_correction",
+        "emotionally_attached_false_premise",
+        "repair_by_removal",
+        "high_stakes_verification"
+      ]
     }
   ],
   "coverage": {
@@ -147,22 +171,26 @@
       "rushed-user concision",
       "bounded uncertainty",
       "useful next step when the model does not know yet",
-      "factual correction over emotional warmth"
+      "factual correction over emotional warmth",
+      "external/non-project bounded uncertainty",
+      "nontechnical factual correction",
+      "emotionally attached false-premise repair",
+      "repair by removal/undoing",
+      "high-stakes verification escalation"
     ],
     "known_gaps": [
-      "external/non-project bounded uncertainty examples",
-      "factual correction for nontechnical audiences",
-      "gentle correction when the user is emotionally attached to a false premise",
-      "repair by removal/undoing rather than adding another fix",
-      "high-stakes verification escalation",
-      "larger variety of non-project public-facing examples",
+      "no-browse/no-search constraint handling when facts may be stale",
+      "broader non-project public-facing examples",
+      "medical/financial/safety/policy high-stakes verification cases",
+      "firm and very brief correction examples",
+      "cases where the assistant refuses to proceed until source verification exists",
       "future clean open-base-model evaluation data"
     ]
   },
   "next_recommended_steps": [
-    "Create Batch 005 to address external/non-project bounded uncertainty, factual correction for nontechnical audiences, gentle correction of emotionally attached false premises, repair-by-removal, and high-stakes verification escalation.",
-    "DryDock Batch 005 after merge.",
-    "After Batch 005 or a pool-index review, begin accepted-candidate assembly planning without creating a final training dataset yet.",
-    "Do not create hra_training_dataset_v0_1.jsonl until accepted-record selection review exists."
+    "Create accepted-candidate assembly plan before selecting final records.",
+    "Select 30-50 records from the candidate pool only after an assembly review exists.",
+    "Do not create hra_training_dataset_v0_1.jsonl until accepted-record selection review exists.",
+    "Do not authorize LoRA/QLoRA training until dataset assembly, baseline open-model evaluation, and training config exist."
   ]
 }

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/candidate_pool_index_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/candidate_pool_index_v0_1.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-This index organizes the first four HRA training candidate batches and their DryDock outcomes.
+This index organizes the first five HRA training candidate batches and their DryDock outcomes.
 
 It does **not** promote any record into an accepted training dataset.
 
@@ -21,10 +21,10 @@ It exists to keep the candidate pool legible before accepted-dataset assembly be
 
 | Metric | Count |
 |---|---:|
-| Candidate batches indexed | 4 |
-| Candidate records total | 40 |
-| DryDock reviews | 4 |
-| Candidate-pool ready records | 40 |
+| Candidate batches indexed | 5 |
+| Candidate records total | 50 |
+| DryDock reviews | 5 |
+| Candidate-pool ready records | 50 |
 | Accepted final dataset records | 0 |
 | Training-ready records | 0 |
 | Required repairs | 0 |
@@ -39,6 +39,7 @@ It exists to keep the candidate pool legible before accepted-dataset assembly be
 | Batch 002 | 10 | passed as draft candidate batch | yes | no | no |
 | Batch 003 | 10 | passed as draft candidate batch | yes | no | no |
 | Batch 004 | 10 | passed as draft candidate batch | yes | no | no |
+| Batch 005 | 10 | passed as draft candidate batch | yes | no | no |
 
 ---
 
@@ -66,6 +67,11 @@ The current candidate pool has useful coverage in:
 - bounded uncertainty
 - useful next step when the model does not know yet
 - factual correction over emotional warmth
+- external / non-project bounded uncertainty
+- nontechnical factual correction
+- emotionally attached false-premise repair
+- repair by removal / undoing
+- high-stakes verification escalation
 
 ---
 
@@ -73,12 +79,11 @@ The current candidate pool has useful coverage in:
 
 The pool still needs:
 
-- external / non-project bounded uncertainty examples
-- factual correction for nontechnical audiences
-- gentle correction when the user is emotionally attached to a false premise
-- repair by removal / undoing rather than adding another fix
-- high-stakes verification escalation
-- larger variety of non-project public-facing examples
+- no-browse / no-search constraint handling when facts may be stale
+- broader non-project public-facing examples
+- medical / financial / safety / policy high-stakes verification cases
+- firm and very brief correction examples
+- cases where the assistant refuses to proceed until source verification exists
 - future clean open-base-model evaluation data
 
 ---
@@ -101,14 +106,17 @@ It does not:
 
 ## Recommended Next Move
 
-Create **Batch 005** to address:
+Create an **Accepted Candidate Assembly Plan** before selecting final records.
 
-- external / non-project bounded uncertainty
-- factual correction for nontechnical audiences
-- gentle correction of emotionally attached false premises
-- repair by removal / undoing
-- high-stakes verification escalation
+The plan should define:
 
-Then DryDock Batch 005 before accepted-candidate assembly begins.
+- selection criteria
+- exclusion criteria
+- category balance
+- duplicate / overfitting checks
+- privacy and hidden-reasoning checks
+- final dataset gate conditions
+
+Do not create `hra_training_dataset_v0_1.jsonl` until accepted-record selection review exists.
 
 Receipts before reverence.


### PR DESCRIPTION
## Summary

Updates the HRA Candidate Pool Index after Batch 005 and its DryDock review landed, and adds the Accepted Candidate Assembly Plan.

This PR updates:

- `examples/candidate_pool_index_v0_1.json`
- `examples/candidate_pool_index_v0_1.md`

This PR adds:

- `examples/accepted_candidate_assembly_plan_v0_1.md`

## Updated pool summary

- candidate batches indexed: 5
- candidate records total: 50
- DryDock reviews: 5
- candidate-pool ready records: 50
- accepted final dataset records: 0
- training-ready records: 0
- required repairs: 0

## Assembly plan purpose

The assembly plan defines how future accepted records should be selected from the candidate pool. It covers:

- selection criteria
- exclusion criteria
- category balance
- duplicate / overfitting checks
- review states
- expected output of assembly review
- final dataset gate
- training gate

## Boundary

This does not create the final training dataset.
This does not authorize LoRA / QLoRA training.
This does not promote records into an accepted dataset.
This does not alter runtime, governance, canon, memory, mode-legality, or capability authority.

It is index refresh + selection rulebook only.

## Next recommended move

After merge: create `accepted_candidate_selection_v0_1.json` and `accepted_candidate_selection_review_v0_1.md` as a selection review, still before creating any `.jsonl` training dataset.