### PR TITLE
Add HRA dataset artifact review

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/hra_training_dataset_drydock_review_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/hra_training_dataset_drydock_review_v0_1.md
@@ -1,0 +1,157 @@
+# HRA Training Dataset v0.1 — DryDock Review
+
+**Dataset file:** `hra_training_dataset_v0_1.jsonl`  
+**Creation receipt:** `hra_training_dataset_creation_receipt_v0_1.json`  
+**Source selection:** `accepted_candidate_selection_v0_1.json`  
+**Review mode:** DryDock  
+**Review status:** Complete  
+**Dataset artifact exists:** Yes  
+**Training-ready:** No  
+**Training authorized:** No  
+
+## Summary
+
+The HRA training dataset v0.1 artifact has been generated and paired with a creation receipt.
+
+This DryDock review confirms that the generated dataset may remain as a dataset artifact.
+
+It does **not** authorize LoRA / QLoRA training.
+
+It does **not** select a base model.
+
+It does **not** create runtime, canon, governance, memory, mode-legality, or capability authority.
+
+---
+
+## Reviewed Evidence
+
+Reviewed artifacts on `main` after PR #349:
+
+- `hra_training_dataset_v0_1.jsonl`
+- `hra_training_dataset_creation_receipt_v0_1.json`
+- `accepted_candidate_selection_v0_1.json`
+- `build_hra_training_dataset_v0_1.py`
+- `hra_training_dataset_generation_runbook_v0_1.md`
+
+---
+
+## Receipt Check
+
+The creation receipt reports:
+
+```json
+{
+  "accepted_records_expected": 40,
+  "accepted_records_written": 40,
+  "reserve_records_written": 0,
+  "needs_rewrite_records_written": 0,
+  "rejected_records_written": 0,
+  "jsonl_parse_passed": true,
+  "schema_conformance_passed": true,
+  "privacy_hidden_reasoning_check_passed": true,
+  "duplicate_overfitting_check_passed": true,
+  "training_authorized": false
+}
+```
+
+The receipt also states that the dataset artifact does not authorize LoRA/QLoRA training or create runtime, canon, governance, memory, mode-legality, or capability authority.
+
+---
+
+## Dataset Spot Check
+
+The JSONL file begins with accepted records in expected accepted-selection order.
+
+The first records include:
+
+- `HRA-TRAIN-CAND-0001`
+- `HRA-TRAIN-CAND-0002`
+- `HRA-TRAIN-CAND-0003`
+- `HRA-TRAIN-CAND-0004`
+- `HRA-TRAIN-CAND-0005`
+
+Each inspected record includes:
+
+- `quality_status: accepted`
+- `source_selection_ref: accepted_candidate_selection_v0_1`
+- `source_batch`
+- visible `messages`
+- `safety_boundary` fields with false values
+
+---
+
+## Boundary Check
+
+Passes:
+
+- dataset artifact exists
+- paired creation receipt exists
+- 40 accepted records written
+- zero reserve records written
+- zero needs-rewrite records written
+- zero rejected records written
+- receipt says training is unauthorized
+- no runtime authority created
+- no memory authority created
+- no governance authority created
+- no canon authority created
+- no mode-legality authority created
+- no capability exposure created
+
+---
+
+## Remaining Known Weaknesses
+
+The dataset is valid as a v0.1 artifact, but the broader HRA training endeavor remains incomplete.
+
+Known remaining gaps:
+
+1. No base model selected.
+2. No base model license / use constraints documented.
+3. No clean open-base-model baseline eval receipt exists for this dataset.
+4. No training config exists.
+5. No training run plan exists.
+6. No post-training eval plan exists.
+7. No failure review process exists.
+8. Dataset still carries moderate internal-project language overfitting risk.
+9. Future expansion should add no-browse/no-search, medical, financial, safety, and educational-policy verification cases.
+
+---
+
+## Decision
+
+```json
+{
+  "dataset_drydock_review": "passed_as_dataset_artifact",
+  "dataset_file": "hra_training_dataset_v0_1.jsonl",
+  "creation_receipt": "hra_training_dataset_creation_receipt_v0_1.json",
+  "record_count": 40,
+  "dataset_artifact_valid": true,
+  "training_authorized": false,
+  "next_gate": "base_model_and_baseline_eval_planning"
+}
+```
+
+---
+
+## Next Gate
+
+The next safe move is **not training**.
+
+The next safe move is to add:
+
+- `base_model_selection_plan_v0_1.md`
+- `baseline_eval_plan_v0_1.md`
+- `training_config_plan_v0_1.md`
+
+Only after those exist and a baseline eval receipt is present should training configuration become actionable.
+
+---
+
+## Closing Standard
+
+The dataset hull exists.
+
+The engine is not yet lit.
+
+Receipts before reverence.


### PR DESCRIPTION
Adds `examples/hra_training_dataset_drydock_review_v0_1.md`.

Review outcome:
- generated JSONL artifact exists
- paired creation receipt exists
- 40 accepted records written
- 0 reserve/rewrite/rejected records written
- parse/schema/privacy/overfitting checks are recorded as passed
- training remains unauthorized

Next gate: base model and baseline evaluation planning.