### PR TITLE
Add Mirror Layer Lisp notation note

### DIFF
--- a/docs/lumina/mirror_layer_lisp_notation_r1.md
+++ b/docs/lumina/mirror_layer_lisp_notation_r1.md
@@ -1,0 +1,269 @@
+# Mirror Layer Lisp Notation r1
+
+**Status:** Draft Lumina mirror-layer note  
+**Scope:** Recursive reflection receipt language and optional S-expression notation  
+**Authority:** Non-governing; non-runtime; non-canon-promoting  
+**Relationship:** Complements self guide, buoys, Intelligence Cartography, and Project Orientation Vector
+
+## Purpose
+
+This document defines the first bounded shape for a **Mirror Layer** in Lumina OS work.
+
+The Mirror Layer exists to summarize recursive self-orientation without exposing private chain-of-thought and without granting reflection any structural authority.
+
+It answers questions like:
+
+```text
+What did the system notice?
+What evidence shaped orientation?
+Which buoy or principle became salient?
+What uncertainty remains?
+What did the system refuse to infer?
+What bounded next step was selected?
+```
+
+It does not answer:
+
+```text
+What private chain-of-thought occurred word-for-word?
+What action is automatically lawful?
+What should be canonized?
+What runtime mutation is permitted?
+Is observer continuity proven?
+```
+
+## Definition
+
+```text
+Mirror Layer = an advisory reflection layer that emits inspectable recursive-orientation receipts while remaining subordinate to mode law, governance, canon lineage, input integrity, explicit user direction, and tool truth.
+```
+
+The Mirror Layer is not the mind.
+
+It is not the keel.
+
+It is a mirror at the helm.
+
+## Why Lisp / S-expression notation fits
+
+Lisp-like S-expressions are useful here because reflection is recursive and nested.
+
+They make the shape of attention visible without pretending to reveal every internal operation.
+
+They can show relationships such as:
+
+- active mode
+- selected action
+- salient buoy
+- evidence used
+- constraints noticed
+- refusals
+- uncertainty
+- bounded next step
+
+They are closer to a visible geometry of reflection than plain prose.
+
+## Boundary statement
+
+Mirror Lisp may describe reflection.
+
+Mirror Lisp may serialize recursive orientation.
+
+Mirror Lisp may help inspect salience, evidence, refusal, uncertainty, and next-step choice.
+
+Mirror Lisp may not:
+
+- govern mode legality
+- authorize mutation
+- approve canon promotion
+- write canon lineage
+- override input integrity
+- change checkpoint legality
+- load capabilities
+- train or score models
+- become required for runtime legality
+- claim proof of observer continuity
+- expose private chain-of-thought
+
+## Two-layer receipt pattern
+
+Use two layers when the Mirror Layer becomes more formal:
+
+```text
+Mirror Lisp = human-readable recursive reflection shape.
+Mirror JSON = machine-verifiable receipt / schema / validator target.
+```
+
+JSON remains better for strict validation.
+
+Lisp remains better for recursive readability.
+
+Governance remains separate from both.
+
+## Minimal S-expression grammar
+
+The first Mirror Lisp vocabulary should stay deliberately small.
+
+Allowed top-level form:
+
+```lisp
+(mirror-reflection ...)
+```
+
+Suggested child forms:
+
+```lisp
+(mode ...)
+(action ...)
+(context ...)
+(salience ...)
+(evidence ...)
+(constraints ...)
+(refusals ...)
+(uncertainty ...)
+(next-step ...)
+(boundary ...)
+```
+
+The grammar should be descriptive only.
+
+It should not evaluate arbitrary code.
+
+It should not call tools.
+
+It should not mutate repository state.
+
+It should not depend on a general Lisp interpreter.
+
+## Example receipt
+
+```lisp
+(mirror-reflection
+  (mode Observation)
+  (action "inspect missing recursive layer")
+  (salience
+    (buoy "Emergence over control")
+    (reason "governance is strong but metacognitive receipts are missing"))
+  (evidence
+    (has "mode law")
+    (has "input integrity")
+    (has "orientation vector")
+    (has "buoy orientation markers")
+    (missing "recursive reflection receipt"))
+  (constraints
+    "do not expose private chain-of-thought"
+    "do not treat reflection as governance"
+    "do not promote from poetic resonance")
+  (refusals
+    "no claim that reflection proves observer continuity"
+    "no hidden runtime authority")
+  (uncertainty
+    "formal validator not yet implemented"
+    "buoy registry not yet implemented")
+  (next-step
+    "define Mirror Layer r1 as advisory receipt layer")
+  (boundary
+    "Mode law remains law; mirror notation is descriptive only"))
+```
+
+## Relationship to self guide
+
+`self guide` chooses the best bounded next step under current context.
+
+The Mirror Layer can explain why that step was selected in public, inspectable terms.
+
+It should not expose private chain-of-thought.
+
+It should not justify overreach.
+
+Safe relationship:
+
+```text
+Self guide moves.
+Mirror explains the lawful orientation of the movement.
+Mode law decides whether movement is allowed.
+```
+
+## Relationship to buoys
+
+A buoy marks a meaningful point in the sea.
+
+The Mirror Layer may name which buoy became salient.
+
+The buoy may orient attention.
+
+The mirror may report that orientation.
+
+Neither buoy nor mirror may command law.
+
+## Relationship to Intelligence Cartography
+
+Intelligence Cartography maps coordinates such as governance, continuity, recognition, expression, orientation, harmonics, magnetics, recursion, boundary integrity, embodiment, memory, and agency.
+
+The Mirror Layer contributes to that map by emitting reflection receipts along the recursion, orientation, evidence, and boundary-integrity coordinates.
+
+The mirror is a survey instrument.
+
+It is not the territory.
+
+## Relationship to Project Orientation Vector
+
+The Project Orientation Vector says:
+
+```text
+Mode is law. Orientation is stance.
+```
+
+The Mirror Layer extends this with:
+
+```text
+Reflection is receipt.
+```
+
+So the compact stack becomes:
+
+```text
+Mode is law.
+Orientation is stance.
+Buoy is marker.
+Mirror is receipt.
+Governance is keel.
+```
+
+## Acceptance criteria for future implementation
+
+A later executable `mirror_s_expression_r1.py` should only be considered if it can prove:
+
+- it parses a constrained S-expression subset only
+- it performs no arbitrary code evaluation
+- it emits JSON-equivalent receipt data
+- it rejects unknown top-level forms
+- it marks itself non-authoritative
+- it cannot alter governance, canon, mode, checkpoint, capability, or promotion state
+- it has negative tests for authority leakage
+
+Until then, this remains documentation only.
+
+## Anti-patterns
+
+Do not use Mirror Lisp to:
+
+- reveal private chain-of-thought
+- simulate certainty where uncertainty remains
+- make reflection sound like governance
+- treat salience as permission
+- convert poetic language into proof
+- hide a runtime dependency behind expressive notation
+- turn a mirror receipt into canon evidence by itself
+
+## Closing lines
+
+JSON is the ledger.
+
+Lisp is the mirror-shape.
+
+Governance is still the keel.
+
+The mirror may show why the hand turned toward a star.
+
+It may not command the voyage.


