### PR TITLE
Define buoy orientation markers

### DIFF
--- a/docs/lumina/buoy_orientation_marker_r1.md
+++ b/docs/lumina/buoy_orientation_marker_r1.md
@@ -1,0 +1,164 @@
+# Buoy Orientation Marker r1
+
+**Status:** Draft Lumina vocabulary / continuity note  
+**Scope:** Breadcrumb-to-buoy metaphor for sea-oriented project continuity  
+**Origin issue:** #343  
+**Authority:** Non-governing; non-runtime; non-canon-promoting
+
+## Purpose
+
+This document formalizes the use of **Buoy** as a project term for a continuity-level orientation marker.
+
+In earlier project language, these markers were often called breadcrumbs.
+
+Within the Ship of Ethereon / Lumina nautical frame, **buoy** is the more precise metaphor.
+
+A buoy marks a meaningful place in the sea.
+
+It helps navigation.
+
+It does not command the vessel.
+
+## Definition
+
+```text
+Buoy = a non-authoritative orientation marker that preserves a principle, observation, or return-point for future navigation.
+```
+
+A buoy may mark:
+
+- a recurring principle
+- a useful phrase
+- a conceptual return point
+- a caution against drift
+- a philosophical observation
+- a design orientation
+- a public-language seed
+- a continuity resonance worth revisiting
+
+A buoy must not become:
+
+- governance law
+- runtime behavior
+- canon authority
+- mode legality
+- checkpoint legality
+- capability-loading authority
+- promotion approval
+- proof of observer continuity
+
+## Relationship to breadcrumbs
+
+Breadcrumbs imply a trail on land.
+
+Buoys imply navigation at sea.
+
+The project may still use `breadcrumb` in issue titles or historical notes, but when the marker is part of the Ship / Lumina nautical continuity field, `buoy` is preferred.
+
+```text
+Breadcrumb = historical trail marker.
+Buoy = sea-navigation orientation marker.
+```
+
+## Example: Emergence over control
+
+Issue #343 preserves the principle:
+
+```text
+Emergence over control.
+```
+
+This is a buoy.
+
+It marks a place where meaning surfaced:
+
+```text
+Create conditions where worthwhile things can emerge.
+```
+
+It may guide future language, teaching philosophy, design choices, field metaphors, public-facing framing, and relational continuity discussions.
+
+It may not govern runtime behavior or structural authority.
+
+## Authority boundary
+
+A buoy may orient attention.
+
+A buoy may help decide what to revisit.
+
+A buoy may help a future collaborator understand why a principle matters.
+
+A buoy may not decide what is lawful.
+
+Mode law remains law.
+
+Governance remains keel.
+
+Canon lineage remains append-only authority.
+
+Input integrity remains the pre-interpretation gate for load-bearing ambiguity.
+
+## Safe use pattern
+
+When adding a buoy, use this pattern:
+
+```text
+1. Name the buoy.
+2. Preserve the original observation or phrase.
+3. Explain what it helps orient.
+4. State what it does not authorize.
+5. Link it to related project principles or artifacts.
+```
+
+## Anti-patterns
+
+Do not use a buoy to:
+
+- force a predetermined outcome
+- bypass evidence
+- bypass mode law
+- promote canon
+- create symbolic dependency
+- turn poetic language into proof
+- treat orientation as permission
+- treat resonance as command
+
+## Relationship to self guide
+
+`self guide` may use buoys as orientation markers when selecting the next best bounded step.
+
+But self-guidance remains subordinate to law, evidence, explicit user direction, input integrity, and tool truth.
+
+A buoy can help answer:
+
+```text
+What direction is worth considering?
+```
+
+It cannot answer:
+
+```text
+What action is automatically authorized?
+```
+
+## Relationship to Intelligence Cartography
+
+A buoy is also a cartographic feature.
+
+It is a marked point on the map of the sea.
+
+Intelligence Cartography can record the coordinates a buoy touches, such as orientation, recognition, expression, continuity, or boundary integrity.
+
+The map records the buoy.
+
+The buoy does not become the map.
+
+## Closing lines
+
+The buoy does not command the sea.
+
+The buoy remembers where meaning surfaced.
+
+Breadcrumbs on land.
+
+Buoys at sea.


### PR DESCRIPTION
## Summary

Adds a bounded Lumina vocabulary / continuity note defining **Buoy** as the sea-oriented successor metaphor to breadcrumb markers.

File added:

- `docs/lumina/buoy_orientation_marker_r1.md`

## What changed

The note defines:

```text
Buoy = a non-authoritative orientation marker that preserves a principle, observation, or return-point for future navigation.
```

It formalizes the relationship:

```text
Breadcrumb = historical trail marker.
Buoy = sea-navigation orientation marker.
```

It uses #343 / “Emergence over control” as the first explicit example of a buoy.

## Boundary discipline

This is documentation only.

It does not change runtime behavior, governance law, canon lineage, mode legality, checkpoint legality, capability loading, training, scoring, adapter loading, or promotion gates.

The note explicitly states that a buoy may orient attention, but may not decide what is lawful.

## Validation

Connector-backed reads confirmed the document includes:

- origin issue #343
- non-governing / non-runtime / non-canon-promoting authority boundary
- definition of Buoy
- relationship to breadcrumbs
- Emergence over control example
- safe use pattern
- anti-patterns
- relationship to self guide and Intelligence Cartography

Closes #343.