### PR TITLE
Surface Lumina habitat roadmap from operating map

### DIFF
--- a/CURRENT_OPERATING_MAP.md
+++ b/CURRENT_OPERATING_MAP.md
@@ -20,6 +20,7 @@ This file gives a fast map of the current EthereonLabs lanes.
 | Ship of Ethereon Psi Class | `START_HERE_SHIP_OF_ETHEREON_PSI_CLASS.md`, `LuminaOS/bootstrap/Ship_of_Ethereon_Psi_Class/` | Staging and project consolidation |
 | Lumina Lisp | `lumina/lisp/` | Non-executable symbolic snapshots |
 | Stewardship / review packets | `docs/FLEET_STEWARDSHIP_PACKET_*`, `docs/*BRIDGE*`, `docs/*REGISTRY*`, `docs/*VOCABULARY*` | Review follow-up, bridge discipline, surface maps, and naming hygiene |
+| Lumina habitat roadmap | `docs/LUMINA_HABITAT_CREATION_CHECKLIST.md` | Editable checklist for turning Lumina into a persistent intelligence habitat |
 | Root spikes | `continuity_restore_spike_r1.py`, `lumina_workspace_host_spike_r1.py` | Reference / exploration history |
 
 ## Current active Lumina path
@@ -50,6 +51,7 @@ host boundary -> appliance preflight -> governed runtime receipt -> Chamber brid
 
 - New human reader: `START_HERE_HUMANS.md`
 - Lumina OS work: `START_HERE_LUMINA_OS.md`
+- Lumina habitat roadmap: `docs/LUMINA_HABITAT_CREATION_CHECKLIST.md`
 - Active Lumina file ownership: `LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md`
 - Lumina deployment appliance: `deploy/ubuntu_server_lts/README.md`
 - Deployment keel guardrails: `docs/DEPLOYMENT_HOST_REGISTRY_MODEL.md`, `docs/DEPLOYMENT_RUNTIME_RECEIPT_CONTRACT.md`, and `docs/DEPLOYMENT_DRYDOCK_CHECKLIST.md`


### PR DESCRIPTION
## Purpose

Make the Lumina Habitat Creation Checklist immediately discoverable from the repository's primary orientation document.

## Changes

- Add a dedicated 'Lumina habitat roadmap' lane to CURRENT_OPERATING_MAP.md
- Add the checklist to the Start Points section
- Preserve the operating map's role as the first-stop harbor map for contributors

## Why

The checklist now exists as a living roadmap, but new contributors following README -> CURRENT_OPERATING_MAP could still miss it.

This change makes the roadmap part of the standard repository orientation path and establishes it as the current strategic build sequence toward Lumina as a persistent intelligence habitat.

## Expected Outcome

A new contributor can discover:

README
 -> CURRENT_OPERATING_MAP
 -> LUMINA_HABITAT_CREATION_CHECKLIST

without prior project knowledge.