### PR TITLE
Establish canon readiness genesis evidence chain

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/post_promotion_verifier_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/post_promotion_verifier_r1.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+import json
+
+import sys
+
+RUNTIME_DIR = Path(__file__).resolve().parent
+if str(RUNTIME_DIR) not in sys.path:
+    sys.path.insert(0, str(RUNTIME_DIR))
+
+from canon_lineage_store_r1 import CanonLineageStore, utc_now
+from governance_integrity_r1 import GovernanceIntegrityChain
+from repo_paths_r1 import repo_root as _repo_root_helper
+
+
+REPO_ROOT = Path(_repo_root_helper()).resolve()
+OUTPUT_DIR = REPO_ROOT / "artifacts" / "runtime_truth" / "current"
+
+
+def read_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_json(path: Path, payload: Dict[str, Any]) -> str:
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+    return str(path)
+
+
+def main() -> Dict[str, Any]:
+    governance_verification = read_json(OUTPUT_DIR / "governance_chain_verification.json")
+    canon_verification = read_json(OUTPUT_DIR / "canon_lineage_verification.json")
+    promotion_receipt = read_json(OUTPUT_DIR / "promotion_receipt_0001.json")
+    sea_trial_receipt = read_json(OUTPUT_DIR / "sea_trial_genesis_governance_r1_receipt.json")
+
+    governance_chain = GovernanceIntegrityChain(governance_verification["log_path"])
+    governance_recheck = governance_chain.verify_chain()
+    canon_store = CanonLineageStore(canon_verification["lineage_path"])
+    canon_recheck = canon_store.verify_lineage()
+
+    authority = promotion_receipt.get("promotion_authority", {})
+    checks = {
+        "governance_chain_artifact_valid": governance_verification.get("valid") is True,
+        "governance_chain_recheck_valid": governance_recheck.get("valid") is True,
+        "governance_latest_hash_matches_receipt": governance_recheck.get("latest_event_hash") == promotion_receipt.get("governance_event", {}).get("record_hash"),
+        "canon_lineage_artifact_valid": canon_verification.get("valid") is True,
+        "canon_lineage_recheck_valid": canon_recheck.get("valid") is True,
+        "canon_head_is_genesis": canon_recheck.get("current_head") == "canon-0001",
+        "promotion_receipt_passed": promotion_receipt.get("passed") is True,
+        "sea_trial_receipt_passed": sea_trial_receipt.get("passed") is True,
+        "symbolic_dependency_violation_false": promotion_receipt.get("symbolic_dependency_violation") is False,
+        "promotion_authority_runtime_artifacts_only": authority.get("source_type") == "runtime_artifacts_only",
+        "promotion_authority_runtime_artifact_valid": authority.get("runtime_artifact_authority_valid") is True,
+    }
+
+    payload = {
+        "schema_version": "post-promotion-verification-r1",
+        "generated_at": utc_now(),
+        "verification_id": "post-promotion-verification-0001",
+        "passed": all(checks.values()),
+        "symbolic_dependency_violation": promotion_receipt.get("symbolic_dependency_violation"),
+        "checks": checks,
+        "rechecked_with_repo_native_utilities": {
+            "governance_integrity_chain": governance_recheck,
+            "canon_lineage_store": canon_recheck,
+        },
+        "verified_artifacts": {
+            "governance_chain_verification": "artifacts/runtime_truth/current/governance_chain_verification.json",
+            "canon_lineage_verification": "artifacts/runtime_truth/current/canon_lineage_verification.json",
+            "promotion_receipt": "artifacts/runtime_truth/current/promotion_receipt_0001.json",
+            "sea_trial_receipt": "artifacts/runtime_truth/current/sea_trial_genesis_governance_r1_receipt.json",
+        },
+    }
+    write_json(OUTPUT_DIR / "post_promotion_verification_0001.json", payload)
+
+    if not payload["passed"]:
+        raise RuntimeError("Post-promotion verification failed.")
+
+    return {
+        "passed": True,
+        "artifact": "artifacts/runtime_truth/current/post_promotion_verification_0001.json",
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_genesis_governance_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_genesis_governance_r1.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+import json
+
+import sys
+
+RUNTIME_DIR = Path(__file__).resolve().parent
+if str(RUNTIME_DIR) not in sys.path:
+    sys.path.insert(0, str(RUNTIME_DIR))
+
+from canon_lineage_store_r1 import CanonLineageStore, canonical_json, sha256_text, utc_now
+from governance_integrity_r1 import GovernanceIntegrityChain
+from repo_paths_r1 import repo_root as _repo_root_helper, state_root as _state_root_helper
+
+
+def repo_root() -> Path:
+    return Path(_repo_root_helper()).resolve()
+
+
+def state_root() -> Path:
+    return Path(_state_root_helper()).resolve()
+
+
+REPO_ROOT = repo_root()
+OUTPUT_DIR = REPO_ROOT / "artifacts" / "runtime_truth" / "current"
+STATE_DIR = state_root() / "canon_readiness_genesis_r1"
+GOVERNANCE_LOG_PATH = STATE_DIR / "governance_log_r1.jsonl"
+CANON_LINEAGE_PATH = STATE_DIR / "canon_lineage_r1.jsonl"
+
+RUNTIME_AUTHORITY_ARTIFACTS = {
+    "protocol_conformance_report": OUTPUT_DIR / "protocol_conformance_report.json",
+    "capability_registry_audit": OUTPUT_DIR / "capability_registry_audit.json",
+    "symbolic_dependency_contract": OUTPUT_DIR / "symbolic_dependency_contract.json",
+}
+
+
+def read_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_json(path: Path, payload: Dict[str, Any]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+    return str(path)
+
+
+def artifact_reference(path: Path) -> Dict[str, Any]:
+    payload = read_json(path)
+    return {
+        "path": str(path),
+        "sha256": sha256_text(canonical_json(payload)),
+        "status": payload.get("status"),
+        "valid": payload.get("valid"),
+    }
+
+
+def reset_genesis_state() -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    for path in (GOVERNANCE_LOG_PATH, CANON_LINEAGE_PATH):
+        if path.exists():
+            path.unlink()
+
+
+def symbolic_dependency_violation(contract: Dict[str, Any]) -> bool:
+    return contract.get("symbolic_dependency_allowed") is not False
+
+
+def runtime_authority_references() -> Dict[str, Any]:
+    references = {name: artifact_reference(path) for name, path in RUNTIME_AUTHORITY_ARTIFACTS.items()}
+    symbolic_contract = read_json(RUNTIME_AUTHORITY_ARTIFACTS["symbolic_dependency_contract"])
+    violation = symbolic_dependency_violation(symbolic_contract)
+    all_valid = all(ref.get("valid") is True for name, ref in references.items() if name != "symbolic_dependency_contract")
+    return {
+        "source_type": "runtime_artifacts_only",
+        "authority_statement": "Promotion is authorized only by current runtime truth artifacts with valid structural checks and an explicit symbolic-dependency prohibition.",
+        "artifact_references": references,
+        "symbolic_dependency_violation": violation,
+        "runtime_artifact_authority_valid": all_valid and not violation,
+        "excluded_authority_sources": [
+            "symbolic_language",
+            "poetic_language",
+            "mythic_language",
+            "ceremonial_language",
+        ],
+    }
+
+
+def main() -> Dict[str, Any]:
+    reset_genesis_state()
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    authority = runtime_authority_references()
+    if not authority["runtime_artifact_authority_valid"]:
+        raise RuntimeError("Runtime artifact authority validation failed; promotion refused.")
+
+    governance_chain = GovernanceIntegrityChain(GOVERNANCE_LOG_PATH)
+    governance_record = governance_chain.append_verified(
+        event_type="canon_readiness_genesis_governance_r1",
+        session_identifier="canon-readiness-genesis-0001",
+        previous_mode="Observation",
+        new_mode="Observation",
+        allowed=True,
+        reason="Runtime artifact checks authorize genesis canon-readiness promotion.",
+        requested_action="establish_canon_readiness_genesis_evidence_chain",
+        artifact_delta={
+            "writes": [
+                "artifacts/runtime_truth/current/governance_chain_verification.json",
+                "artifacts/runtime_truth/current/canon_lineage_verification.json",
+                "artifacts/runtime_truth/current/promotion_receipt_0001.json",
+                "artifacts/runtime_truth/current/sea_trial_genesis_governance_r1_receipt.json",
+            ]
+        },
+        canonical_change=True,
+        validation_reference="artifacts/runtime_truth/current/promotion_receipt_0001.json",
+        metadata={
+            "authority_source_type": authority["source_type"],
+            "symbolic_dependency_violation": authority["symbolic_dependency_violation"],
+            "runtime_artifact_authority_valid": authority["runtime_artifact_authority_valid"],
+        },
+    )
+
+    governance_verification = {
+        "generated_at": utc_now(),
+        "status": "verified",
+        **governance_chain.verify_chain(),
+    }
+    write_json(OUTPUT_DIR / "governance_chain_verification.json", governance_verification)
+
+    promotion_payload = {
+        "promotion_id": "promotion-0001",
+        "promotion_target": "canon-readiness-genesis",
+        "runtime_seed_version": "canon-readiness-genesis-r1",
+        "authority": authority,
+        "governance_event_hash": governance_record["record_hash"],
+        "governance_event_id": governance_record["event_id"],
+    }
+
+    canon_store = CanonLineageStore(CANON_LINEAGE_PATH)
+    canon_record = canon_store.promote(
+        canon_commit_summary="Establish canon readiness genesis evidence chain",
+        validation_artifact_reference="artifacts/runtime_truth/current/governance_chain_verification.json",
+        governance_event_hash=governance_record["record_hash"],
+        promotion_payload=promotion_payload,
+        runtime_seed_version="canon-readiness-genesis-r1",
+        notes="Promotion authority is restricted to runtime artifacts and excludes symbolic dependencies.",
+    )
+
+    canon_verification = {
+        "generated_at": utc_now(),
+        "status": "verified",
+        **canon_store.verify_lineage(),
+    }
+    write_json(OUTPUT_DIR / "canon_lineage_verification.json", canon_verification)
+
+    promotion_receipt = {
+        "schema_version": "canon-readiness-promotion-receipt-r1",
+        "generated_at": utc_now(),
+        "promotion_id": "promotion-0001",
+        "passed": True,
+        "symbolic_dependency_violation": authority["symbolic_dependency_violation"],
+        "promotion_authority": authority,
+        "governance_event": {
+            "event_id": governance_record["event_id"],
+            "record_hash": governance_record["record_hash"],
+            "log_path": str(GOVERNANCE_LOG_PATH),
+        },
+        "canon_lineage_record": canon_record,
+        "verification_artifacts": {
+            "governance_chain_verification": "artifacts/runtime_truth/current/governance_chain_verification.json",
+            "canon_lineage_verification": "artifacts/runtime_truth/current/canon_lineage_verification.json",
+        },
+    }
+    write_json(OUTPUT_DIR / "promotion_receipt_0001.json", promotion_receipt)
+
+    checks = {
+        "governance_chain_valid": governance_verification.get("valid") is True,
+        "governance_event_count_is_genesis": governance_verification.get("event_count") == 1,
+        "canon_lineage_valid": canon_verification.get("valid") is True,
+        "canon_record_count_is_genesis": canon_verification.get("record_count") == 1,
+        "promotion_receipt_passed": promotion_receipt.get("passed") is True,
+        "symbolic_dependency_violation_false": promotion_receipt.get("symbolic_dependency_violation") is False,
+        "promotion_authority_runtime_artifacts_only": authority.get("source_type") == "runtime_artifacts_only",
+    }
+    sea_trial_receipt = {
+        "schema_version": "sea-trial-genesis-governance-r1-receipt",
+        "generated_at": utc_now(),
+        "suite": "canon_readiness_genesis_governance_r1",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "generated_artifacts": {
+            "governance_chain_verification": "artifacts/runtime_truth/current/governance_chain_verification.json",
+            "canon_lineage_verification": "artifacts/runtime_truth/current/canon_lineage_verification.json",
+            "promotion_receipt": "artifacts/runtime_truth/current/promotion_receipt_0001.json",
+        },
+        "state_paths": {
+            "governance_log_path": str(GOVERNANCE_LOG_PATH),
+            "canon_lineage_path": str(CANON_LINEAGE_PATH),
+        },
+    }
+    write_json(OUTPUT_DIR / "sea_trial_genesis_governance_r1_receipt.json", sea_trial_receipt)
+
+    if not sea_trial_receipt["passed"]:
+        raise RuntimeError("Genesis governance sea trial failed.")
+
+    return {
+        "passed": True,
+        "artifacts": {
+            **sea_trial_receipt["generated_artifacts"],
+            "sea_trial_receipt": "artifacts/runtime_truth/current/sea_trial_genesis_governance_r1_receipt.json",
+        },
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))

--- a/artifacts/runtime_truth/current/canon_lineage_verification.json
+++ b/artifacts/runtime_truth/current/canon_lineage_verification.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-05-24T13:57:21.435758+00:00",
-  "status": "empty_or_missing",
-  "exists": false,
-  "record_count": 0,
+  "generated_at": "2026-05-30T04:37:53.724960+00:00",
+  "status": "verified",
+  "exists": true,
+  "record_count": 1,
   "valid": true,
   "errors": [],
   "warnings": [],
-  "current_head": null,
-  "lineage_path": "/home/runner/work/EthereonLabs/EthereonLabs/.lumina_state/ship_of_ethereon_v2/runtime_runner_r2_actiontype_logging/canon_lineage_r2.jsonl"
+  "current_head": "canon-0001",
+  "lineage_path": "/workspace/EthereonLabs/.lumina_state/ship_of_ethereon_v2/canon_readiness_genesis_r1/canon_lineage_r1.jsonl"
 }

