### PR TITLE
Derive symbolic_dependency_violation from promotion receipt in post-promotion verifier

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/canon_lineage_store_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/canon_lineage_store_r1.py
@@ -20,6 +20,22 @@ def sha256_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+def infer_repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / ".git").exists() or (parent / "LuminaOS").exists():
+            return parent
+    return Path.cwd()
+
+
+def repo_relative_path(path: str | Path) -> str:
+    resolved = Path(path).resolve()
+    root = infer_repo_root().resolve()
+    try:
+        return str(resolved.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
 @dataclass
 class CanonRecord:
     canon_version: str
@@ -164,5 +180,5 @@ class CanonLineageStore:
             "errors": errors,
             "warnings": warnings,
             "current_head": rows[-1]["canon_version"] if rows else None,
-            "lineage_path": str(self.lineage_path),
+            "lineage_path": repo_relative_path(self.lineage_path),
         }

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/governance_integrity_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/governance_integrity_r1.py
@@ -29,6 +29,22 @@ def sha256_file(path: str | Path) -> str:
     return h.hexdigest()
 
 
+def infer_repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / ".git").exists() or (parent / "LuminaOS").exists():
+            return parent
+    return Path.cwd()
+
+
+def repo_relative_path(path: str | Path) -> str:
+    resolved = Path(path).resolve()
+    root = infer_repo_root().resolve()
+    try:
+        return str(resolved.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
 @dataclass
 class GovernanceIntegrityRecord:
     event_id: str
@@ -165,5 +181,5 @@ class GovernanceIntegrityChain:
             "errors": errors,
             "warnings": warnings,
             "latest_event_hash": previous_hash,
-            "log_path": str(self.log_path),
+            "log_path": repo_relative_path(self.log_path),
         }

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/post_promotion_verifier_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/post_promotion_verifier_r1.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+import argparse
+import json
+import sys
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def infer_repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / ".git").exists() or (parent / "LuminaOS").exists():
+            return parent
+    return Path.cwd()
+
+
+REPO_ROOT = infer_repo_root()
+
+
+def repo_relative_path(path: str | Path) -> str:
+    resolved = Path(path).resolve()
+    root = REPO_ROOT.resolve()
+    try:
+        return str(resolved.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+DEFAULT_PROMOTION_RECEIPT = REPO_ROOT / "artifacts" / "runtime_truth" / "current" / "promotion_receipt.json"
+DEFAULT_OUTPUT = REPO_ROOT / "artifacts" / "runtime_truth" / "current" / "post_promotion_verification.json"
+
+
+def read_json(path: str | Path) -> Dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_json(path: str | Path, payload: Dict[str, Any]) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+
+
+def build_post_promotion_verification(
+    promotion_receipt: Dict[str, Any],
+    *,
+    promotion_receipt_path: Optional[str | Path] = None,
+) -> Dict[str, Any]:
+    """Build the post-promotion verifier receipt from the committed promotion receipt.
+
+    The symbolic dependency verdict is intentionally read from the committed
+    promotion receipt's payload instead of being hardcoded by this verifier.
+    Missing payload data defaults to a violation so incomplete receipts fail
+    closed.
+    """
+    symbolic_dependency_violation = bool(
+        promotion_receipt.get("promotion_payload", {}).get("symbolic_dependency_violation", True)
+    )
+
+    checks = {
+        "promotion_receipt_present": bool(promotion_receipt),
+        "promotion_payload_present": isinstance(promotion_receipt.get("promotion_payload"), dict),
+        "no_symbolic_dependency_violation": symbolic_dependency_violation is False,
+    }
+    payload = {
+        "schema_version": "post-promotion-verification-r1",
+        "generated_at": utc_now(),
+        "promotion_receipt_path": repo_relative_path(promotion_receipt_path) if promotion_receipt_path else None,
+        "promotion_receipt_id": promotion_receipt.get("promotion_receipt_id") or promotion_receipt.get("receipt_id"),
+        "promotion_artifact": promotion_receipt.get("promotion_artifact"),
+        "symbolic_dependency_violation": symbolic_dependency_violation,
+        "checks": checks,
+        "passed": all(checks.values()),
+        "authority_boundary": "Verification receipt only; does not authorize action, mutate canon, change mode legality, expose capabilities, or execute tools.",
+    }
+    return payload
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verify a committed promotion receipt after promotion.")
+    parser.add_argument("--promotion-receipt", default=str(DEFAULT_PROMOTION_RECEIPT))
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    receipt_path = Path(args.promotion_receipt)
+    promotion_receipt = read_json(receipt_path)
+    payload = build_post_promotion_verification(promotion_receipt, promotion_receipt_path=receipt_path)
+    write_json(args.output, payload)
+    print(json.dumps(payload, indent=2))
+    return 0 if payload["passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_emitter_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_emitter_r1.py
@@ -5,10 +5,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 import json
 
-try:
+if __package__:
     from .governance_integrity_r1 import GovernanceIntegrityChain
     from .canon_lineage_store_r1 import CanonLineageStore
-except Exception:
+else:
     from governance_integrity_r1 import GovernanceIntegrityChain
     from canon_lineage_store_r1 import CanonLineageStore
 
@@ -27,6 +27,22 @@ DEFAULT_FORBIDDEN_SYMBOLIC_DEPENDENCIES = [
     "capability exposure",
     "governance verification",
 ]
+
+
+def infer_repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / ".git").exists() or (parent / "LuminaOS").exists():
+            return parent
+    return Path.cwd()
+
+
+def repo_relative_path(path: str | Path) -> str:
+    resolved = Path(path).resolve()
+    root = infer_repo_root().resolve()
+    try:
+        return str(resolved.relative_to(root))
+    except ValueError:
+        return str(path)
 
 
 class RuntimeTruthEmitter:
@@ -68,7 +84,7 @@ class RuntimeTruthEmitter:
         path = self.output_dir / filename
         with path.open("w", encoding="utf-8") as f:
             json.dump(payload, f, indent=2)
-        return str(path)
+        return repo_relative_path(path)
 
     def write_governance_chain_verification(self) -> str:
         if not self.governance_log_path:
@@ -142,7 +158,7 @@ class RuntimeTruthEmitter:
             payload = {
                 "generated_at": utc_now(),
                 "status": "audited",
-                "registry_path": str(self.capability_registry_path),
+                "registry_path": repo_relative_path(self.capability_registry_path),
                 "capability_count": len(capabilities),
                 "valid": not issues,
                 "issues": issues,
@@ -174,7 +190,7 @@ class RuntimeTruthEmitter:
             payload = {
                 "generated_at": utc_now(),
                 "status": "audited",
-                "protocol_path": str(self.protocol_path),
+                "protocol_path": repo_relative_path(self.protocol_path),
                 "valid": not issues,
                 "issues": issues,
             }

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_public_snapshot_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_public_snapshot_r1.py
@@ -4,9 +4,9 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 import json
 
-try:
+if __package__:
     from .runtime_truth_observation_cycle_r1 import run_runtime_truth_observation_cycle, infer_repo_root
-except Exception:
+else:
     from runtime_truth_observation_cycle_r1 import run_runtime_truth_observation_cycle, infer_repo_root
 
 
@@ -15,6 +15,15 @@ PUBLIC_RUNTIME_DIR = REPO_ROOT / "public" / "runtime"
 LATEST_CYCLE_PATH = PUBLIC_RUNTIME_DIR / "latest_cycle.json"
 SNAPSHOT_PATH = PUBLIC_RUNTIME_DIR / "runtime_truth_snapshot.json"
 LATEST_CYCLE_SCHEMA_VERSION = "lumina-runtime-ui-cycle-v0.4"
+
+
+def repo_relative_path(path: str | Path) -> str:
+    resolved = Path(path).resolve()
+    root = REPO_ROOT.resolve()
+    try:
+        return str(resolved.relative_to(root))
+    except ValueError:
+        return str(path)
 
 
 def _read_json(path: Path) -> Dict[str, Any]:
@@ -107,7 +116,7 @@ def build_public_runtime_truth_snapshot(
     latest = _read_json(latest_path)
     public_snapshot = {
         "schema_version": "lumina-runtime-truth-public-snapshot-v0.1",
-        "source_latest_cycle": str(latest_path),
+        "source_latest_cycle": repo_relative_path(latest_path),
         "latest_cycle_run_id": latest.get("run_id"),
         "latest_cycle_timestamp": latest.get("timestamp"),
         "mode": latest.get("mode", {}),

--- a/artifacts/runtime_truth/current/canon_lineage_verification.json
+++ b/artifacts/runtime_truth/current/canon_lineage_verification.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T13:57:21.435758+00:00",
+  "generated_at": "2026-05-30T05:01:10.384155+00:00",
   "status": "empty_or_missing",
   "exists": false,
   "record_count": 0,
@@ -7,5 +7,5 @@
   "errors": [],
   "warnings": [],
   "current_head": null,
-  "lineage_path": "/home/runner/work/EthereonLabs/EthereonLabs/.lumina_state/ship_of_ethereon_v2/runtime_runner_r2_actiontype_logging/canon_lineage_r2.jsonl"
+  "lineage_path": ".lumina_state/ship_of_ethereon_v2/runtime_runner_r2_actiontype_logging/canon_lineage_r2.jsonl"
 }

--- a/artifacts/runtime_truth/current/capability_registry_audit.json
+++ b/artifacts/runtime_truth/current/capability_registry_audit.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-05-24T13:57:21.436365+00:00",
+  "generated_at": "2026-05-30T05:01:10.384938+00:00",
   "status": "audited",
-  "registry_path": "/home/runner/work/EthereonLabs/EthereonLabs/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json",
+  "registry_path": "LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/capability_registry_r1.json",
   "capability_count": 13,
   "valid": true,
   "issues": []

--- a/artifacts/runtime_truth/current/governance_chain_verification.json
+++ b/artifacts/runtime_truth/current/governance_chain_verification.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T13:57:21.435581+00:00",
+  "generated_at": "2026-05-30T05:01:10.383542+00:00",
   "status": "empty_or_missing",
   "exists": false,
   "event_count": 0,
@@ -7,5 +7,5 @@
   "errors": [],
   "warnings": [],
   "latest_event_hash": null,
-  "log_path": "/home/runner/work/EthereonLabs/EthereonLabs/.lumina_state/ship_of_ethereon_v2/runtime_runner_r2_actiontype_logging/governance_log_r2.jsonl"
+  "log_path": ".lumina_state/ship_of_ethereon_v2/runtime_runner_r2_actiontype_logging/governance_log_r2.jsonl"
 }

--- a/artifacts/runtime_truth/current/post_promotion_verification.json
+++ b/artifacts/runtime_truth/current/post_promotion_verification.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "post-promotion-verification-r1",
+  "generated_at": "2026-05-30T05:01:10.951409+00:00",
+  "promotion_receipt_path": "artifacts/runtime_truth/current/promotion_receipt.json",
+  "promotion_receipt_id": "runtime-truth-promotion-001",
+  "promotion_artifact": "artifacts/runtime_truth/current",
+  "symbolic_dependency_violation": false,
+  "checks": {
+    "promotion_receipt_present": true,
+    "promotion_payload_present": true,
+    "no_symbolic_dependency_violation": true
+  },
+  "passed": true,
+  "authority_boundary": "Verification receipt only; does not authorize action, mutate canon, change mode legality, expose capabilities, or execute tools."
+}

--- a/artifacts/runtime_truth/current/promotion_receipt.json
+++ b/artifacts/runtime_truth/current/promotion_receipt.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "promotion-receipt-r1",
+  "promotion_receipt_id": "runtime-truth-promotion-001",
+  "promotion_artifact": "artifacts/runtime_truth/current",
+  "promotion_payload": {
+    "validation_artifact_id": "runtime-truth-current",
+    "change_summary": "Committed runtime truth promotion receipt for post-promotion verification.",
+    "symbolic_dependency_violation": false
+  },
+  "authority_boundary": "Committed receipt only; does not authorize action, mutate canon, change mode legality, expose capabilities, or execute tools."
+}

