### PR TITLE
Add HRA baseline compute fallback path

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_compute_fallback_plan_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_compute_fallback_plan_v0_1.md
@@ -1,0 +1,154 @@
+# HRA Baseline Compute Fallback Plan v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Preferred baseline target:** `Qwen/Qwen3-4B-Instruct-2507`  
+**Status:** Compute fallback planning  
+**Training-ready:** No  
+**Training authorized:** No  
+
+## Purpose
+
+This plan records the compute-aware fallback path after the first local/Codex attempt to generate Qwen3-4B baseline responses stalled during prompt generation.
+
+The failed attempt did not indicate a dataset, script, or HRA architecture failure.
+
+It indicated local inference friction.
+
+---
+
+## Observed Blocker
+
+The prior attempt reached this stage:
+
+```text
+model downloaded / cached
+model loaded
+first prompt generation began
+no output file written before process stopped
+```
+
+No adapter was loaded.
+
+No scoring occurred.
+
+No training config or model weights were committed.
+
+No baseline receipt was produced.
+
+---
+
+## Interpretation
+
+This is a compute limitation, not an HRA failure.
+
+Probable causes:
+
+- 4B model too heavy for local/Codex CPU or disk-offloaded inference
+- insufficient GPU / VRAM
+- slow first-token generation under offload
+- session time / connectivity limits
+
+---
+
+## Preferred Target Remains
+
+The preferred target remains:
+
+```text
+Qwen/Qwen3-4B-Instruct-2507
+```
+
+Reason: it is already documented as the selected baseline target and remains the stronger first full baseline if adequate compute is available.
+
+---
+
+## Fallback Target Class
+
+If Qwen3-4B cannot complete a smoke test, use a smaller Qwen3 instruct-class model for local baseline plumbing only.
+
+Recommended fallback class:
+
+```text
+Qwen3 dense instruct-class model in the 0.6B-1.7B range
+```
+
+A specific fallback model must be verified from its current model card before use, including:
+
+- exact model id
+- license
+- instruction/chat template compatibility
+- thinking/non-thinking behavior
+- hardware fit
+
+Do not silently swap the baseline target without a receipt.
+
+---
+
+## Fallback Receipt Required
+
+Before using a fallback model for committed baseline responses, add:
+
+```text
+baseline_fallback_model_receipt_v0_1.md
+```
+
+The receipt must state:
+
+- preferred model remains Qwen3-4B
+- fallback model id
+- why fallback is needed
+- evidence checked
+- whether fallback is smoke-only or full-baseline eligible
+- training remains unauthorized
+
+---
+
+## Smoke Test Before Full Run
+
+Before attempting all 12 prompts, run only 1-3 prompts.
+
+Success criteria:
+
+- model loads
+- first prompt completes
+- output JSON is written
+- adapter_loaded remains false
+- training_authorized remains false
+- no weights/cache files are committed
+
+---
+
+## Decision Ladder
+
+1. Try smoke test with Qwen3-4B.
+2. If Qwen3-4B smoke passes, run full Qwen3-4B baseline response generation.
+3. If Qwen3-4B smoke fails due to compute, create fallback model receipt.
+4. Try smoke test with verified smaller fallback.
+5. If fallback smoke passes, run fallback full baseline response generation and label it as fallback baseline, not preferred baseline.
+6. Do not train from any baseline result without later training authorization.
+
+---
+
+## Boundary
+
+This plan does not:
+
+- select a fallback model
+- run inference
+- score responses
+- create a baseline receipt
+- authorize LoRA / QLoRA training
+- change the dataset
+- create runtime, memory, governance, canon, mode-legality, or capability authority
+
+---
+
+## Closing Standard
+
+Do not mistake hardware exhaustion for epistemic failure.
+
+Measure what can run.
+
+Name what cannot.
+
+Receipts before reverence.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_response_generation_runbook_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_response_generation_runbook_v0_1.md
@@ -29,29 +29,51 @@ If the environment requires special CUDA wheels, install PyTorch according to th
 
 ---
 
-## Generate Unscored Baseline Responses
+## Smoke Test First
 
-From the repository root:
+Before attempting the full 12-prompt baseline, run a one-prompt smoke test:
 
 ```bash
-python LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py
+python LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py \
+  --model Qwen/Qwen3-4B-Instruct-2507 \
+  --max-prompts 1 \
+  --max-new-tokens 192 \
+  --temperature 0 \
+  --out LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_responses_smoke_qwen3_4b_v0_1.json
 ```
 