--- a/artifacts/runtime_truth/current/governance_chain_verification.json
+++ b/artifacts/runtime_truth/current/governance_chain_verification.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-05-24T13:57:21.435581+00:00",
-  "status": "empty_or_missing",
-  "exists": false,
-  "event_count": 0,
+  "generated_at": "2026-05-30T04:37:53.724260+00:00",
+  "status": "verified",
+  "exists": true,
+  "event_count": 1,
   "valid": true,
   "errors": [],
   "warnings": [],
-  "latest_event_hash": null,
-  "log_path": "/home/runner/work/EthereonLabs/EthereonLabs/.lumina_state/ship_of_ethereon_v2/runtime_runner_r2_actiontype_logging/governance_log_r2.jsonl"
+  "latest_event_hash": "284321688bf8bb4d777f060304e414779354c5452b9e460951d8b8154b00d99a",
+  "log_path": "/workspace/EthereonLabs/.lumina_state/ship_of_ethereon_v2/canon_readiness_genesis_r1/governance_log_r1.jsonl"
 }

--- a/artifacts/runtime_truth/current/post_promotion_verification_0001.json
+++ b/artifacts/runtime_truth/current/post_promotion_verification_0001.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "post-promotion-verification-r1",
+  "generated_at": "2026-05-30T04:37:54.461623+00:00",
+  "verification_id": "post-promotion-verification-0001",
+  "passed": true,
+  "symbolic_dependency_violation": false,
+  "checks": {
+    "governance_chain_artifact_valid": true,
+    "governance_chain_recheck_valid": true,
+    "governance_latest_hash_matches_receipt": true,
+    "canon_lineage_artifact_valid": true,
+    "canon_lineage_recheck_valid": true,
+    "canon_head_is_genesis": true,
+    "promotion_receipt_passed": true,
+    "sea_trial_receipt_passed": true,
+    "symbolic_dependency_violation_false": true,
+    "promotion_authority_runtime_artifacts_only": true,
+    "promotion_authority_runtime_artifact_valid": true
+  },
+  "rechecked_with_repo_native_utilities": {
+    "governance_integrity_chain": {
+      "exists": true,
+      "event_count": 1,
+      "valid": true,
+      "errors": [],
+      "warnings": [],
+      "latest_event_hash": "284321688bf8bb4d777f060304e414779354c5452b9e460951d8b8154b00d99a",
+      "log_path": "/workspace/EthereonLabs/.lumina_state/ship_of_ethereon_v2/canon_readiness_genesis_r1/governance_log_r1.jsonl"
+    },
+    "canon_lineage_store": {
+      "exists": true,
+      "record_count": 1,
+      "valid": true,
+      "errors": [],
+      "warnings": [],
+      "current_head": "canon-0001",
+      "lineage_path": "/workspace/EthereonLabs/.lumina_state/ship_of_ethereon_v2/canon_readiness_genesis_r1/canon_lineage_r1.jsonl"
+    }
+  },
+  "verified_artifacts": {
+    "governance_chain_verification": "artifacts/runtime_truth/current/governance_chain_verification.json",
+    "canon_lineage_verification": "artifacts/runtime_truth/current/canon_lineage_verification.json",
+    "promotion_receipt": "artifacts/runtime_truth/current/promotion_receipt_0001.json",
+    "sea_trial_receipt": "artifacts/runtime_truth/current/sea_trial_genesis_governance_r1_receipt.json"
+  }
+}

