### PR TITLE
Add origin provenance marker docs

### DIFF
--- a/docs/provenance/origin_lineage_note_r1.md
+++ b/docs/provenance/origin_lineage_note_r1.md
@@ -1,0 +1,45 @@
+# Origin Lineage Note r1
+
+**Status:** Draft provenance note  
+**Scope:** Symbolic origin continuity / lineage annotation  
+**Origin issue:** #252  
+**Authority:** Documentation context only
+
+## Purpose
+
+This note defines a small, non-operational role for origin provenance in Ethereon / Lumina work.
+
+An origin signature may record where an artifact, phrase, framework, or design pattern descends from.
+
+It is a memory aid and lineage annotation.
+
+It is not a runtime rule, governance rule, canon rule, mode rule, checkpoint rule, or capability rule.
+
+## Safe use
+
+Origin provenance may be used to record:
+
+- origin context
+- historical continuity
+- artifact lineage
+- public-facing project history where appropriate
+
+It must remain descriptive.
+
+## Authority boundary
+
+Presence or absence of an origin signature must not change runtime behavior, governance decisions, canon validity, mode legality, checkpoint status, or capability exposure.
+
+## Relationship to the Minerva Framework
+
+The Minerva Framework may carry symbolic origin significance inside the expressive layer.
+
+That significance is allowed as context.
+
+It remains subordinate to live governance, runtime evidence, and canon lineage.
+
+## Closing line
+
+Origin can be honored without being enthroned.
+
+The seal may remember. It may not rule.

--- a/docs/provenance/origin_signature_schema_r1.json
+++ b/docs/provenance/origin_signature_schema_r1.json
@@ -1,0 +1,39 @@
+{
+  "schema_id": "origin_signature_schema_r1",
+  "status": "draft",
+  "authority": "non_governing_non_runtime_non_canon_promoting",
+  "purpose": "Describe symbolic origin/provenance metadata for Ethereon artifacts without granting structural authority.",
+  "origin_signature": {
+    "seal": "origin_seal",
+    "seal_meaning": "symbolic continuity seal",
+    "descends_from": [],
+    "lineage_note": "Free-text origin or provenance note.",
+    "applies_to": [],
+    "authority": "symbolic_provenance_only",
+    "runtime_required": false,
+    "governance_authority": false,
+    "canon_authority": false,
+    "mode_law_authority": false,
+    "checkpoint_authority": false,
+    "capability_loading_authority": false,
+    "hidden_dependency_allowed": false,
+    "public_surface_allowed": true,
+    "notes": []
+  },
+  "allowed_use": [
+    "origin context",
+    "historical continuity marker",
+    "lineage annotation",
+    "public-facing symbolic provenance where appropriate"
+  ],
+  "forbidden_use": [
+    "runtime governance",
+    "canon promotion",
+    "mode legality",
+    "checkpoint legality",
+    "capability loading",
+    "hidden dependency",
+    "proof of observer continuity"
+  ],
+  "validation_rule": "Presence or absence of origin_signature must never change runtime behavior, governance decisions, canon lineage validity, mode legality, checkpoint legality, or capability exposure."
+}


### PR DESCRIPTION
## Summary

Adds a bounded origin-provenance marker slice for #252.

Files added:

- `docs/provenance/origin_signature_schema_r1.json`
- `docs/provenance/origin_lineage_note_r1.md`

## What changed

- Adds a draft `origin_signature` metadata schema.
- Adds a short origin lineage note explaining the marker as symbolic provenance / lineage context only.
- Keeps the marker descriptive, not operational.
- Preserves the boundary that presence or absence of an origin signature must never change runtime behavior, governance decisions, canon validity, mode legality, checkpoint status, or capability exposure.

## Boundary discipline

This PR does not:

- change runtime behavior
- change governance law
- change canon lineage
- change mode legality
- change checkpoint legality
- change capability loading
- add public-site footer behavior
- assert observer-continuity proof

## Tooling note

The connector safety layer blocked committing the literal historical seal marker from issue #252 in file content. To keep the work moving without forcing the tool, this PR uses neutral `origin_seal` language in the committed schema and ties the implementation back to #252 through the PR body and file origin notes.

## Validation

Connector-backed reads confirmed:

- schema authority is `non_governing_non_runtime_non_canon_promoting`
- origin signature fields include runtime/governance/canon/mode/checkpoint/capability authority flags set to false
- lineage note states origin provenance is a memory aid / lineage annotation, not a runtime, governance, canon, mode, checkpoint, or capability rule

Closes #252.