--- a/artifacts/runtime_truth/current/protocol_conformance_report.json
+++ b/artifacts/runtime_truth/current/protocol_conformance_report.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-05-24T13:57:21.436563+00:00",
+  "generated_at": "2026-05-30T05:01:10.385569+00:00",
   "status": "audited",
-  "protocol_path": "/home/runner/work/EthereonLabs/EthereonLabs/LuminaOS/bootstrap/Ship_of_Ethereon_V2/protocols/Ethereon_Mode_Protocol_v1.3.json",
+  "protocol_path": "LuminaOS/bootstrap/Ship_of_Ethereon_V2/protocols/Ethereon_Mode_Protocol_v1.3.json",
   "valid": true,
   "issues": []
 }

--- a/artifacts/runtime_truth/current/symbolic_dependency_contract.json
+++ b/artifacts/runtime_truth/current/symbolic_dependency_contract.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-05-24T13:57:21.435169+00:00",
+  "generated_at": "2026-05-30T05:01:10.382826+00:00",
   "symbolic_context_present_allowed": true,
   "symbolic_dependency_allowed": false,
   "forbidden_symbolic_dependencies": [

--- a/public/runtime/runtime_truth_snapshot.json
+++ b/public/runtime/runtime_truth_snapshot.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "lumina-runtime-truth-public-snapshot-v0.1",
-  "source_latest_cycle": "/home/runner/work/EthereonLabs/EthereonLabs/public/runtime/latest_cycle.json",
-  "latest_cycle_run_id": "run-574ef002-dfc",
-  "latest_cycle_timestamp": "2026-05-24T08:44:40.933393+00:00",
+  "source_latest_cycle": "public/runtime/latest_cycle.json",
+  "latest_cycle_run_id": "run-19e5112b-9f8",
+  "latest_cycle_timestamp": "2026-05-30T04:17:42.535732+00:00",
   "mode": {
     "requested": "Continuity",
     "current": "Observation"
@@ -38,11 +38,11 @@
     }
   },
   "artifact_paths": {
-    "symbolic_dependency_contract": "/home/runner/work/EthereonLabs/EthereonLabs/artifacts/runtime_truth/current/symbolic_dependency_contract.json",
-    "governance_chain_verification": "/home/runner/work/EthereonLabs/EthereonLabs/artifacts/runtime_truth/current/governance_chain_verification.json",
-    "canon_lineage_verification": "/home/runner/work/EthereonLabs/EthereonLabs/artifacts/runtime_truth/current/canon_lineage_verification.json",
-    "capability_registry_audit": "/home/runner/work/EthereonLabs/EthereonLabs/artifacts/runtime_truth/current/capability_registry_audit.json",
-    "protocol_conformance_report": "/home/runner/work/EthereonLabs/EthereonLabs/artifacts/runtime_truth/current/protocol_conformance_report.json"
+    "symbolic_dependency_contract": "artifacts/runtime_truth/current/symbolic_dependency_contract.json",
+    "governance_chain_verification": "artifacts/runtime_truth/current/governance_chain_verification.json",
+    "canon_lineage_verification": "artifacts/runtime_truth/current/canon_lineage_verification.json",
+    "capability_registry_audit": "artifacts/runtime_truth/current/capability_registry_audit.json",
+    "protocol_conformance_report": "artifacts/runtime_truth/current/protocol_conformance_report.json"
   },
   "authority_boundary": "Public runtime truth summary only; does not authorize action, alter governance, mutate canon, change mode legality, expose capabilities, or execute tools."
 }


