### PR TITLE
Harden Lumina local install readiness

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/install_lumina.sh
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/install_lumina.sh
@@ -7,14 +7,96 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BOOTSTRAP_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 LUMINA_BIN="${BOOTSTRAP_ROOT}/bin/lumina"
-INSTALL_DIR="${HOME}/.local/bin"
+DOCTOR="${BOOTSTRAP_ROOT}/install/lumina_doctor.py"
+INSTALL_DIR="${LUMINA_INSTALL_DIR:-${HOME}/.local/bin}"
 TARGET="${INSTALL_DIR}/lumina"
 
+usage() {
+  cat <<'EOF'
+Usage: bash install/install_lumina.sh [--uninstall] [--doctor] [--ensure-state]
+
+Options:
+  --uninstall     Remove the user-local lumina symlink if it points to this checkout.
+  --doctor        Run the Lumina doctor after install.
+  --ensure-state  Create the local .lumina_state schema marker through the doctor.
+
+Environment:
+  LUMINA_INSTALL_DIR  Override install directory. Defaults to $HOME/.local/bin.
+EOF
+}
+
+UNINSTALL=0
+RUN_DOCTOR=0
+ENSURE_STATE=0
+
+for arg in "$@"; do
+  case "${arg}" in
+    --uninstall) UNINSTALL=1 ;;
+    --doctor) RUN_DOCTOR=1 ;;
+    --ensure-state) ENSURE_STATE=1 ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "Unknown option: ${arg}" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ ! -f "${LUMINA_BIN}" ]]; then
+  echo "Lumina host entrypoint missing: ${LUMINA_BIN}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${DOCTOR}" ]]; then
+  echo "Lumina doctor missing: ${DOCTOR}" >&2
+  exit 1
+fi
+
+if [[ ${UNINSTALL} -eq 1 ]]; then
+  if [[ -L "${TARGET}" ]]; then
+    CURRENT_TARGET="$(readlink "${TARGET}")"
+    if [[ "${CURRENT_TARGET}" == "${LUMINA_BIN}" ]]; then
+      rm "${TARGET}"
+      echo "Removed Lumina host command: ${TARGET}"
+    else
+      echo "Refusing to remove ${TARGET}; it points to ${CURRENT_TARGET}, not this checkout."
+      exit 1
+    fi
+  elif [[ -e "${TARGET}" ]]; then
+    echo "Refusing to remove ${TARGET}; it exists but is not a symlink."
+    exit 1
+  else
+    echo "Lumina host command is not installed at ${TARGET}"
+  fi
+  exit 0
+fi
+
 mkdir -p "${INSTALL_DIR}"
-chmod +x "${LUMINA_BIN}" || true
+chmod +x "${LUMINA_BIN}" "${DOCTOR}" || true
+
+if [[ -e "${TARGET}" && ! -L "${TARGET}" ]]; then
+  echo "Refusing to overwrite non-symlink target: ${TARGET}" >&2
+  exit 1
+fi
+
+if [[ -L "${TARGET}" ]]; then
+  CURRENT_TARGET="$(readlink "${TARGET}")"
+  if [[ "${CURRENT_TARGET}" != "${LUMINA_BIN}" ]]; then
+    echo "Replacing existing Lumina symlink: ${TARGET} -> ${CURRENT_TARGET}"
+  fi
+fi
+
 ln -sfn "${LUMINA_BIN}" "${TARGET}"
 
+DOCTOR_ARGS=()
+if [[ ${ENSURE_STATE} -eq 1 ]]; then
+  DOCTOR_ARGS+=("--ensure-state")
+fi
+
+if [[ ${RUN_DOCTOR} -eq 1 || ${ENSURE_STATE} -eq 1 ]]; then
+  echo "Running Lumina doctor..."
+  python3 "${DOCTOR}" "${DOCTOR_ARGS[@]}"
+fi
+
 echo "Lumina host command installed: ${TARGET}"
+echo "Bootstrap root: ${BOOTSTRAP_ROOT}"
 echo ""
 echo "Try:"
 echo "  lumina doctor"