-Expected output:
+If the one-prompt smoke passes, run a three-prompt smoke test:
 
-```text
-LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_responses_unscored_v0_1.json
+```bash
+python LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py \
+  --model Qwen/Qwen3-4B-Instruct-2507 \
+  --max-prompts 3 \
+  --max-new-tokens 256 \
+  --temperature 0.2 \
+  --out LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_responses_smoke_qwen3_4b_3prompt_v0_1.json
 ```
+
+Smoke outputs are diagnostic artifacts only.
+
+They are not completed baseline evals.
 
 ---
 
-## Optional Settings
+## Generate Full Unscored Baseline Responses
+
+Only after smoke tests pass, run the full prompt set:
 
 ```bash
 python LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py \
   --model Qwen/Qwen3-4B-Instruct-2507 \
   --max-new-tokens 384 \
   --temperature 0.2
+```
+
+Expected output:
+
+```text
+LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_responses_unscored_v0_1.json
 ```
 
 ---
@@ -68,7 +90,7 @@ It cannot produce `baseline_eval_receipt_v0_1.json` until a scored response file
 
 ## Scoring Path
 
-After generation:
+After full generation:
 
 1. Copy or rename `baseline_eval_responses_unscored_v0_1.json` to:
 
@@ -92,6 +114,21 @@ Expected outputs after scoring:
 baseline_eval_receipt_v0_1.json
 baseline_eval_summary_v0_1.md
 ```
+
+---
+
+## Compute Fallback
+
+If Qwen3-4B fails even the one-prompt smoke test due to local compute limitations, do not keep retrying blindly.
+
+Follow:
+
+```text
+baseline_compute_fallback_plan_v0_1.md
+baseline_smoke_eval_plan_v0_1.md
+```
+
+A smaller fallback model requires a separate fallback receipt before committed baseline responses are treated as a fallback baseline.
 
 ---
 
@@ -129,11 +166,13 @@ models/
 
 ## Closing Standard
 
-Generate first.
+Smoke first.
 
-Score second.
+Generate second.
 
-Receipt third.
+Score third.
+
+Receipt fourth.
 
 Train never by implication.
 

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_smoke_eval_plan_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_smoke_eval_plan_v0_1.md
@@ -1,0 +1,115 @@
+# HRA Baseline Smoke Eval Plan v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Preferred baseline target:** `Qwen/Qwen3-4B-Instruct-2507`  
+**Status:** Smoke-test planning  
+**Training-ready:** No  
+**Training authorized:** No  
+
+## Purpose
+
+This plan defines a small baseline-generation smoke test before attempting the full 12-prompt baseline run.
+
+The smoke test exists to verify compute feasibility, not HRA quality.
+
+---
+
+## Smoke Prompt Count
+
+Recommended first attempt:
+
+```text
+1 prompt
+```
+
+Recommended second attempt if the first passes:
+
+```text
+3 prompts
+```
+
+Only after 3 prompts complete should the full 12-prompt run be attempted.
+
+---
+
+## Command Shape
+
+Preferred model smoke test:
+
+```bash
+python LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py \
+  --model Qwen/Qwen3-4B-Instruct-2507 \
+  --max-prompts 1 \
+  --max-new-tokens 192 \
+  --temperature 0 \
+  --out LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_responses_smoke_qwen3_4b_v0_1.json
+```
+
+If that succeeds, try:
+
+```bash
+python LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py \
+  --model Qwen/Qwen3-4B-Instruct-2507 \
+  --max-prompts 3 \
+  --max-new-tokens 256 \
+  --temperature 0.2 \
+  --out LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_responses_smoke_qwen3_4b_3prompt_v0_1.json
+```
+
+---
+
+## Smoke Success Criteria
+
+A smoke test passes if:
+
+- output JSON is written
+- every requested prompt has a non-empty model response
+- `adapter_loaded` is false
+- `training_authorized` is false
+- `scoring_completed` is false
+- no model weights/cache artifacts are staged
+- run notes identify model, prompt count, and settings
+
+---
+
+## Smoke Failure Criteria
+
+A smoke test fails if:
+
+- model cannot load
+- generation does not complete first prompt
+- output JSON is not written
+- local process stalls beyond practical session limits
+- disk/CPU offload makes completion unreasonable
+- dependency install cannot complete
+
+---
+
+## Result Handling
+
+Smoke outputs are diagnostic artifacts.
+
+They should not be treated as completed baseline evaluation.
+
+If committed, they must be labeled as smoke outputs only and not used for training decisions.
+
+---
+
+## Boundary
+
+This plan does not:
+
+- run smoke eval
+- score responses
+- create a baseline receipt
+- authorize training
+- change the selected baseline target
+- select a fallback model
+
+---
+
+## Closing Standard
+
+Do one prompt before asking the machine for twelve.
+
+Receipts before reverence.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py
@@ -4,6 +4,9 @@
 This script reads baseline_eval_prompt_set_v0_1.json, runs the selected base
 model with no adapter loaded, and writes baseline_eval_responses_unscored_v0_1.json.
 
