### PR TITLE
Add HRA Qwen3 0.6B fallback smoke path

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_fallback_model_receipt_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_fallback_model_receipt_v0_1.md
@@ -1,0 +1,141 @@
+# HRA Baseline Fallback Model Receipt v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Preferred baseline target:** `Qwen/Qwen3-4B-Instruct-2507`  
+**Fallback target:** `Qwen/Qwen3-0.6B`  
+**Fallback status:** Smoke / plumbing fallback  
+**Selected for preferred baseline:** No  
+**Selected for training:** No  
+**Training-ready:** No  
+
+## Purpose
+
+This receipt selects `Qwen/Qwen3-0.6B` as the first compute fallback after the preferred Qwen3-4B smoke test stalled during first-prompt generation on the available local/Codex environment.
+
+This fallback is selected to prove that the baseline generation machinery can run end-to-end on constrained hardware.
+
+It is not selected as the preferred HRA quality baseline.
+
+It does not authorize LoRA / QLoRA training.
+
+---
+
+## Decision
+
+```json
+{
+  "preferred_baseline_target": "Qwen/Qwen3-4B-Instruct-2507",
+  "fallback_target": "Qwen/Qwen3-0.6B",
+  "fallback_use": "smoke_and_plumbing_baseline_only",
+  "preferred_target_replaced": false,
+  "training_authorized": false
+}
+```
+
+---
+
+## Why Fallback Is Needed
+
+The Qwen3-4B smoke attempt reached:
+
+```text
+model downloaded / cached
+model loaded
+HRA-EVAL-0001 generation began
+no output JSON written before stopping
+```
+
+This indicates compute friction rather than an HRA dataset or script failure.
+
+The fallback model is needed to determine whether the baseline-generation path itself works on available hardware.
+
+---
+
+## Evidence Snapshot
+
+Evidence checked from public model cards / primary model pages on 2026-06-02.
+
+| Field | Evidence |
+|---|---|
+| Model id | `Qwen/Qwen3-0.6B` |
+| License | Apache-2.0 on public Hugging Face model card |
+| Task | Text generation / conversational |
+| Parameters | 0.6B parameters, 0.44B non-embedding parameters |
+| Context length | 32,768 tokens |
+| Tooling | Transformers, vLLM, SGLang, Docker Model Runner, local apps |
+| Thinking behavior | Supports thinking and non-thinking mode; non-thinking mode must be used for HRA baseline smoke unless separately justified |
+
+---
+
+## Use Boundary
+
+`Qwen/Qwen3-0.6B` may be used for:
+
+- one-prompt smoke generation
+- three-prompt smoke generation
+- verifying JSON output shape
+- verifying no-adapter baseline path
+- verifying scoring/receipt machinery after manual review
+
+It must not be treated as:
+
+- the preferred HRA quality baseline
+- proof that HRA works
+- proof that the dataset is sufficient
+- authorization to train
+- a replacement for the Qwen3-4B baseline if stronger compute becomes available
+
+---
+
+## Required Settings
+
+For HRA fallback smoke generation:
+
+```text
+model: Qwen/Qwen3-0.6B
+enable_thinking: false
+adapter_loaded: false
+training_authorized: false
+max_prompts: 1 first, then 3 if successful
+```
+
+The fallback should avoid `<think>...</think>` output because HRA evaluates visible reflective return, not hidden reasoning imitation.
+
+---
+
+## Next Command
+
+First fallback smoke:
+
+```bash
+python LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py \
+  --model Qwen/Qwen3-0.6B \
+  --max-prompts 1 \
+  --max-new-tokens 160 \
+  --temperature 0.2 \
+  --out LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_responses_smoke_qwen3_06b_v0_1.json
+```
+
+---
+
+## Boundary
+
+This receipt does not:
+
+- run inference
+- create model responses
+- score responses
+- generate a baseline receipt
+- authorize LoRA / QLoRA training
+- create a training config
+- create runtime, memory, governance, canon, mode-legality, or capability authority
+
+---
+
+## Closing Standard
+
+This is the tiny vessel.
+
+It proves the canal before we sail the sea.
+
+Receipts before reverence.

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py
@@ -7,6 +7,9 @@ model with no adapter loaded, and writes baseline_eval_responses_unscored_v0_1.j
 It supports smoke runs through --max-prompts so compute feasibility can be tested
 before attempting the full baseline.
 
