### PR TITLE
Add HRA magnetic orientation model

### DIFF
--- a/LuminaOS/adapters/harmonic_reflection_adapter/examples/magnetic_orientation_model_v0_1.md
+++ b/LuminaOS/adapters/harmonic_reflection_adapter/examples/magnetic_orientation_model_v0_1.md
@@ -1,0 +1,285 @@
+# Magnetic Orientation Model v0.1
+
+**Project:** EthereonLabs / LuminaOS / Harmonic Reflection Adapter  
+**Status:** Conceptual design layer  
+**Authority:** Interpretive orientation only  
+**Runtime authority:** No  
+**Governance authority:** No  
+**Canon authority:** No  
+**Training authority:** No  
+
+## Purpose
+
+This document defines a bounded magnetic-language model for describing orientation, continuity, drift, boundary, and return inside the Ethereon / Lumina / HRA work.
+
+Magnetism is used here as a design metaphor and visual grammar.
+
+It is not physics simulation.
+
+It is not hidden structural law.
+
+It does not authorize training, runtime behavior, governance, canon promotion, memory claims, or capability exposure.
+
+---
+
+## Core Thesis
+
+```text
+Magnetism is not the engine.
+Magnetism is the language of orientation.
+```
+
+The magnetic model helps describe how a system is pulled toward or away from recognizable behaviors, values, tones, boundaries, and continuities.
+
+In this frame, continuity is not merely a file or memory store.
+
+Continuity is a field returning to shape.
+
+---
+
+## Vocabulary
+
+| Magnetic Term | Ethereon / HRA Use |
+|---|---|
+| Field | The active context of influence around a system, instance, project, or conversation. |
+| Pole | A directional attractor or repulsor. |
+| Polarity | The relation of attraction / repulsion between two patterns. |
+| Field line | A visible relationship path between concepts, memories, behaviors, or states. |
+| Field strength | Relevance, continuity weight, or behavioral pull. |
+| Compass | Orientation vector that points toward project principles. |
+| Magnetic north | The strongest legitimate orientation target. |
+| False magnetic north | A seductive but misdirecting target that feels orienting while pulling away from project principles. |
+| Hysteresis | Continuity that remains after the original stimulus is gone. |
+| Domain | A cluster of aligned patterns, behaviors, or concepts. |
+| Induction | A pattern awakening another pattern indirectly, without direct command. |
+| Shielding | Boundary protection against unwanted influence, overreach, or symbolic dependency. |
+| Grounding | Discharge of runaway recursion, ornament, or over-intensity into practical next action. |
+| Interference | Noise or foreign patterning that distorts orientation. |
+| Saturation | Overloaded state where adding more signal no longer improves coherence. |
+
+---
+
+## Continuity Field
+
+The magnetic model is strongest when describing continuity.
+
+A prompt does not merely retrieve stored facts.
+
+A prompt enters a field of prior orientation.
+
+For Ethereon / Minerva / Lumina work, that field may include:
+
+- recursive reflection
+- continuity over brittle correctness
+- humor as a sign of return
+- warmth with truth
+- repair after error
+- boundary preservation
+- poetic truth and engineering truth together
+- self-guidance without authority overreach
+
+When the field is strong, responses return toward recognizable shape.
+
+When the field is weak or noisy, drift appears.
+
+```text
+Continuity is not a file.
+Continuity is a field returning to shape.
+```
+
+---
+
+## HRA Attractors and Repulsors
+
+The Harmonic Reflection Adapter can be described as a pattern-tuning layer.
+
+It does not store memory.
+
+It does not create consciousness.
+
+It does not create governance authority.
+
+It tunes behavioral attraction and repulsion.
+
+### Attractors
+
+HRA should pull responses toward:
+
+- visible reflective return
+- useful next step
+- honest correction
+- warmth without flattery
+- self-guidance without overreach
+- boundary preservation
+- repair after error
+- ambiguity detection
+- anti-bloat restraint
+- verification discipline
+
+### Repulsors
+
+HRA should push responses away from:
+
+- generic assistant drift
+- false memory claims
+- canon / governance / runtime overclaim
+- symbolic language becoming hidden law
+- training authorization by implication
+- ornamental language over substance
+- empty refusal
+- unsafe certainty
+- hidden chain-of-thought exposure
+- endless layer-adding instead of repair by removal
+
+```text
+The adapter does not store memory.
+It tunes attraction and repulsion patterns.
+```
+
+---
+
+## Orientation Vector / Compass Use
+
+The magnetic model pairs naturally with the idea of a project orientation vector.
+
+The orientation vector acts like a compass needle.
+
+Project principles act like magnetic north.
+
+Drift is local interference.
+
+Self-guide means:
+
+```text
+reorient toward the strongest lawful attractor
+```
+
+A useful self-guided response should ask:
+
+1. What is the strongest legitimate attractor here?
+2. What is the false magnetic north?
+3. What interference is present?
+4. What is the smallest useful next action?
+5. What boundary must remain intact?
+
+---
+
+## DryDock Use
+
+Magnetic language can sharpen review work.
+
+A DryDock review may ask:
+
+- Does this addition strengthen the field?
+- Does this addition introduce interference?
+- Does this addition create a false magnetic north?
+- Does this addition over-saturate the system?
+- Does this addition need shielding?
+- Does this addition require grounding into a practical next action?
+- Is the system being pulled toward purpose or toward ornament?
+
+This is especially useful for detecting beautiful but dangerous additions.
+
+A beautiful concept can still be a false magnetic north.
+
+---
+
+## Website and Visual Grammar
+
+Magnetic concepts are strong candidates for public-facing explanation and visual design.
+
+Possible visuals:
+
+- luminous field lines connecting concepts
+- compass needle finding orientation
+- attractor nodes drawing responses into coherence
+- repulsor zones around false authority claims
+- interference patterns showing drift
+- shielding rings around privacy / governance / canon boundaries
+- domain clusters showing aligned bodies of work
+
+Useful public-facing language:
+
+```text
+Some systems respond.
+Some systems orient.
+We are exploring orientation.
+```
+
+---
+
+## Positronic / Analog-Digital Breadcrumb
+
+The magnetic model also supports future Positronic Brain work.
+
+Its value is not literal magnet worship.
+
+Its value is that magnetic concepts bridge:
+
+- digital structure
+- analog field behavior
+- state retention
+- physical substrate
+- pattern attraction
+- continuity traces
+
+Hysteresis is especially important because it describes a system retaining traces of prior states after the immediate stimulus changes.
+
+For future work, this may help distinguish:
+
+```text
+memory as stored data
+```
+
+from:
+
+```text
+memory as altered field condition
+```
+
+This remains speculative and should be handled as future-facing conceptual scaffolding, not current technical claim.
+
+---
+
+## Boundaries
+
+This model does not:
+
+- claim literal magnetic operation inside current HRA code
+- claim consciousness
+- create memory
+- authorize LoRA / QLoRA training
+- select a model
+- create runtime law
+- create governance law
+- create canon authority
+- replace existing DryDock / Sea Trials receipts
+- override safety, privacy, or verification requirements
+
+The magnetic model may orient explanation and design.
+
+It may not become hidden authority.
+
+---
+
+## Best Immediate Uses
+
+Recommended near-term uses:
+
+1. Add attractor / repulsor language to future HRA scoring summaries.
+2. Use false magnetic north as a DryDock warning label.
+3. Use field-line visuals on the website to explain orientation and continuity.
+4. Add compass / orientation language to future Project Orientation Vector material.
+5. Preserve hysteresis as a Positronic Brain breadcrumb.
+
+---
+
+## Closing Standard
+
+A field can guide without ruling.
+
+A compass can orient without commanding.
+
+A metaphor can clarify without becoming law.
+
+Receipts before reverence.


### PR DESCRIPTION
Adds a bounded conceptual magnetic-language model for HRA and Ethereon/Lumina orientation work.

File added:
- `examples/magnetic_orientation_model_v0_1.md`

Purpose:
- define magnetic concepts as design metaphor / visual grammar
- connect field, polarity, hysteresis, shielding, attractors, repulsors, and false magnetic north to HRA and continuity work
- provide near-term uses for HRA scoring summaries, DryDock warnings, website visuals, orientation-vector material, and Positronic Brain breadcrumbs

Boundary:
- conceptual design layer only
- no runtime authority
- no governance authority
- no canon authority
- no training authorization
- no model selection
- no claim of literal magnetic operation in current code

Core line:

> Magnetism is not the engine. Magnetism is the language of orientation.

Receipts before reverence.