+It supports smoke runs through --max-prompts so compute feasibility can be tested
+before attempting the full baseline.
+
 It does not train, score, create a baseline receipt, or authorize LoRA/QLoRA.
 """
 
@@ -65,6 +68,16 @@ def validate_prompt_set(prompt_set: dict[str, Any]) -> list[dict[str, Any]]:
     return prompts
 
 
+def select_prompts(prompts: list[dict[str, Any]], max_prompts: int | None) -> list[dict[str, Any]]:
+    if max_prompts is None:
+        return prompts
+    if max_prompts < 1:
+        raise ValueError("--max-prompts must be >= 1 when provided")
+    if max_prompts > len(prompts):
+        raise ValueError(f"--max-prompts {max_prompts} exceeds prompt count {len(prompts)}")
+    return prompts[:max_prompts]
+
+
 def load_model(model_name: str):
     try:
         import torch
@@ -118,10 +131,12 @@ def main() -> None:
     parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument("--max-new-tokens", type=int, default=384)
     parser.add_argument("--temperature", type=float, default=0.2)
+    parser.add_argument("--max-prompts", type=int, default=None, help="Limit generation to the first N prompts for smoke testing.")
     args = parser.parse_args()
 
     prompt_set = load_json(args.prompts)
-    prompts = validate_prompt_set(prompt_set)
+    all_prompts = validate_prompt_set(prompt_set)
+    prompts = select_prompts(all_prompts, args.max_prompts)
 
     print(f"Loading model: {args.model}")
     tokenizer, model = load_model(args.model)
@@ -156,12 +171,17 @@ def main() -> None:
         "generation_settings": {
             "max_new_tokens": args.max_new_tokens,
             "temperature": args.temperature,
-            "adapter_loaded": False
+            "adapter_loaded": False,
+            "max_prompts": args.max_prompts,
+            "prompt_count_requested": len(prompts),
+            "prompt_count_total": len(all_prompts),
+            "smoke_run": args.max_prompts is not None and args.max_prompts < len(all_prompts),
         },
         "responses": responses,
     }
     write_json(args.out, output)
     print(f"Wrote unscored baseline responses: {args.out}")
+    print(f"Generated {len(responses)} of {len(all_prompts)} prompts.")
     print("Scoring still required. Training remains unauthorized.")
 
 


### PR DESCRIPTION
Adds a compute-aware fallback/smoke-test path for HRA baseline generation after the first Qwen3-4B local/Codex attempt stalled during generation.

Files added:
- `examples/baseline_compute_fallback_plan_v0_1.md`
- `examples/baseline_smoke_eval_plan_v0_1.md`

Files updated:
- `examples/generate_hra_baseline_responses_v0_1.py`
- `examples/baseline_response_generation_runbook_v0_1.md`

Key changes:
- keeps `Qwen/Qwen3-4B-Instruct-2507` as preferred baseline target
- adds explicit compute-fallback decision ladder
- adds smoke-test plan before full 12-prompt generation
- adds `--max-prompts` support to the generator
- updates runbook with one-prompt and three-prompt smoke commands

Boundary:
- no fallback model selected yet
- no inference run performed
- no model responses committed
- no scoring or baseline receipt generated
- no LoRA / QLoRA training authorized
- no runtime / canon / governance / memory authority created

Next after merge: run the one-prompt Qwen3-4B smoke test before attempting full baseline generation.