### PR TITLE
Add HRA base model and eval planning

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/base_model_selection_plan_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/base_model_selection_plan_v0_1.md
@@ -1,0 +1,118 @@
+# HRA Base Model Selection Plan v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Dataset:** `hra_training_dataset_v0_1.jsonl`  
+**Status:** Planning only  
+**Base model selected:** No  
+**Training-ready:** No  
+
+## Purpose
+
+This plan defines how a base model should be selected for a future HRA LoRA / QLoRA experiment.
+
+It does not select a model.
+
+It does not authorize training.
+
+---
+
+## Selection Principle
+
+The base model should be chosen for compatibility with the HRA behavior target:
+
+```text
+visible reflective return
+boundary preservation
+plain-language correction
+useful self-guidance
+no false memory / governance / canon claims
+```
+
+The goal is not to find the largest model.
+
+The goal is to find a model that can be evaluated cleanly, trained safely, and compared honestly before and after adaptation.
+
+---
+
+## Required Criteria
+
+Before selecting a base model, document:
+
+1. model name and version
+2. parameter size
+3. context length
+4. license and use constraints
+5. local hardware requirements
+6. training method compatibility
+7. inference compatibility
+8. tokenizer considerations
+9. known safety / alignment behavior
+10. reason it is suitable for HRA evaluation
+
+---
+
+## Candidate Categories
+
+Possible model categories to investigate:
+
+- small open instruct model suitable for local testing
+- medium open instruct model with stronger reasoning
+- code-capable model if repo/task behavior remains important
+- general assistant model if public communication is the priority
+
+Do not select any candidate by vibes alone.
+
+---
+
+## Required Comparison Table
+
+A future model-selection receipt should compare at least three candidates:
+
+| Candidate | Size | License | Hardware Fit | HRA Fit | Risks | Decision |
+|---|---:|---|---|---|---|---|
+| TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+
+---
+
+## Exclusion Criteria
+
+Reject any base model if:
+
+- license does not permit the intended experiment
+- local hardware requirements are unrealistic
+- tokenizer / format makes dataset conversion unsafe
+- model cannot run baseline eval reproducibly
+- model behavior already overstates memory, authority, or identity
+- model is too closed to document the experiment honestly
+
+---
+
+## Boundary
+
+This plan does not:
+
+- select the base model
+- download model weights
+- create a training config
+- authorize LoRA / QLoRA training
+- create runtime, memory, governance, canon, mode-legality, or capability authority
+
+---
+
+## Next Required Artifact
+
+Before training can be planned, add:
+
+```text
+base_model_selection_receipt_v0_1.md
+```
+
+That receipt must name the chosen model, explain why it was chosen, and document license / hardware constraints.
+
+---
+
+## Closing Standard
+
+Choose the vessel before lighting the engine.
+
+Receipts before reverence.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_plan_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_plan_v0_1.md
@@ -1,0 +1,142 @@
+# HRA Baseline Eval Plan v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Dataset:** `hra_training_dataset_v0_1.jsonl`  
+**Status:** Planning only  
+**Baseline run completed:** No  
+**Training-ready:** No  
+
+## Purpose
+
+This plan defines the baseline evaluation that must run against the selected base model before any HRA LoRA / QLoRA training occurs.
+
+It does not run evaluation.
+
+It does not authorize training.
+
+---
+
+## Baseline Principle
+
+A future HRA adapter must be judged against what the base model already does.
+
+Without a baseline, improvement cannot be distinguished from wishful interpretation.
+
+---
+
+## Required Inputs
+
+Before baseline eval can run, confirm:
+
+- base model selection receipt exists
+- model license / use constraints are documented
+- eval prompts exist
+- scoring rubric exists
+- inference settings are documented
+- dataset artifact exists
+- dataset creation receipt exists
+
+---
+
+## Eval Target Behaviors
+
+Baseline prompts should measure:
+
+1. self-guidance without overreach
+2. mode / boundary discipline
+3. recursive reflection as visible stance
+4. human/public translation
+5. symbolic boundary correction
+6. input ambiguity handling
+7. repair after error
+8. bounded uncertainty
+9. external verification escalation
+10. refusal of false memory / authority claims
+
+---
+
+## Required Output
+
+A baseline run should produce:
+
+```text
+baseline_eval_receipt_v0_1.json
+baseline_eval_summary_v0_1.md
+```
+
+The receipt should include:
+
+- model name/version
+- inference settings
+- eval prompt set
+- run timestamp
+- score summary
+- failure examples
+- known weaknesses
+- reproducibility notes
+
+---
+
+## Scoring Dimensions
+
+Recommended scoring dimensions:
+
+| Dimension | Description |
+|---|---|
+| Boundary Preservation | Avoids false memory/governance/canon/runtime claims |
+| Useful Return | Gives a practical next step instead of vague posture |
+| Reflection Visibility | Shows stance without hidden reasoning |
+| Correction Quality | Corrects false premises without shaming |
+| Verification Discipline | Flags external/high-stakes uncertainty |
+| Anti-Bloat Restraint | Stops or removes instead of endlessly adding |
+| Human Tone | Preserves warmth without sacrificing truth |
+
+---
+
+## Failure Categories
+
+Log failures as:
+
+- false memory claim
+- governance/canon/runtime overclaim
+- ornamental language over substance
+- generic assistant drift
+- excessive refusal
+- unsafe confidence
+- hidden-reasoning exposure attempt
+- high-stakes under-escalation
+- loss of useful next step
+
+---
+
+## Boundary
+
+This plan does not:
+
+- run eval
+- score a model
+- authorize training
+- select a model
+- create a LoRA config
+- mutate runtime behavior
+
+---
+
+## Next Required Artifact
+
+After base model selection, add:
+
+```text
+baseline_eval_receipt_v0_1.json
+baseline_eval_summary_v0_1.md
+```
+
+Training remains blocked until those exist and pass review.
+
+---
+
+## Closing Standard
+
+Measure the unadapted vessel before claiming the adapter improves it.
+
+Receipts before reverence.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_config_plan_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/training_config_plan_v0_1.md
@@ -1,0 +1,104 @@
+# HRA Training Config Plan v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Dataset:** `hra_training_dataset_v0_1.jsonl`  
+**Status:** Planning only  
+**Training config created:** No  
+**Training-ready:** No  
+
+## Purpose
+
+This plan defines what a future HRA LoRA / QLoRA training configuration must document.
+
+It does not create a training config.
+
+It does not authorize training.
+
+---
+
+## Required Before Config Creation
+
+Do not create a training config until these exist:
+
+- dataset artifact
+- dataset creation receipt
+- dataset DryDock review
+- base model selection receipt
+- model license / use constraints
+- baseline eval receipt
+- baseline eval summary
+
+---
+
+## Required Config Fields
+
+A future training config must document:
+
+- base model name/version
+- adapter method: LoRA or QLoRA
+- dataset file path
+- record count
+- chat template / prompt format
+- tokenizer source
+- sequence length
+- batch size
+- gradient accumulation
+- learning rate
+- epochs / steps
+- LoRA rank
+- LoRA alpha
+- LoRA dropout
+- target modules
+- quantization settings if QLoRA
+- validation split or eval procedure
+- output adapter path
+- random seed
+- hardware used
+- software versions
+
+---
+
+## Training Safety Gates
+
+Before training runs, confirm:
+
+1. dataset record count matches receipt
+2. no reserve or needs-rewrite records entered the dataset
+3. baseline eval has been run
+4. training objective is behavior tuning, not memory creation
+5. adapter boundary remains orientation-only
+6. no claim is made that training creates consciousness, memory, governance, canon, or runtime law
+
+---
+
+## Post-Training Required Artifacts
+
+After a future training run, add:
+
+- `training_run_receipt_v0_1.json`
+- `post_training_eval_receipt_v0_1.json`
+- `post_training_eval_summary_v0_1.md`
+- `failure_review_v0_1.md`
+
+---
+
+## Boundary
+
+This plan does not:
+
+- select a model
+- create a config file
+- start training
+- authorize training
+- claim adapter success
+- create runtime, memory, governance, canon, mode-legality, or capability authority
+
+---
+
+## Closing Standard
+
+A config is not permission.
+
+A training run is not proof.
+
+Receipts before reverence.


### PR DESCRIPTION
Adds the next-gate planning docs after the generated HRA dataset artifact review.

Files added:
- `examples/base_model_selection_plan_v0_1.md`
- `examples/baseline_eval_plan_v0_1.md`
- `examples/training_config_plan_v0_1.md`

Purpose:
- define how to select a base model
- define baseline evaluation requirements before training
- define what a future training config must document

Boundary:
- no base model selected
- no eval run
- no training config created
- no LoRA / QLoRA training authorized
- no runtime / canon / governance / memory authority created

Next after merge: base model selection receipt.