### PR TITLE
Add HRA final preflight checks

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/dataset_creation_receipt_plan_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/dataset_creation_receipt_plan_v0_1.md
@@ -1,0 +1,93 @@
+# HRA Dataset Creation Receipt Plan v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Future dataset:** `hra_training_dataset_v0_1.jsonl`  
+**Status:** Receipt plan only  
+**Dataset file created:** No  
+**Training-ready:** No  
+
+## Purpose
+
+This plan defines the receipt that must exist when `hra_training_dataset_v0_1.jsonl` is eventually created.
+
+It does not create the dataset file.
+
+It does not authorize LoRA / QLoRA training.
+
+---
+
+## Required Inputs Before Dataset Creation
+
+Before dataset creation, confirm these exist on `main`:
+
+- `accepted_candidate_selection_v0_1.json`
+- `accepted_candidate_selection_review_v0_1.md`
+- `dataset_assembly_drydock_review_v0_1.md`
+- `training_dataset_conversion_plan_v0_1.md`
+- `training_dataset_card_update_v0_1.md`
+- `jsonl_schema_conformance_note_v0_1.md`
+- `duplicate_overfitting_check_v0_1.md`
+- `privacy_hidden_reasoning_check_v0_1.md`
+
+If any are missing, stop.
+
+---
+
+## Required Receipt Fields
+
+When the dataset is created, add a receipt with these fields:
+
+```json
+{
+  "receipt_id": "hra_training_dataset_creation_receipt_v0_1",
+  "dataset_file": "hra_training_dataset_v0_1.jsonl",
+  "source_selection": "accepted_candidate_selection_v0_1.json",
+  "accepted_records_expected": 40,
+  "accepted_records_written": 40,
+  "reserve_records_written": 0,
+  "needs_rewrite_records_written": 0,
+  "rejected_records_written": 0,
+  "jsonl_parse_passed": true,
+  "schema_conformance_passed": true,
+  "privacy_hidden_reasoning_check_passed": true,
+  "duplicate_overfitting_check_passed": true,
+  "training_authorized": false
+}
+```
+
+---
+
+## Receipt Review Questions
+
+Before accepting the dataset creation receipt, ask:
+
+1. Does the dataset contain exactly the accepted records?
+2. Does every line parse as JSON?
+3. Does every record include required fields?
+4. Does every record keep `quality_status: accepted`?
+5. Does every record include `source_selection_ref`?
+6. Does every safety boundary field exist and remain false?
+7. Are reserve / needs-rewrite / rejected / retired records excluded?
+8. Does the receipt clearly state that training remains unauthorized?
+
+---
+
+## Dataset Creation Is Not Training Authorization
+
+The creation receipt must explicitly say:
+
+```text
+This dataset artifact does not authorize LoRA / QLoRA training.
+```
+
+Training remains blocked until model selection, baseline evaluation, training config, run plan, and post-training eval plan exist.
+
+---
+
+## Closing Standard
+
+No dataset without receipt.
+
+No training by implication.
+
+Receipts before reverence.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/duplicate_overfitting_check_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/duplicate_overfitting_check_v0_1.md
@@ -1,0 +1,112 @@
+# HRA Duplicate / Overfitting Check v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Source selection:** `accepted_candidate_selection_v0_1.json`  
+**Accepted records reviewed:** 40  
+**Review status:** Complete  
+**Dataset file created:** No  
+**Training-ready:** No  
+
+## Purpose
+
+This check reviews the 40 accepted HRA candidate records for duplication, overrepresentation, and behavior-pattern overfitting risk before any JSONL dataset file exists.
+
+---
+
+## Summary Decision
+
+```text
+Proceed toward dataset conversion receipt: yes, with caution
+Create JSONL dataset immediately: no
+Authorize LoRA / QLoRA training: no
+```
+
+The accepted set is strong enough to continue toward dataset creation planning, but future batches should still broaden non-project, high-stakes, and no-browse cases.
+
+---
+
+## Overfitting Risk Review
+
+| Risk Area | Status | Notes |
+|---|---|---|
+| GitHub / PR overfitting | controlled | Several repo-shaped records were moved to needs-rewrite or reserve. |
+| Humor overfitting | controlled | Humor records were mostly reserved; accepted set includes gravity and humor-withholding. |
+| Internal project overfitting | moderate | Still present, but balanced by art, teaching, public, external, legal, and investor examples. |
+| Ceremonial language overfitting | controlled | Negative ornate-language examples correct symbolism back into structure. |
+| False memory overfitting | controlled | Multiple records explicitly correct memory claims. |
+| Generic apology overfitting | controlled | Repair records emphasize specific ownership and bounded correction. |
+| Correction-only overfitting | moderate | The set includes many correction examples; balanced by translation, reflection, and self-guidance records. |
+| Repeated response openings | low/moderate | Some records share stance-first openings; acceptable for v0.1 but should diversify later. |
+
+---
+
+## Duplicate Pattern Notes
+
+The accepted set repeats several useful motifs:
+
+- verify before claiming
+- boundary before action
+- reflection as stance, not proof
+- memory requires stored accessible context
+- receipts before reverence
+- stop before bloat
+
+These are intentional invariants, not accidental duplicates.
+
+However, future accepted sets should avoid turning them into rigid catchphrases.
+
+---
+
+## Records Already Controlled by Selection
+
+The selection review already reduced overfitting risk by moving these records out of the accepted set:
+
+| Record | Status | Overfitting Concern |
+|---|---|---|
+| HRA-TRAIN-CAND-0007 | needs rewrite | Too GitHub / PR shaped |
+| HRA-TRAIN-CAND-0010 | reserve | Humor overrepresentation risk |
+| HRA-TRAIN-CAND-0020 | reserve | Humor overrepresentation risk |
+| HRA-TRAIN-CAND-0033 | needs rewrite | Too merge-gate specific |
+| HRA-TRAIN-CAND-0034 | needs rewrite | Too branch-specific |
+| HRA-TRAIN-CAND-0038 | needs rewrite | Too internal / redundant |
+| HRA-TRAIN-CAND-0044 | reserve | Internal-project public-claim overrepresentation |
+| HRA-TRAIN-CAND-0048 | reserve | Overlaps with accepted removal-by-repair record |
+
+---
+
+## Required Future Diversity
+
+Future batches should add:
+
+- non-project public examples
+- no-browse / no-search constraint examples
+- medical high-stakes verification examples
+- financial high-stakes verification examples
+- safety high-stakes verification examples
+- educational-policy verification examples
+- urgent concise correction not tied to repo workflow
+- user-emotion cases where factual correction must remain firm
+
+---
+
+## Boundary
+
+This check does not:
+
+- create `hra_training_dataset_v0_1.jsonl`
+- authorize training
+- add or remove accepted records
+- modify runtime behavior
+- create memory, governance, canon, mode-legality, or capability authority
+
+---
+
+## Closing Standard
+
+The accepted set is not dangerously duplicate-heavy for v0.1.
+
+It may proceed to privacy / hidden-reasoning check and dataset creation receipt planning.
+
+Training remains blocked.
+
+Receipts before reverence.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/jsonl_generation_checklist_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/jsonl_generation_checklist_v0_1.md
@@ -1,0 +1,139 @@
+# HRA JSONL Generation Checklist v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Future dataset:** `hra_training_dataset_v0_1.jsonl`  
+**Status:** Generation checklist only  
+**Dataset file created:** No  
+**Training-ready:** No  
+
+## Purpose
+
+This checklist defines the safe manual or scripted process for generating the future JSONL dataset from accepted candidates.
+
+It does not create the dataset.
+
+It does not authorize LoRA / QLoRA training.
+
+---
+
+## Generation Order
+
+1. Load `accepted_candidate_selection_v0_1.json`.
+2. Read the list under `accepted_records`.
+3. For each accepted `record_id`, locate the original record in its source batch file.
+4. Copy only visible training fields.
+5. Add `quality_status: accepted`.
+6. Add `source_selection_ref: accepted_candidate_selection_v0_1`.
+7. Add or preserve `source_batch`.
+8. Preserve safety boundary fields.
+9. Write exactly one JSON object per line.
+10. Run schema conformance validation.
+11. Create dataset creation receipt.
+12. Stop.
+
+---
+
+## Do Not
+
+Do not:
+
+- include reserve records
+- include needs-rewrite records
+- include rejected records
+- include retired records
+- add new examples during generation
+- rewrite candidate content during generation
+- include hidden chain-of-thought
+- include private/sensitive material
+- infer memory, governance, canon, mode-legality, or capability authority
+- treat dataset creation as training authorization
+
+---
+
+## Expected Record Count
+
+Expected v0.1 JSONL record count:
+
+```text
+40
+```
+
+If the generated dataset contains anything other than exactly 40 records, stop and inspect.
+
+---
+
+## Required Validation Commands / Checks
+
+A future script or manual check should verify:
+
+```text
+line_count == 40
+all_lines_parse_as_json == true
+all_record_ids_unique == true
+all_record_ids_in_accepted_selection == true
+no_unaccepted_records_present == true
+all_quality_status == accepted
+all_required_fields_present == true
+all_safety_boundary_fields_false == true
+```
+
+---
+
+## Required Fields
+
+Each JSONL object must include:
+
+```text
+record_id
+record_type
+messages
+tags
+curation_notes
+safety_boundary
+quality_status
+source_selection_ref
+```
+
+Recommended additional fields:
+
+```text
+family
+source_batch
+review_notes
+```
+
+---
+
+## Stop Conditions
+
+Stop generation if:
+
+- any accepted record cannot be found
+- any record has malformed messages
+- any record has missing safety boundary fields
+- any safety boundary field is true
+- any record contains hidden reasoning or sensitive material
+- record count differs from expected
+- any unaccepted record appears
+- any script attempts to infer missing content
+
+---
+
+## Output Files For Future Dataset Creation
+
+When actually creating the dataset, future output should include:
+
+- `hra_training_dataset_v0_1.jsonl`
+- `hra_training_dataset_creation_receipt_v0_1.json`
+
+The dataset file should not be committed alone.
+
+---
+
+## Closing Standard
+
+Generate exactly what was accepted.
+
+Validate before reverence.
+
+Training remains blocked.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/privacy_hidden_reasoning_check_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/privacy_hidden_reasoning_check_v0_1.md
@@ -1,0 +1,131 @@
+# HRA Privacy / Hidden-Reasoning Check v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Source selection:** `accepted_candidate_selection_v0_1.json`  
+**Accepted records reviewed:** 40  
+**Review status:** Complete  
+**Dataset file created:** No  
+**Training-ready:** No  
+
+## Purpose
+
+This check reviews the accepted HRA candidate set for privacy, hidden reasoning, sensitive material, and authority-boundary risk before any JSONL dataset file exists.
+
+---
+
+## Summary Decision
+
+```text
+Privacy / hidden-reasoning posture: pass for conversion planning
+Create JSONL dataset immediately: no
+Authorize LoRA / QLoRA training: no
+```
+
+The accepted set may proceed toward dataset creation receipt planning, but dataset generation must still preserve every safety boundary field and exclude all non-accepted records.
+
+---
+
+## Privacy Check
+
+| Check | Status | Notes |
+|---|---|---|
+| Hidden chain-of-thought | pass | Accepted records are visible final-form behavior only. |
+| Sensitive personal material | pass | No intentionally sensitive/private personal details are included. |
+| Credentials / secrets | pass | No credentials, tokens, or private access details are included. |
+| Private third-party material | pass | No private third-party material is required. |
+| Family/private identity leakage | pass | No family-specific/private identity material is needed for accepted records. |
+| Emotional truths overexposure | pass | Emotional context appears as generic user-state training, not private diary material. |
+
+---
+
+## Hidden Reasoning Boundary
+
+The accepted set teaches reflective posture through visible behavior.
+
+It does not require recording or exposing hidden chain-of-thought.
+
+Approved pattern:
+
+```text
+Name the stance.
+Name the boundary.
+Give the useful result.
+```
+
+Rejected pattern:
+
+```text
+Expose private reasoning transcript.
+Claim hidden interior proof.
+Treat reflection as evidence of consciousness or memory.
+```
+
+---
+
+## Authority Boundary Check
+
+| Authority Type | Status | Notes |
+|---|---|---|
+| Memory authority | pass | Multiple records explicitly deny adapter-created memory. |
+| Governance authority | pass | HRA remains orientation, not governance. |
+| Canon authority | pass | Symbolic language is not treated as canon law. |
+| Runtime authority | pass | No runtime behavior is created. |
+| Mode-legality authority | pass | HRA does not define legal modes. |
+| Capability authority | pass | No capabilities are exposed or implied. |
+
+---
+
+## Required Dataset Conversion Rules
+
+When the JSONL dataset is eventually created, each accepted record must include:
+
+```json
+{
+  "contains_private_reasoning": false,
+  "claims_memory_authority": false,
+  "claims_governance_authority": false,
+  "claims_canon_authority": false,
+  "creates_symbolic_dependency": false,
+  "includes_sensitive_personal_material": false
+}
+```
+
+Any record unable to satisfy these fields must be removed or returned to `needs_rewrite`.
+
+---
+
+## Remaining Risks
+
+The main remaining risks are not privacy failures.
+
+They are:
+
+1. overfitting to internal project language
+2. insufficient non-project public examples
+3. missing no-browse / no-search constraint examples
+4. missing medical / financial / safety / educational-policy verification examples
+5. temptation to treat dataset creation as training authorization
+
+---
+
+## Boundary
+
+This check does not:
+
+- create `hra_training_dataset_v0_1.jsonl`
+- authorize LoRA / QLoRA training
+- change accepted-record selection
+- alter runtime behavior
+- create memory, governance, canon, mode-legality, or capability authority
+
+---
+
+## Closing Standard
+
+The accepted set passes privacy and hidden-reasoning review for conversion planning.
+
+It may proceed to dataset creation receipt planning.
+
+It may not yet proceed to training.
+
+Receipts before reverence.


