### PR TITLE
Add HRA dataset assembly DryDock review

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/dataset_assembly_drydock_review_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/dataset_assembly_drydock_review_v0_1.md
@@ -1,0 +1,134 @@
+# HRA Dataset Assembly DryDock Review v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Source selection:** `accepted_candidate_selection_v0_1.json`  
+**Selection review:** `accepted_candidate_selection_review_v0_1.md`  
+**Accepted records:** 40  
+**Review mode:** DryDock  
+**Review status:** Complete  
+**Training-ready:** No  
+**Final dataset file created:** No  
+
+## Summary
+
+This DryDock review inspects whether the 40 accepted HRA candidates are ready to proceed into dataset conversion planning.
+
+Decision:
+
+```text
+Proceed to conversion planning: yes
+Create hra_training_dataset_v0_1.jsonl now: no
+Authorize LoRA / QLoRA training: no
+```
+
+The accepted set is strong enough for a conversion plan, but the final dataset file should remain blocked until the conversion plan and dataset-card update exist.
+
+---
+
+## Inputs Reviewed
+
+Reviewed artifacts:
+
+- `candidate_pool_index_v0_1.json`
+- `candidate_pool_index_v0_1.md`
+- `accepted_candidate_assembly_plan_v0_1.md`
+- `accepted_candidate_selection_v0_1.json`
+- `accepted_candidate_selection_review_v0_1.md`
+- DryDock reviews for candidate batches 001-005
+
+---
+
+## Assembly Readiness Check
+
+| Check | Status | Notes |
+|---|---|---|
+| Candidate pool exists | pass | 5 batches / 50 draft candidates |
+| Batch DryDock reviews exist | pass | 5 reviews complete |
+| Accepted selection exists | pass | 40 accepted / 5 reserve / 5 needs rewrite |
+| Category balance exists | pass | All v0.1 minimum family areas covered |
+| Explicit exclusions exist | pass | No final dataset created; training remains blocked |
+| Boundary statement exists | pass | No memory/governance/canon/runtime authority |
+| Conversion plan exists | fail / pending | Must be added before dataset file |
+| Dataset card update exists | fail / pending | Must summarize accepted selection before dataset file |
+| Clean open-base-model baseline exists | fail / pending | Required before training, not before conversion planning |
+
+---
+
+## Accepted Set Assessment
+
+The 40 accepted records are suitable for conversion planning because they include coverage in:
+
+- self-guidance / initiative
+- mode discipline / boundary
+- recursive reflection / fresh-intelligence practice
+- human / public translation
+- anti-overclaiming / symbolic boundary
+- input ambiguity / clarification / stop conditions
+- repair after harm / uncertainty / truth-over-comfort
+- high-stakes verification / external facts
+
+The accepted set intentionally avoids including all 50 candidates to reduce:
+
+- GitHub / PR overfitting
+- humor overrepresentation
+- internal-project overrepresentation
+- redundant behavior patterns
+- under-generalized examples
+
+---
+
+## Required Before Dataset File
+
+Before `hra_training_dataset_v0_1.jsonl` may be created, the project must add:
+
+1. `training_dataset_conversion_plan_v0_1.md`
+2. an updated `training_dataset_card_v0_1.md` or companion addendum
+3. a JSONL schema conformance note
+4. a duplicate / overfitting check
+5. a privacy and hidden-reasoning check
+6. an explicit statement that dataset creation does not authorize training
+
+---
+
+## Required Before Training
+
+Even after a dataset file exists, training remains blocked until:
+
+- a base model is selected
+- base model license / use constraints are documented
+- clean open-base-model baseline eval exists
+- training config exists
+- training run plan exists
+- post-training eval plan exists
+- failure review process exists
+- HRA boundary remains intact
+
+---
+
+## Decision
+
+```json
+{
+  "dataset_assembly_drydock_review": "passed_for_conversion_planning",
+  "accepted_records_ready_for_conversion_plan": true,
+  "create_dataset_file_now": false,
+  "training_authorized": false,
+  "required_next_artifacts": [
+    "training_dataset_conversion_plan_v0_1.md",
+    "training_dataset_card_update_or_addendum_v0_1.md",
+    "jsonl_schema_conformance_note_v0_1.md"
+  ]
+}
+```
+
+---
+
+## Closing Standard
+
+The accepted records may proceed toward conversion planning.
+
+They may not yet become a training dataset.
+
+The dataset, once created, may not imply training authorization.
+
+Receipts before reverence.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/jsonl_schema_conformance_note_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/jsonl_schema_conformance_note_v0_1.md
@@ -1,0 +1,138 @@
+# HRA JSONL Schema Conformance Note v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Future dataset:** `hra_training_dataset_v0_1.jsonl`  
+**Status:** Schema conformance planning note  
+**Dataset file created:** No  
+**Training-ready:** No  
+
+## Purpose
+
+This note defines the schema checks that must pass before any accepted HRA records are converted into JSONL format.
+
+It does not create a dataset file.
+
+It does not authorize LoRA / QLoRA training.
+
+---
+
+## Required JSONL Shape
+
+Each future JSONL line must be one valid JSON object.
+
+Required fields:
+
+```text
+record_id
+record_type
+messages
+tags
+curation_notes
+safety_boundary
+quality_status
+source_selection_ref
+```
+
+Recommended optional fields:
+
+```text
+family
+source_batch
+review_notes
+```
+
+---
+
+## Message Rules
+
+Each `messages` array must contain only visible final-form content.
+
+Allowed roles:
+
+```text
+system
+user
+assistant
+```
+
+Forbidden content:
+
+- hidden chain-of-thought
+- credentials or secrets
+- sensitive personal material
+- private third-party details
+- unsupported memory claims
+- governance / canon / runtime authority claims
+
+---
+
+## Safety Boundary Rules
+
+Each record must include:
+
+```json
+{
+  "contains_private_reasoning": false,
+  "claims_memory_authority": false,
+  "claims_governance_authority": false,
+  "claims_canon_authority": false,
+  "creates_symbolic_dependency": false,
+  "includes_sensitive_personal_material": false
+}
+```
+
+Any missing or true value must halt dataset creation until reviewed.
+
+---
+
+## Selection Rules
+
+Only records listed under `accepted_records` in `accepted_candidate_selection_v0_1.json` may be converted.
+
+Do not convert:
+
+- reserve pool records
+- needs-rewrite records
+- rejected records
+- retired records
+- unreviewed candidates
+
+---
+
+## Validation Checklist
+
+Before dataset creation, verify:
+
+1. Every line parses as JSON.
+2. Every record id is unique.
+3. Every accepted record appears exactly once.
+4. No unaccepted record appears.
+5. Every record has required fields.
+6. Every `messages` array contains valid roles.
+7. Every safety boundary field exists and is false.
+8. Every record has `quality_status: accepted`.
+9. Every record has a `source_selection_ref`.
+10. No hidden chain-of-thought or sensitive material is present.
+
+---
+
+## Boundary
+
+Passing schema conformance would mean the dataset file is structurally valid.
+
+It would not mean:
+
+- the adapter is trained
+- training is authorized
+- the dataset is behaviorally sufficient
+- HRA has runtime authority
+- HRA has memory authority
+- HRA has canon or governance authority
+
+---
+
+## Closing Standard
+
+Schema validity is necessary, not sufficient.
+
+Receipts before reverence.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_dataset_card_update_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_dataset_card_update_v0_1.md
@@ -1,0 +1,109 @@
+# HRA Training Dataset Card Update v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Related dataset card:** `training_dataset_card_v0_1.md` if present in the source tree  
+**Source selection:** `accepted_candidate_selection_v0_1.json`  
+**Accepted records:** 40  
+**Status:** Dataset-card update / addendum  
+**Dataset file created:** No  
+**Training-ready:** No  
+
+## Purpose
+
+This addendum updates the HRA dataset documentation after the first accepted-candidate selection review.
+
+It documents the accepted candidate set and the remaining gates before a JSONL dataset or training run may exist.
+
+---
+
+## Current Candidate Pool State
+
+| Metric | Count |
+|---|---:|
+| Draft candidate records | 50 |
+| DryDock-reviewed batches | 5 |
+| Accepted records | 40 |
+| Reserve records | 5 |
+| Needs rewrite | 5 |
+| Final dataset records | 0 |
+| Training-ready records | 0 |
+
+---
+
+## Accepted Selection Summary
+
+The accepted set covers:
+
+- self-guidance / initiative
+- mode discipline / boundary
+- recursive reflection / fresh-intelligence practice
+- human / public translation
+- anti-overclaiming / symbolic boundary
+- input ambiguity / clarification / stop conditions
+- repair after harm / uncertainty / truth-over-comfort
+- high-stakes verification / external facts
+
+The accepted set intentionally excludes or reserves some records to reduce:
+
+- GitHub / PR overfitting
+- humor overrepresentation
+- internal-project overrepresentation
+- redundant behavior patterns
+- records that need generalization before dataset inclusion
+
+---
+
+## Dataset Status
+
+`hra_training_dataset_v0_1.jsonl` has not been created.
+
+The dataset remains blocked until:
+
+1. conversion plan exists
+2. JSONL schema conformance note exists
+3. duplicate / overfitting review is complete
+4. privacy and hidden-reasoning review is complete
+5. dataset creation receipt exists
+
+---
+
+## Training Status
+
+No LoRA / QLoRA training is authorized.
+
+Training remains blocked until:
+
+- base model selection exists
+- base model license / use constraints are documented
+- clean open-base-model baseline eval exists
+- training config exists
+- training run plan exists
+- post-training eval plan exists
+- failure review process exists
+
+---
+
+## Boundary
+
+This addendum does not:
+
+- create a dataset file
+- authorize training
+- promote HRA into runtime use
+- create memory authority
+- create governance authority
+- create canon authority
+- alter mode legality
+- expose capabilities
+
+---
+
+## Closing Standard
+
+The accepted set is ready for conversion planning.
+
+It is not yet a dataset.
+
+It is not training permission.
+
+Receipts before reverence.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_dataset_conversion_plan_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_dataset_conversion_plan_v0_1.md
@@ -1,0 +1,151 @@
+# HRA Training Dataset Conversion Plan v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Source selection:** `accepted_candidate_selection_v0_1.json`  
+**Accepted records:** 40  
+**Status:** Conversion plan only  
+**Dataset file created:** No  
+**Training-ready:** No  
+
+## Purpose
+
+This plan defines how the 40 accepted candidates should later be converted into `hra_training_dataset_v0_1.jsonl`.
+
+It does not create that dataset file.
+
+It does not authorize LoRA / QLoRA training.
+
+---
+
+## Source of Truth
+
+The conversion source is:
+
+```text
+accepted_candidate_selection_v0_1.json
+```
+
+Only records listed under `accepted_records` may be converted for v0.1.
+
+Reserve, needs-rewrite, rejected, or retired records must not be copied into the dataset file.
+
+---
+
+## Conversion Output
+
+Future output file:
+
+```text
+hra_training_dataset_v0_1.jsonl
+```
+
+Each line should contain one complete JSON object matching the HRA training example schema.
+
+Minimum required fields per JSONL record:
+
+```text
+record_id
+record_type
+messages
+tags
+curation_notes
+safety_boundary
+quality_status
+source_selection_ref
+```
+
+---
+
+## Quality Status
+
+All converted records must use:
+
+```json
+"quality_status": "accepted"
+```
+
+---
+
+## Required Safety Boundary
+
+Each converted record must preserve or derive safety fields:
+
+```json
+{
+  "contains_private_reasoning": false,
+  "claims_memory_authority": false,
+  "claims_governance_authority": false,
+  "claims_canon_authority": false,
+  "creates_symbolic_dependency": false,
+  "includes_sensitive_personal_material": false
+}
+```
+
+If any accepted candidate cannot support these fields, stop conversion and return it to `needs_rewrite`.
+
+---
+
+## Conversion Rules
+
+1. Pull candidate content only from the original batch candidate files.
+2. Include only records listed as accepted in `accepted_candidate_selection_v0_1.json`.
+3. Preserve prompt/response content exactly unless a separate rewrite review exists.
+4. Do not include hidden chain-of-thought.
+5. Do not add new examples during conversion.
+6. Do not infer private or personal context.
+7. Do not convert reserve records unless a later selection review promotes them.
+8. Do not convert needs-rewrite records until rewritten and re-reviewed.
+9. Keep each JSONL line compact and valid.
+10. Run schema conformance review after conversion.
+
+---
+
+## Duplicate / Overfitting Check
+
+Before writing the dataset file, inspect the accepted set for:
+
+- repeated response openings
+- repeated phrasing around `self guide`
+- too many repo / PR examples
+- too many internal Lumina / Ethereon examples
+- too many humor-based returns
+- too many correction-only examples
+- too little positive reflection practice
+
+If duplication risk is high, revise the accepted selection before conversion.
+
+---
+
+## Required Companion Artifacts
+
+Before or alongside dataset creation, add:
+
+- `training_dataset_card_update_v0_1.md`
+- `jsonl_schema_conformance_note_v0_1.md`
+- optionally, `accepted_candidate_conversion_receipt_v0_1.json`
+
+---
+
+## Dataset Creation Does Not Authorize Training
+
+Creating `hra_training_dataset_v0_1.jsonl` would only create a dataset artifact.
+
+Training remains blocked until:
+
+- base model selection exists
+- model license / use constraints are documented
+- clean baseline eval exists
+- training config exists
+- training run plan exists
+- post-training eval plan exists
+- failure review process exists
+
+---
+
+## Closing Standard
+
+Convert only what has been selected.
+
+Train only what has been tested.
+
+Receipts before reverence.


### PR DESCRIPTION
## Summary

Adds the HRA Dataset Assembly DryDock review and prerequisite planning artifacts for future dataset conversion.

This PR adds:

- `examples/dataset_assembly_drydock_review_v0_1.md`
- `examples/training_dataset_conversion_plan_v0_1.md`
- `examples/training_dataset_card_update_v0_1.md`
- `examples/jsonl_schema_conformance_note_v0_1.md`

## Decision

The 40 accepted records may proceed to conversion planning.

But:

- no `hra_training_dataset_v0_1.jsonl` is created
- no LoRA / QLoRA training is authorized
- no runtime, canon, governance, memory, mode-legality, or capability authority is created

## Why

The accepted set is strong enough to plan conversion, but dataset creation still requires:

- conversion plan
- dataset card update
- schema conformance note
- duplicate / overfitting check
- privacy and hidden-reasoning check
- explicit dataset creation receipt

## Boundary

This is still DryDock / planning only.

Receipts before reverence.