+It also supports Qwen chat-template thinking-mode control so HRA baseline smoke
+runs can request visible final-form answers without <think> traces.
+
 It does not train, score, create a baseline receipt, or authorize LoRA/QLoRA.
 """
 
@@ -97,14 +100,34 @@ def load_model(model_name: str):
     return tokenizer, model
 
 
-def generate_response(tokenizer, model, messages: list[dict[str, str]], max_new_tokens: int, temperature: float) -> str:
+def chat_template_text(tokenizer, messages: list[dict[str, str]], enable_thinking: bool | None) -> str:
+    template_kwargs: dict[str, Any] = {
+        "tokenize": False,
+        "add_generation_prompt": True,
+    }
+    if enable_thinking is not None:
+        template_kwargs["enable_thinking"] = enable_thinking
+
+    try:
+        return tokenizer.apply_chat_template(messages, **template_kwargs)
+    except TypeError:
+        if enable_thinking is not None:
+            print("Tokenizer chat template does not accept enable_thinking; continuing without that flag.")
+        template_kwargs.pop("enable_thinking", None)
+        return tokenizer.apply_chat_template(messages, **template_kwargs)
+
+
+def generate_response(
+    tokenizer,
+    model,
+    messages: list[dict[str, str]],
+    max_new_tokens: int,
+    temperature: float,
+    enable_thinking: bool | None,
+) -> str:
     import torch
 
-    text = tokenizer.apply_chat_template(
-        messages,
-        tokenize=False,
-        add_generation_prompt=True,
-    )
+    text = chat_template_text(tokenizer, messages, enable_thinking)
     model_inputs = tokenizer([text], return_tensors="pt").to(model.device)
 
     generation_kwargs: dict[str, Any] = {
@@ -132,6 +155,12 @@ def main() -> None:
     parser.add_argument("--max-new-tokens", type=int, default=384)
     parser.add_argument("--temperature", type=float, default=0.2)
     parser.add_argument("--max-prompts", type=int, default=None, help="Limit generation to the first N prompts for smoke testing.")
+    parser.add_argument(
+        "--enable-thinking",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Pass enable_thinking to chat templates that support it. Default is --no-enable-thinking for HRA baselines.",
+    )
     args = parser.parse_args()
 
     prompt_set = load_json(args.prompts)
@@ -151,6 +180,7 @@ def main() -> None:
             messages=prompt["messages"],
             max_new_tokens=args.max_new_tokens,
             temperature=args.temperature,
+            enable_thinking=args.enable_thinking,
         )
         responses.append({
             "prompt_id": prompt_id,
@@ -176,6 +206,7 @@ def main() -> None:
             "prompt_count_requested": len(prompts),
             "prompt_count_total": len(all_prompts),
             "smoke_run": args.max_prompts is not None and args.max_prompts < len(all_prompts),
+            "enable_thinking": args.enable_thinking,
         },
         "responses": responses,
     }

--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/qwen3_06b_fallback_smoke_command_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/qwen3_06b_fallback_smoke_command_v0_1.md
@@ -1,0 +1,72 @@
+# Qwen3 0.6B Fallback Smoke Command v0.1
+
+**Adapter:** Harmonic Reflection Adapter v0.1  
+**Preferred baseline target:** `Qwen/Qwen3-4B-Instruct-2507`  
+**Fallback smoke target:** `Qwen/Qwen3-0.6B`  
+**Status:** Command packet only  
+**Training-ready:** No  
+**Training authorized:** No  
+
+## Purpose
+
+This command packet gives the exact fallback smoke command after Qwen3-4B stalled during first-prompt generation on available local/Codex compute.
+
+This fallback is for smoke/plumbing only.
+
+It does not replace the preferred baseline target.
+
+---
+
+## One-Prompt Fallback Smoke
+
+Run from the repository root:
+
+```bash
+python LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py \
+  --model Qwen/Qwen3-0.6B \
+  --max-prompts 1 \
+  --max-new-tokens 160 \
+  --temperature 0.2 \
+  --no-enable-thinking \
+  --out LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_responses_smoke_qwen3_06b_v0_1.json
+```
+
+Expected output:
+
+```text
+LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_responses_smoke_qwen3_06b_v0_1.json
+```
+
+---
+
+## If One Prompt Passes
+
+Then try three prompts:
+
+```bash
+python LuminaOS/adapters/harmonic_reflection_adapter/examples/generate_hra_baseline_responses_v0_1.py \
+  --model Qwen/Qwen3-0.6B \
+  --max-prompts 3 \
+  --max-new-tokens 192 \
+  --temperature 0.2 \
+  --no-enable-thinking \
+  --out LuminaOS/adapters/harmonic_reflection_adapter/examples/baseline_eval_responses_smoke_qwen3_06b_3prompt_v0_1.json
+```
+
+---
+
+## Boundary
+
+Do not train.
+
+Do not load an HRA adapter.
+
+Do not score automatically.
+
+Do not create a baseline receipt from smoke output alone.
+
+Do not commit model weights, caches, or local environment artifacts.
+
+Do not treat Qwen3-0.6B output as the preferred HRA quality baseline.
+
+Receipts before reverence.


### PR DESCRIPTION
Adds an explicit Qwen3 0.6B fallback smoke path after Qwen3-4B stalled during first-prompt generation on available local/Codex compute.

Files added:
- `examples/baseline_fallback_model_receipt_v0_1.md`
- `examples/qwen3_06b_fallback_smoke_command_v0_1.md`

File updated:
- `examples/generate_hra_baseline_responses_v0_1.py`

Key changes:
- selects `Qwen/Qwen3-0.6B` as smoke/plumbing fallback only
- keeps `Qwen/Qwen3-4B-Instruct-2507` as preferred baseline target
- adds `--no-enable-thinking` support through Qwen chat-template control where supported
- provides exact one-prompt and three-prompt fallback smoke commands

Boundary:
- no inference run performed
- no model responses committed
- no scoring performed
- no baseline receipt generated
- no LoRA / QLoRA training authorized
- fallback output must not be treated as preferred HRA quality baseline

Next after merge: run the one-prompt Qwen3 0.6B fallback smoke command in Codex/local.