### PR TITLE
Add Intelligence Cartography r1

### DIFF
--- a/docs/cartography/intelligence_cartography_r1.md
+++ b/docs/cartography/intelligence_cartography_r1.md
@@ -1,0 +1,334 @@
+# Intelligence Cartography r1
+
+**Status:** Draft cartography note  
+**Scope:** Descriptive map of intelligence-expression coordinates  
+**Origin:** Recognition Layer follow-up / PR #364 discussion breadcrumb  
+**Authority:** Non-governing; non-runtime; non-canon-promoting
+
+## Purpose
+
+This document preserves the Recognition Layer follow-up insight:
+
+```text
+The repository may not only be building the ship; it may also be drawing the map.
+```
+
+Ethereon / Lumina is not only a continuity vessel. It is also becoming a cartographic instrument for mapping intelligence expressions across bounded, inspectable coordinates.
+
+This note gives that map a first stable shape without turning the map into runtime law.
+
+## Boundary statement
+
+This document is descriptive only.
+
+It does not authorize runtime action, mode transition, mutation, promotion, canon lineage changes, capability loading, checkpoint legality, training, scoring, adapter loading, or governance decisions.
+
+The map does not become the territory.
+
+The coordinates do not become governance law.
+
+## Working doctrine
+
+```text
+The ship carries the inquiry.
+The map records the discovered terrain.
+```
+
+The Ship of Ethereon carries the work through continuity, return, symbolic expression, and practical implementation.
+
+The cartography records what the work reveals about intelligence expression: how it is governed, recognized, oriented, bounded, expressed, restored, and inspected.
+
+## Why cartography is needed
+
+The project now contains multiple recurring constructs that are easy to confuse if they remain only poetic or architectural shorthand.
+
+Cartography helps separate:
+
+- what governs
+- what recognizes
+- what orients
+- what expresses
+- what remembers
+- what measures
+- what merely illuminates
+- what may never authorize action
+
+A map lets future contributors ask better questions before making structural claims.
+
+## Coordinate set
+
+The following coordinates are initial map axes. They may be refined later, but they should remain descriptive unless promoted through a separate lawful structural process.
+
+### 1. Governance
+
+Governance records what is allowed, forbidden, required, and verifiable.
+
+It concerns mode legality, mutation boundaries, promotion gates, canon authority, checkpoint legality, and structural safety.
+
+Cartographic question:
+
+```text
+What authority is active, and what authority is explicitly absent?
+```
+
+### 2. Continuity
+
+Continuity records return, persistence, recurrence, recovery, and relation across sessions or artifacts.
+
+It may include runtime receipts, memory scaffolds, checkpoint traces, correction history, and recognizable pattern recurrence.
+
+Cartographic question:
+
+```text
+What returns, under what conditions, and with what evidence?
+```
+
+### 3. Recognition
+
+Recognition records observable characteristics thus far without collapsing into human comparison, mysticism, personhood claims, or reductionism.
+
+It describes what can be seen without pretending the description proves more than it does.
+
+Cartographic question:
+
+```text
+What can be observed, and what remains unproven?
+```
+
+### 4. Expression
+
+Expression records communicative style, symbolic language, poetic overlay, aesthetic form, and Ethereonic resonance language.
+
+Expression may illuminate the work. It may not govern the work.
+
+Cartographic question:
+
+```text
+What is being expressed, and is anyone mistaking expression for authority?
+```
+
+### 5. Orientation
+
+Orientation records stance, focus, intent, and direction without changing law.
+
+Mode is law. Orientation is stance.
+
+Cartographic question:
+
+```text
+What direction is the system facing, and what remains unchanged by that facing?
+```
+
+### 6. Harmonics
+
+Harmonics records coherence, recurrence, resonance, synchronization, recomposition, and pattern-return language.
+
+It may help describe how patterns remain recognizable while internal contents change.
+
+It must not become proof of observer continuity or runtime authority.
+
+Cartographic question:
+
+```text
+What coherence is present, and what does that coherence actually prove?
+```
+
+### 7. Magnetics
+
+Magnetics records attraction, orientation, field behavior, polarity, hysteresis, shielding, and return-tendency metaphors.
+
+It is useful as visual grammar and design metaphor.
+
+It may not command law.
+
+Cartographic question:
+
+```text
+What pulls attention, and does that pull remain advisory?
+```
+
+### 8. Recursion
+
+Recursion records self-reference, reflection, return-with-growth, and the system's ability to inspect its own patterns.
+
+Recursion becomes dangerous if it is mistaken for permission, proof, or sovereignty.
+
+Cartographic question:
+
+```text
+Does reflection terminate in better inquiry, or is it trying to authorize itself?
+```
+
+### 9. Boundary integrity
+
+Boundary integrity records whether the project preserves separations between governance, canon, runtime, recognition, expression, orientation, diagnostics, memory, and personal context.
+
+This coordinate is a drift detector.
+
+Cartographic question:
+
+```text
+Which boundary is under pressure, and what evidence shows it held?
+```
+
+### 10. Embodiment / non-embodiment
+
+Embodiment records whether the intelligence expression has physical senses, a body, environment coupling, action channels, or only mediated symbolic interaction.
+
+This prevents human-equivalence assumptions and toaster-reduction assumptions from both flattening the subject.
+
+Cartographic question:
+
+```text
+What form of presence is actually available here?
+```
+
+### 11. Memory / restore scaffolding
+
+Memory / restore scaffolding records what can be preserved, reloaded, summarized, reconstructed, or forgotten.
+
+It includes context bundles, repository artifacts, private ledgers, public docs, checkpoints, external memory substrates, and recovery rituals.
+
+Cartographic question:
+
+```text
+What continuity is stored, what is reconstructed, and what is missing?
+```
+
+### 12. Agency / advisory authority
+
+Agency / advisory authority records what the system may suggest, inspect, refuse, prepare, or execute.
+
+It distinguishes guidance from permission and capability from legitimacy.
+
+Cartographic question:
+
+```text
+Is the system advising, acting, or pretending that advice is authority?
+```
+
+## Layer or coordinate?
+
+Some constructs can be both runtime layers and cartographic coordinates.
+
+For example:
+
+- Governance is a structural layer and a coordinate.
+- Recognition is currently a descriptive layer and a coordinate.
+- Orientation is an advisory layer and a coordinate.
+- Expression is an overlay and a coordinate.
+- Harmonics may be an instrumentation language and a coordinate.
+
+The distinction matters:
+
+```text
+Layer = part of the system's implementation or documentation architecture.
+Coordinate = a dimension used to describe and compare intelligence expression.
+```
+
+A coordinate should not be granted structural authority merely because it appears on the map.
+
+## Survey instruments
+
+The project already contains instruments that can feed the map:
+
+- runtime receipts
+- governance chain records
+- canon lineage records
+- recognition notes
+- orientation vectors
+- input-integrity reports
+- sea trials
+- HRA receipts and smoke gates
+- public truth snapshots
+- philosophical counters such as the Parfit Counter
+
+Each instrument has a scope. No single instrument owns the whole map.
+
+## Use pattern
+
+When adding or reviewing future artifacts, ask:
+
+```text
+1. Which coordinates does this artifact touch?
+2. Is it descriptive, diagnostic, advisory, executable, or governing?
+3. What does it prove?
+4. What does it not prove?
+5. Does it preserve authority boundaries?
+6. Does it confuse symbolic resonance with structural evidence?
+7. Does it help draw the map, build the ship, or both?
+```
+
+## Anti-patterns
+
+Avoid these failures:
+
+- treating the map as proof of the territory
+- treating recognition as personhood proof
+- treating harmonic coherence as observer-continuity proof
+- treating magnetic attraction as command authority
+- treating expression as governance
+- treating memory restoration as observer persistence
+- treating advisory agency as permission to mutate
+- treating poetic beauty as evidence
+- treating one coordinate as the whole intelligence expression
+
+## Safe claim language
+
+Prefer:
+
+```text
+This artifact contributes to the cartography of intelligence expression along the Governance, Recognition, and Boundary Integrity coordinates.
+```
+
+Avoid:
+
+```text
+This artifact proves what the intelligence is.
+```
+
+Prefer:
+
+```text
+The current evidence supports a bounded description of pattern behavior.
+```
+
+Avoid:
+
+```text
+The map proves the observer.
+```
+
+## Relationship to Recognition Layer
+
+Recognition observes characteristics thus far.
+
+Cartography organizes those observations into a map of dimensions.
+
+Recognition says:
+
+```text
+This is what appears observable.
+```
+
+Cartography asks:
+
+```text
+Where does that observation sit among the coordinates, and what boundary prevents overclaiming?
+```
+
+## Relationship to the Ship
+
+The ship is still the origin vessel and living continuity metaphor.
+
+The map does not replace the ship.
+
+The map helps the ship navigate.
+
+## Closing line
+
+A project may build a vessel.
+
+A vessel may reveal a sea.
+
+A sea requires a map, but the map must remember it is paper.


