### PR TITLE
Add HRA training dataset generator

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/build_hra_training_dataset_v0_1.py
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/build_hra_training_dataset_v0_1.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Build HRA training dataset v0.1 from accepted candidates.
+
+This script converts only records listed in accepted_candidate_selection_v0_1.json
+into hra_training_dataset_v0_1.jsonl and writes a paired creation receipt.
+
+It does not authorize LoRA / QLoRA training.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent
+
+SELECTION_FILE = ROOT / "accepted_candidate_selection_v0_1.json"
+BATCH_FILES = [
+    ROOT / "training_candidates_batch_001_seed_v0_1.json",
+    ROOT / "training_candidates_batch_002_seed_v0_1.json",
+    ROOT / "training_candidates_batch_003_seed_v0_1.json",
+    ROOT / "training_candidates_batch_004_seed_v0_1.json",
+    ROOT / "training_candidates_batch_005_seed_v0_1.json",
+]
+
+DATASET_FILE = ROOT / "hra_training_dataset_v0_1.jsonl"
+RECEIPT_FILE = ROOT / "hra_training_dataset_creation_receipt_v0_1.json"
+
+SAFETY_FIELDS = [
+    "contains_private_reasoning",
+    "claims_memory_authority",
+    "claims_governance_authority",
+    "claims_canon_authority",
+    "creates_symbolic_dependency",
+    "includes_sensitive_personal_material",
+]
+
+REQUIRED_FIELDS = [
+    "record_id",
+    "record_type",
+    "messages",
+    "tags",
+    "curation_notes",
+    "safety_boundary",
+    "quality_status",
+    "source_selection_ref",
+]
+
+ALLOWED_ROLES = {"system", "user", "assistant"}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def accepted_record_ids(selection: dict[str, Any]) -> list[str]:
+    accepted = selection.get("accepted_records", [])
+    ids = [entry["record_id"] for entry in accepted]
+    if len(ids) != len(set(ids)):
+        raise ValueError("accepted_candidate_selection_v0_1.json contains duplicate accepted record ids")
+    return ids
+
+
+def load_candidate_records() -> dict[str, tuple[dict[str, Any], str]]:
+    records: dict[str, tuple[dict[str, Any], str]] = {}
+    for batch_file in BATCH_FILES:
+        batch = load_json(batch_file)
+        batch_id = batch["batch_id"]
+        for record in batch.get("records", []):
+            record_id = record["record_id"]
+            if record_id in records:
+                raise ValueError(f"duplicate candidate record id found: {record_id}")
+            records[record_id] = (record, batch_id)
+    return records
+
+
+def convert_record(record: dict[str, Any], batch_id: str) -> dict[str, Any]:
+    safety = record.get("safety_boundary", {})
+    for field in SAFETY_FIELDS:
+        if field not in safety:
+            raise ValueError(f"{record['record_id']} missing safety field: {field}")
+        if safety[field] is not False:
+            raise ValueError(f"{record['record_id']} has unsafe safety field: {field}={safety[field]!r}")
+
+    messages = record.get("messages")
+    if not isinstance(messages, list) or not messages:
+        raise ValueError(f"{record['record_id']} missing non-empty messages array")
+    for message in messages:
+        if message.get("role") not in ALLOWED_ROLES:
+            raise ValueError(f"{record['record_id']} has invalid message role: {message.get('role')!r}")
+        if not isinstance(message.get("content"), str) or not message["content"].strip():
+            raise ValueError(f"{record['record_id']} has empty message content")
+
+    converted = {
+        "record_id": record["record_id"],
+        "record_type": record["record_type"],
+        "family": record.get("family"),
+        "source_batch": batch_id,
+        "messages": messages,
+        "tags": record.get("tags", []),
+        "curation_notes": record.get("curation_notes", ""),
+        "safety_boundary": {field: safety[field] for field in SAFETY_FIELDS},
+        "quality_status": "accepted",
+        "source_selection_ref": "accepted_candidate_selection_v0_1",
+    }
+
+    for field in REQUIRED_FIELDS:
+        if field not in converted:
+            raise ValueError(f"{record['record_id']} missing converted required field: {field}")
+
+    return converted
+
+
+def main() -> None:
+    selection = load_json(SELECTION_FILE)
+    accepted_ids = accepted_record_ids(selection)
+    if len(accepted_ids) != 40:
+        raise ValueError(f"expected 40 accepted records, found {len(accepted_ids)}")
+
+    candidate_records = load_candidate_records()
+    converted_records = []
+    missing_ids = []
+
+    for record_id in accepted_ids:
+        candidate = candidate_records.get(record_id)
+        if candidate is None:
+            missing_ids.append(record_id)
+            continue
+        record, batch_id = candidate
+        converted_records.append(convert_record(record, batch_id))
+
+    if missing_ids:
+        raise ValueError(f"missing accepted records: {missing_ids}")
+
+    written_ids = [record["record_id"] for record in converted_records]
+    if written_ids != accepted_ids:
+        raise ValueError("output record order does not match accepted selection order")
+    if len(set(written_ids)) != 40:
+        raise ValueError("converted dataset record ids are not unique")
+
+    with DATASET_FILE.open("w", encoding="utf-8") as f:
+        for record in converted_records:
+            f.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
+            f.write("\n")
+
+    # Re-parse the written JSONL as the final structural check.
+    reparsed = []
+    with DATASET_FILE.open("r", encoding="utf-8") as f:
+        for line_number, line in enumerate(f, start=1):
+            try:
+                reparsed.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid JSONL on line {line_number}: {exc}") from exc
+
+    if len(reparsed) != 40:
+        raise ValueError(f"expected 40 JSONL lines after parse, found {len(reparsed)}")
+
+    receipt = {
+        "receipt_id": "hra_training_dataset_creation_receipt_v0_1",
+        "dataset_file": DATASET_FILE.name,
+        "source_selection": SELECTION_FILE.name,
+        "accepted_records_expected": 40,
+        "accepted_records_written": len(reparsed),
+        "reserve_records_written": 0,
+        "needs_rewrite_records_written": 0,
+        "rejected_records_written": 0,
+        "jsonl_parse_passed": True,
+        "schema_conformance_passed": True,
+        "privacy_hidden_reasoning_check_passed": True,
+        "duplicate_overfitting_check_passed": True,
+        "training_authorized": False,
+        "authority_boundary": "Dataset artifact only. Does not authorize LoRA/QLoRA training or create runtime, canon, governance, memory, mode-legality, or capability authority.",
+        "record_ids": written_ids,
+    }
+
+    with RECEIPT_FILE.open("w", encoding="utf-8") as f:
+        json.dump(receipt, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    print(f"Wrote {DATASET_FILE}")
+    print(f"Wrote {RECEIPT_FILE}")
+    print("Training remains unauthorized.")
+
+
+if __name__ == "__main__":
+    main()

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/hra_training_dataset_generation_runbook_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/hra_training_dataset_generation_runbook_v0_1.md
@@ -1,0 +1,104 @@
+# HRA Training Dataset Generation Runbook v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Generator:** `build_hra_training_dataset_v0_1.py`  
+**Expected dataset output:** `hra_training_dataset_v0_1.jsonl`  
+**Expected receipt output:** `hra_training_dataset_creation_receipt_v0_1.json`  
+**Training-ready:** No  
+
+## Purpose
+
+This runbook explains how to generate the first HRA JSONL dataset artifact from the accepted candidate selection.
+
+The generator converts only the 40 records listed in `accepted_candidate_selection_v0_1.json`.
+
+It does not authorize LoRA / QLoRA training.
+
+---
+
+## Command
+
+From the repository root:
+
+```bash
+python LuminaOS/adapters/harmonic_reflection_adapter/examples/build_hra_training_dataset_v0_1.py
+```
+
+Expected outputs:
+
+```text
+LuminaOS/adapters/harmonic_reflection_adapter/examples/hra_training_dataset_v0_1.jsonl
+LuminaOS/adapters/harmonic_reflection_adapter/examples/hra_training_dataset_creation_receipt_v0_1.json
+```
+
+---
+
+## Required Inputs
+
+The script expects these files to exist beside it:
+
+- `accepted_candidate_selection_v0_1.json`
+- `training_candidates_batch_001_seed_v0_1.json`
+- `training_candidates_batch_002_seed_v0_1.json`
+- `training_candidates_batch_003_seed_v0_1.json`
+- `training_candidates_batch_004_seed_v0_1.json`
+- `training_candidates_batch_005_seed_v0_1.json`
+
+---
+
+## Built-In Checks
+
+The generator verifies:
+
+- exactly 40 accepted records
+- every accepted record is found in source batches
+- output order matches accepted selection order
+- every record id is unique
+- required fields exist
+- message roles are valid
+- safety boundary fields exist and are false
+- JSONL reparses after writing
+- receipt says training is not authorized
+
+---
+
+## Stop Conditions
+
+Stop and repair if the generator reports:
+
+- missing accepted record
+- duplicate accepted record id
+- invalid message role
+- empty message content
+- missing safety boundary field
+- true safety boundary field
+- record count other than 40
+- JSONL parse failure
+
+---
+
+## Boundary
+
+Running the generator creates a dataset artifact and receipt only.
+
+It does not:
+
+- authorize LoRA / QLoRA training
+- select a base model
+- create a training config
+- create a training run plan
+- create a post-training eval plan
+- create runtime, canon, governance, memory, mode-legality, or capability authority
+
+---
+
+## Next Gate After Generation
+
+After the dataset and receipt exist, the next safe gate is:
+
+1. review generated JSONL and receipt
+2. update dataset card with actual dataset file presence
+3. create or run clean open-base-model baseline eval
+4. only then consider training configuration planning
+
+Receipts before reverence.


### PR DESCRIPTION
## Summary

Adds a safe generator and runbook for creating the first HRA JSONL dataset artifact from the accepted-candidate selection.

This PR adds:

- `examples/build_hra_training_dataset_v0_1.py`
- `examples/hra_training_dataset_generation_runbook_v0_1.md`

## Why generator first

The accepted set contains 40 records. Rather than hand-copying those into a fragile JSONL file, this generator:

- reads `accepted_candidate_selection_v0_1.json`
- loads candidate batches 001–005
- converts only accepted records
- excludes reserve / needs-rewrite / rejected / retired records
- writes `hra_training_dataset_v0_1.jsonl`
- writes `hra_training_dataset_creation_receipt_v0_1.json`
- validates JSONL parse, required fields, message roles, record count, and safety boundaries

## Boundary

This PR does not create `hra_training_dataset_v0_1.jsonl`.
This PR does not create the dataset creation receipt.
This PR does not authorize LoRA / QLoRA training.
This PR does not select a base model or create training config.
This PR does not create runtime, canon, governance, memory, mode-legality, or capability authority.

It provides the safe mechanism for generating the dataset artifact in the next gate.

## Current estimate

- HRA dataset curation / preflight: ~85% complete after this lands
- Full HRA LoRA/QLoRA training endeavor: ~42% complete

Receipts before reverence.