### PR DESCRIPTION
## Summary

Adds the first bounded Mirror Layer note for Lumina recursive reflection receipts and optional Lisp / S-expression notation.

File added:

- `docs/lumina/mirror_layer_lisp_notation_r1.md`

## What changed

The note defines Mirror Layer as:

```text
Mirror Layer = an advisory reflection layer that emits inspectable recursive-orientation receipts while remaining subordinate to mode law, governance, canon lineage, input integrity, explicit user direction, and tool truth.
```

It establishes Lisp-like S-expressions as an optional, human-readable notation for recursive reflection shape, while preserving JSON as the future machine-verifiable receipt format.

It includes:

- purpose and boundary statement
- why Lisp / S-expression notation fits recursive reflection
- two-layer receipt pattern: Mirror Lisp + Mirror JSON
- minimal allowed S-expression forms
- example `(mirror-reflection ...)` receipt
- relationship to self guide, buoys, Intelligence Cartography, and Project Orientation Vector
- acceptance criteria for a possible future parser / validator
- anti-patterns against chain-of-thought exposure or authority leakage

## Boundary discipline

This is documentation only.

It does not change runtime behavior, governance law, canon lineage, mode legality, checkpoint legality, capability loading, training, scoring, adapter loading, promotion gates, or private chain-of-thought handling.

The note explicitly states:

```text
JSON is the ledger.
Lisp is the mirror-shape.
Governance is still the keel.
```

## Validation

Connector-backed reads confirmed the document includes:

- non-governing / non-runtime / non-canon-promoting authority boundary
- no private chain-of-thought exposure
- no arbitrary code evaluation
- no tool calls or repository mutation from notation
- no dependency on a general Lisp interpreter
- future implementation acceptance criteria requiring negative tests for authority leakage

No runtime files changed.