### PR DESCRIPTION
### Motivation

- Ensure the post-promotion verifier reads the actual symbolic-dependency verdict from the committed promotion receipt rather than hardcoding a value so verification reflects the committed payload.
- Keep runtime-truth artifact paths repo-relative to avoid leaking local absolute paths into public artifacts. 
- Emit a small, inspectable verification artifact that mirrors the promotion receipt's symbolic verdict for downstream auditing.

### Description

- Added `LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/post_promotion_verifier_r1.py` which computes
  `symbolic_dependency_violation = bool(promotion_receipt.get("promotion_payload", {}).get("symbolic_dependency_violation", True))`, sets `checks["no_symbolic_dependency_violation"] = symbolic_dependency_violation is False`, and includes `"symbolic_dependency_violation": symbolic_dependency_violation` in the output payload.
- Added a committed `artifacts/runtime_truth/current/promotion_receipt.json` sample and a generated `artifacts/runtime_truth/current/post_promotion_verification.json` showing the verifier output, and updated the emitter/public snapshot logic to return repo-relative artifact paths instead of absolute paths.
- Normalized path reporting by adding `repo_relative_path` helpers in the truth emitter, governance/canon verifiers, and public snapshot builder so emitted JSON uses repo-relative paths.

### Testing

- Ran the observation and snapshot pipeline with `PYTHONDONTWRITEBYTECODE=1 python LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_observation_cycle_r1.py` and `.../runtime_truth_public_snapshot_r1.py`, which completed successfully and produced updated artifacts. 
- Executed the new verifier with `PYTHONDONTWRITEBYTECODE=1 python LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/post_promotion_verifier_r1.py` and validated the produced `post_promotion_verification.json` (passed). 
- Ran the runtime truth gate `PYTHONDONTWRITEBYTECODE=1 python studio/runtime_truth_gate_r1.py` and a path-scan to confirm no `/workspace` or `/home/runner` absolute paths remain in regenerated runtime-truth JSON artifacts, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a6d86648c8324b5ada937a73142a0)