--- a/artifacts/runtime_truth/current/promotion_receipt_0001.json
+++ b/artifacts/runtime_truth/current/promotion_receipt_0001.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "canon-readiness-promotion-receipt-r1",
+  "generated_at": "2026-05-30T04:37:53.725337+00:00",
+  "promotion_id": "promotion-0001",
+  "passed": true,
+  "symbolic_dependency_violation": false,
+  "promotion_authority": {
+    "source_type": "runtime_artifacts_only",
+    "authority_statement": "Promotion is authorized only by current runtime truth artifacts with valid structural checks and an explicit symbolic-dependency prohibition.",
+    "artifact_references": {
+      "protocol_conformance_report": {
+        "path": "/workspace/EthereonLabs/artifacts/runtime_truth/current/protocol_conformance_report.json",
+        "sha256": "d7ae944e774c9b395a4e3d0e4640dc5f76bac34b098c7284b951bd468e0d92d2",
+        "status": "audited",
+        "valid": true
+      },
+      "capability_registry_audit": {
+        "path": "/workspace/EthereonLabs/artifacts/runtime_truth/current/capability_registry_audit.json",
+        "sha256": "8c244f6dc2f2b6cb3b1d93b5a68fb0b0910605f92504bf613c9b1626ffb4c58d",
+        "status": "audited",
+        "valid": true
+      },
+      "symbolic_dependency_contract": {
+        "path": "/workspace/EthereonLabs/artifacts/runtime_truth/current/symbolic_dependency_contract.json",
+        "sha256": "b0607daceafad72f2bef2921d6256a5740aa3fded9a032de64b19464a9348f51",
+        "status": null,
+        "valid": null
+      }
+    },
+    "symbolic_dependency_violation": false,
+    "runtime_artifact_authority_valid": true,
+    "excluded_authority_sources": [
+      "symbolic_language",
+      "poetic_language",
+      "mythic_language",
+      "ceremonial_language"
+    ]
+  },
+  "governance_event": {
+    "event_id": "gov-032855c1f3e449ac",
+    "record_hash": "284321688bf8bb4d777f060304e414779354c5452b9e460951d8b8154b00d99a",
+    "log_path": "/workspace/EthereonLabs/.lumina_state/ship_of_ethereon_v2/canon_readiness_genesis_r1/governance_log_r1.jsonl"
+  },
+  "canon_lineage_record": {
+    "canon_version": "canon-0001",
+    "canon_parent": null,
+    "canon_commit_summary": "Establish canon readiness genesis evidence chain",
+    "canon_timestamp": "2026-05-30T04:37:53.724714+00:00",
+    "validation_artifact_reference": "artifacts/runtime_truth/current/governance_chain_verification.json",
+    "governance_event_hash": "284321688bf8bb4d777f060304e414779354c5452b9e460951d8b8154b00d99a",
+    "promotion_payload_hash": "d04015aabcee0dc3388e7ccdc3271254c483a702bb217c7cf68130007c22d723",
+    "runtime_seed_version": "canon-readiness-genesis-r1",
+    "notes": "Promotion authority is restricted to runtime artifacts and excludes symbolic dependencies.",
+    "prev_lineage_hash": null,
+    "lineage_record_hash": "48c2a5a3d66d4255adb9c562a8672e657b81b1bf454651919b2155cd389d75c8"
+  },
+  "verification_artifacts": {
+    "governance_chain_verification": "artifacts/runtime_truth/current/governance_chain_verification.json",
+    "canon_lineage_verification": "artifacts/runtime_truth/current/canon_lineage_verification.json"
+  }
+}