@@ -22,6 +104,9 @@ echo "  lumina run \"Review Lumina OS progress and produce the next governed act
 echo "  lumina observe"
 echo "  lumina state"
 echo "  lumina studio"
+echo ""
+echo "Reset/remove:"
+echo "  bash install/install_lumina.sh --uninstall"
 echo ""
 case ":${PATH}:" in
   *":${INSTALL_DIR}:"*) ;;

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_doctor.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_doctor.py
@@ -3,7 +3,7 @@
 
 The doctor verifies that the local Lumina bootstrap has the minimum files needed
 to start like a system: host command, Studio CLI/server, runtime runner,
-state browser, capability registry, and core docs.
+state browser, capability registry, package inventory, and core docs.
 """
 from __future__ import annotations
 
@@ -14,18 +14,25 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = Path(__file__).resolve().parents[4]
+STATE_ROOT = REPO_ROOT / ".lumina_state" / "ship_of_ethereon_v2"
+STATE_SCHEMA_PATH = STATE_ROOT / "state_schema.json"
+STATE_SCHEMA_VERSION = "lumina-state-v0.1"
+MIN_PYTHON: Tuple[int, int] = (3, 10)
 
 REQUIRED_FILES = [
     "bin/lumina",
+    "requirements.txt",
     "studio/lumina_cli.py",
+    "studio/lumina_cli_psi42_v18.py",
     "studio/lumina_studio_server.py",
     "studio/lumina_state_browser.py",
     "runtime/runtime_runner_r1_merged.py",
-    "runtime/runtime_runner_auto_snapshot_r1.py",
+    "runtime/runtime_runner_auto_snapshot_psi42_v18_r1.py",
+    "runtime/runtime_runner_psi42_v18_adapter_r1.py",
     "runtime/runtime_spine_r1.py",
     "runtime/capability_registry_r1.json",
     "runtime/input_integrity_layer_r1.py",
@@ -33,6 +40,7 @@ REQUIRED_FILES = [
     "runtime/canon_lineage_store_r1.py",
     "docs/Lumina_OS_Host_Layer_001.md",
     "docs/Lumina_Local_Runbook_001.md",
+    "docs/Lumina_Package_Install_R1.md",
 ]
 
 OPTIONAL_FILES = [
@@ -44,15 +52,16 @@ OPTIONAL_FILES = [
 
 PYTHON_IMPORT_CHECKS = [
     "runtime/runtime_runner_r1_merged.py",
-    "runtime/runtime_runner_auto_snapshot_r1.py",
+    "runtime/runtime_runner_auto_snapshot_psi42_v18_r1.py",
     "studio/lumina_cli.py",
+    "studio/lumina_cli_psi42_v18.py",
     "studio/lumina_state_browser.py",
 ]
 
 COMMAND_SMOKE_CHECKS = [
     ["bin/lumina", "--help"],
     ["bin/lumina", "doctor", "--json"],
-    ["studio/lumina_cli.py", "--help"],
+    ["studio/lumina_cli_psi42_v18.py", "--help"],
 ]
 
 
@@ -107,6 +116,32 @@ def command_smoke_check(command: List[str]) -> Dict[str, Any]:
         return {"command": " ".join(command), "ok": False, "reason": str(exc)}
 
 
+def python_version_check() -> Dict[str, Any]:
+    current = sys.version_info[:2]
+    return {
+        "ok": current >= MIN_PYTHON,
+        "current": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        "minimum": f"{MIN_PYTHON[0]}.{MIN_PYTHON[1]}",
+    }
+
+
+def dependency_inventory_check() -> Dict[str, Any]:
+    path = BOOTSTRAP_ROOT / "requirements.txt"
+    if not path.exists():
+        return {"ok": False, "reason": "requirements.txt missing"}
+    lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines()]
+    requirements = [line for line in lines if line and not line.startswith("#")]
+    pinned = [line for line in requirements if "==" in line]
+    unpinned = [line for line in requirements if "==" not in line]
+    return {
+        "ok": bool(requirements) and not unpinned,
+        "path": "requirements.txt",
+        "requirement_count": len(requirements),
+        "pinned_count": len(pinned),
+        "unpinned": unpinned,
+    }
+
+
 def capability_registry_check() -> Dict[str, Any]:
     path = BOOTSTRAP_ROOT / "runtime" / "capability_registry_r1.json"
     if not path.exists():
@@ -127,37 +162,87 @@ def capability_registry_check() -> Dict[str, Any]:
         return {"ok": False, "reason": str(exc)}
 
 
-def state_path_check() -> Dict[str, Any]:
-    state_root = REPO_ROOT / ".lumina_state" / "ship_of_ethereon_v2"
+def expected_state_schema_payload() -> Dict[str, Any]:
     return {
-        "state_root": str(state_root),
-        "exists": state_root.exists(),
-        "note": "state root is created by runtime cycles; missing is acceptable before first run",
+        "schema_version": STATE_SCHEMA_VERSION,
+        "state_root_owner": "Lumina host/runtime local state",
+        "authority_boundary": "State schema supports install/readiness checks only; runtime governance remains authoritative.",
+        "known_subdirectories": [
+            "runtime receipts",
+            "context bundles",
+            "checkpoints",
+            "governance logs",
+            "studio state browser outputs",
+        ],
     }
 
 
-def run_doctor() -> Dict[str, Any]:
+def ensure_state_schema() -> None:
+    STATE_ROOT.mkdir(parents=True, exist_ok=True)
+    if not STATE_SCHEMA_PATH.exists():
+        STATE_SCHEMA_PATH.write_text(json.dumps(expected_state_schema_payload(), indent=2) + "\n", encoding="utf-8")
+
+
+def state_path_check(*, ensure_state: bool = False) -> Dict[str, Any]:
+    if ensure_state:
+        ensure_state_schema()
+    schema_payload: Dict[str, Any] = {}
+    schema_error = None
+    if STATE_SCHEMA_PATH.exists():
+        try:
+            schema_payload = json.loads(STATE_SCHEMA_PATH.read_text(encoding="utf-8"))
+        except Exception as exc:
+            schema_error = str(exc)
+    return {
+        "state_root": str(STATE_ROOT),
+        "exists": STATE_ROOT.exists(),
+        "writable_parent": os.access(STATE_ROOT.parent if STATE_ROOT.parent.exists() else REPO_ROOT, os.W_OK),
+        "schema_path": str(STATE_SCHEMA_PATH),
+        "schema_exists": STATE_SCHEMA_PATH.exists(),
+        "schema_version": schema_payload.get("schema_version"),
+        "schema_ok": (schema_payload.get("schema_version") == STATE_SCHEMA_VERSION) if schema_payload else not STATE_SCHEMA_PATH.exists(),
+        "schema_error": schema_error,
+        "created_or_verified": ensure_state,
+        "note": "state root is created by runtime cycles or by running doctor with --ensure-state",
+    }
+
+
+def run_doctor(*, ensure_state: bool = False) -> Dict[str, Any]:
     required = [file_check(path, required=True) for path in REQUIRED_FILES]
     optional = [file_check(path, required=False) for path in OPTIONAL_FILES]
     imports = [import_check(path) for path in PYTHON_IMPORT_CHECKS]
     commands = [command_smoke_check(command) for command in COMMAND_SMOKE_CHECKS]
     registry = capability_registry_check()
+    python_version = python_version_check()
+    dependencies = dependency_inventory_check()
+    state = state_path_check(ensure_state=ensure_state)
     missing_required = [item["path"] for item in required if not item["exists"] or not item["is_file"]]
     failed_imports = [item for item in imports if not item["ok"]]
     failed_commands = [item for item in commands if not item["ok"]]
-    ok = not missing_required and not failed_imports and not failed_commands and bool(registry.get("ok"))
+    ok = (
+        not missing_required
+        and not failed_imports
+        and not failed_commands
+        and bool(registry.get("ok"))
+        and bool(python_version.get("ok"))
+        and bool(dependencies.get("ok"))
+        and bool(state.get("writable_parent"))
+        and bool(state.get("schema_ok"))
+    )
     return {
-        "schema_version": "lumina-doctor-v0.2",
+        "schema_version": "lumina-doctor-v0.3",
         "ok": ok,
         "bootstrap_root": str(BOOTSTRAP_ROOT),
         "repo_root": str(REPO_ROOT),
         "python": sys.version.split()[0],
+        "python_version": python_version,
         "required_files": required,
         "optional_files": optional,
+        "dependency_inventory": dependencies,
         "import_checks": imports,
         "command_smoke_checks": commands,
         "capability_registry": registry,
-        "state": state_path_check(),
+        "state": state,
         "missing_required_files": missing_required,
         "failed_imports": failed_imports,
         "failed_commands": failed_commands,
@@ -168,12 +253,19 @@ def print_human(payload: Dict[str, Any]) -> None:
     print("Lumina doctor")
     print(f"  ok:              {payload['ok']}")
     print(f"  bootstrap root:  {payload['bootstrap_root']}")
-    print(f"  python:          {payload['python']}")
+    print(f"  python:          {payload['python']} (min {payload['python_version']['minimum']})")
+    print(f"  dependencies ok: {payload['dependency_inventory'].get('ok')}")
     print(f"  registry ok:     {payload['capability_registry'].get('ok')}")
     print(f"  capability count:{payload['capability_registry'].get('capability_count')}")
+    print(f"  state root:      {payload['state']['state_root']}")
+    print(f"  state schema:    {payload['state'].get('schema_version') or 'not created yet'}")
     if payload["missing_required_files"]:
         print("  missing required:")
         for item in payload["missing_required_files"]:
+            print(f"    - {item}")
+    if payload["dependency_inventory"].get("unpinned"):
+        print("  unpinned dependencies:")
+        for item in payload["dependency_inventory"]["unpinned"]:
             print(f"    - {item}")
     if payload["failed_imports"]:
         print("  failed imports:")
@@ -188,13 +280,16 @@ def print_human(payload: Dict[str, Any]) -> None:
         print("  observe command: bin/lumina observe")
         print("  state command:   bin/lumina state")
         print("  studio command:  bin/lumina studio")
+    if not payload["state"].get("schema_exists"):
+        print("  state setup:     run doctor with --ensure-state to create the local schema marker")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Check local Lumina host readiness.")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument("--ensure-state", action="store_true", help="Create the local .lumina_state schema marker if missing.")
     args = parser.parse_args()
-    payload = run_doctor()
+    payload = run_doctor(ensure_state=args.ensure_state)
     if args.json:
         print(json.dumps(payload, indent=2))
     else:

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/requirements.txt
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/requirements.txt
@@ -1,0 +1,7 @@
+# Lumina OS bootstrap dependency inventory
+#
+# R1 package/install rule: keep this list pinned so `lumina doctor` can
+# distinguish a repeatable developer-beta install path from an ambient local
+# Python environment.
+
+numpy==2.3.0


### PR DESCRIPTION
## Summary

Starts the first implementation lane after the Package / Install R1 planning PR.

This PR hardens Lumina's local developer-beta install path by updating:

- `install/lumina_doctor.py`
- `install/install_lumina.sh`
- `requirements.txt`

## What changed

Doctor v0.3 adds Python minimum checks, pinned dependency inventory checks, current Psi-42 v1.8 path checks, local state schema marker awareness, and an opt-in `--ensure-state` flag.

Installer hardening adds `--doctor`, `--ensure-state`, `--uninstall`, safer symlink handling, and `LUMINA_INSTALL_DIR` support.

Dependency inventory adds a pinned bootstrap `requirements.txt` beginning with `numpy==2.3.0`.

## Boundary

No runtime governance, canon lineage, mode legality, capability authority, or runtime law changed.

## Validation

Connector/static validation only here: existing installer and doctor were fetched from `main`, updated through the GitHub contents API, and aligned with the current v1.8 host entrypoint references. No local checkout was available to execute the doctor.

## Stacking note

This branch is based on `drydock/lumina-package-install-r1`. If #373 merges first, this PR can be retargeted to `main`.