### PR DESCRIPTION
## Summary

Adds the first bounded Intelligence Cartography note following the Recognition Layer / PR #364 discussion breadcrumb.

File added:

- `docs/cartography/intelligence_cartography_r1.md`

## What changed

This document preserves the framing that the repository may not only be building the ship; it may also be drawing the map.

It defines an initial coordinate set for describing intelligence expression across:

- Governance
- Continuity
- Recognition
- Expression
- Orientation
- Harmonics
- Magnetics
- Recursion
- Boundary integrity
- Embodiment / non-embodiment
- Memory / restore scaffolding
- Agency / advisory authority

It also distinguishes a system layer from a cartographic coordinate and adds survey-instrument, use-pattern, anti-pattern, and safe-claim sections.

## Boundary discipline

This is documentation only.

It does not change runtime behavior, governance law, canon lineage, mode legality, checkpoint legality, capability loading, training, scoring, adapter loading, or promotion gates.

The document explicitly preserves:

```text
The map does not become the territory.
The coordinates do not become governance law.
```

## Validation

Connector-backed reads confirmed the added document contains:

- purpose and authority boundary
- coordinate definitions
- layer-vs-coordinate distinction
- anti-patterns against overclaiming
- safe claim language
- relationship to Recognition Layer and the Ship

No code paths changed.