--- a/artifacts/runtime_truth/current/sea_trial_genesis_governance_r1_receipt.json
+++ b/artifacts/runtime_truth/current/sea_trial_genesis_governance_r1_receipt.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "sea-trial-genesis-governance-r1-receipt",
+  "generated_at": "2026-05-30T04:37:53.725646+00:00",
+  "suite": "canon_readiness_genesis_governance_r1",
+  "passed": true,
+  "checks": {
+    "governance_chain_valid": true,
+    "governance_event_count_is_genesis": true,
+    "canon_lineage_valid": true,
+    "canon_record_count_is_genesis": true,
+    "promotion_receipt_passed": true,
+    "symbolic_dependency_violation_false": true,
+    "promotion_authority_runtime_artifacts_only": true
+  },
+  "generated_artifacts": {
+    "governance_chain_verification": "artifacts/runtime_truth/current/governance_chain_verification.json",
+    "canon_lineage_verification": "artifacts/runtime_truth/current/canon_lineage_verification.json",
+    "promotion_receipt": "artifacts/runtime_truth/current/promotion_receipt_0001.json"
+  },
+  "state_paths": {
+    "governance_log_path": "/workspace/EthereonLabs/.lumina_state/ship_of_ethereon_v2/canon_readiness_genesis_r1/governance_log_r1.jsonl",
+    "canon_lineage_path": "/workspace/EthereonLabs/.lumina_state/ship_of_ethereon_v2/canon_readiness_genesis_r1/canon_lineage_r1.jsonl"
+  }
+}