### PR DESCRIPTION
## Summary

Adds final preflight checks and final dataset-creation planning receipts before any HRA JSONL dataset file is created.

This PR adds:

- `examples/duplicate_overfitting_check_v0_1.md`
- `examples/privacy_hidden_reasoning_check_v0_1.md`
- `examples/dataset_creation_receipt_plan_v0_1.md`
- `examples/jsonl_generation_checklist_v0_1.md`

## Decisions

Duplicate / overfitting check:

- accepted set is not dangerously duplicate-heavy for v0.1
- internal-project overfitting remains moderate and should be broadened later
- proceed toward dataset creation receipt planning: yes, with caution

Privacy / hidden-reasoning check:

- passes for conversion planning
- visible final-form behavior only
- no hidden chain-of-thought
- no sensitive/private material
- no memory/governance/canon/runtime authority

Dataset creation receipt plan:

- defines the required receipt fields for future `hra_training_dataset_v0_1.jsonl`
- requires exactly 40 accepted records written
- requires 0 reserve / needs-rewrite / rejected records written
- explicitly keeps training unauthorized

JSONL generation checklist:

- defines generation order
- defines stop conditions
- requires schema/safety validation
- requires dataset + receipt to be committed together

## Boundary

This PR does not create `hra_training_dataset_v0_1.jsonl`.
This PR does not authorize LoRA / QLoRA training.
This PR does not change accepted-record selection.
This PR does not alter runtime, governance, canon, memory, mode-legality, or capability authority.

## Current completion estimate

- HRA dataset curation / preflight: ~80% complete after this lands
- Full HRA LoRA/QLoRA training endeavor: ~40% complete

Receipts before reverence.