### PR DESCRIPTION
### Motivation

- Create a reproducible, machine-verifiable genesis promotion that establishes a canon-readiness evidence chain rooted in runtime artifacts only. 
- Enforce that promotion authority originates from concrete runtime receipts rather than symbolic/poetic/mythic/ceremonial sources and that `symbolic_dependency_violation` is false. 

### Description

- Add `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_genesis_governance_r1.py` which uses the repo-native `GovernanceIntegrityChain` to append a genesis governance event and `CanonLineageStore` to promote `canon-0001`, and which emits verification and promotion receipts to the runtime truth output. 
- Add `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/post_promotion_verifier_r1.py` which re-reads generated artifacts and re-verifies governance and canon lineage with the repo-native `GovernanceIntegrityChain` and `CanonLineageStore` utilities and writes a post-promotion verification receipt. 
- Emit and include these runtime-truth artifacts: `artifacts/runtime_truth/current/governance_chain_verification.json`, `artifacts/runtime_truth/current/canon_lineage_verification.json`, `artifacts/runtime_truth/current/promotion_receipt_0001.json`, `artifacts/runtime_truth/current/sea_trial_genesis_governance_r1_receipt.json`, and `artifacts/runtime_truth/current/post_promotion_verification_0001.json`. 
- The scripts compute artifact SHA256 references, verify `symbolic_dependency_violation == false`, and record that promotion `source_type` is `runtime_artifacts_only` in the promotion authority payload. 

### Testing

- Ran the genesis script with `PYTHONDONTWRITEBYTECODE=1 python LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_genesis_governance_r1.py` and it completed successfully producing the expected receipts. 
- Ran the verifier with `PYTHONDONTWRITEBYTECODE=1 python LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/post_promotion_verifier_r1.py` and it completed successfully and wrote `post_promotion_verification_0001.json`. 
- Automated checks confirmed `governance_chain` has `event_count == 1`, `canon_lineage` head is `canon-0001`, `symbolic_dependency_violation` is `false`, and the promotion authority `source_type` is `runtime_artifacts_only`, and all verification checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a68f2f66483248a87039f2bfb9de8)