### PR TITLE
Add Lumina local state schema helper

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/install_lumina.sh
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/install_lumina.sh
@@ -13,12 +13,13 @@ TARGET="${INSTALL_DIR}/lumina"
 
 usage() {
   cat <<'EOF'
-Usage: bash install/install_lumina.sh [--uninstall] [--doctor] [--ensure-state]
+Usage: bash install/install_lumina.sh [--uninstall] [--doctor] [--ensure-state] [--migrate-state]
 
 Options:
-  --uninstall     Remove the user-local lumina symlink if it points to this checkout.
-  --doctor        Run the Lumina doctor after install.
-  --ensure-state  Create the local .lumina_state schema marker through the doctor.
+  --uninstall      Remove the user-local lumina symlink if it points to this checkout.
+  --doctor         Run the Lumina doctor after install.
+  --ensure-state   Create the local .lumina_state schema marker through the doctor.
+  --migrate-state  Migrate a known older local state schema marker through the doctor.
 
 Environment:
   LUMINA_INSTALL_DIR  Override install directory. Defaults to $HOME/.local/bin.
@@ -28,12 +29,14 @@ EOF
 UNINSTALL=0
 RUN_DOCTOR=0
 ENSURE_STATE=0
+MIGRATE_STATE=0
 
 for arg in "$@"; do
   case "${arg}" in
     --uninstall) UNINSTALL=1 ;;
     --doctor) RUN_DOCTOR=1 ;;
     --ensure-state) ENSURE_STATE=1 ;;
+    --migrate-state) MIGRATE_STATE=1 ;;
     --help|-h) usage; exit 0 ;;
     *) echo "Unknown option: ${arg}" >&2; usage; exit 2 ;;
   esac
@@ -89,8 +92,11 @@ DOCTOR_ARGS=()
 if [[ ${ENSURE_STATE} -eq 1 ]]; then
   DOCTOR_ARGS+=("--ensure-state")
 fi
+if [[ ${MIGRATE_STATE} -eq 1 ]]; then
+  DOCTOR_ARGS+=("--migrate-state")
+fi
 
-if [[ ${RUN_DOCTOR} -eq 1 || ${ENSURE_STATE} -eq 1 ]]; then
+if [[ ${RUN_DOCTOR} -eq 1 || ${ENSURE_STATE} -eq 1 || ${MIGRATE_STATE} -eq 1 ]]; then
   echo "Running Lumina doctor..."
   python3 "${DOCTOR}" "${DOCTOR_ARGS[@]}"
 fi
@@ -104,6 +110,10 @@ echo "  lumina run \"Review Lumina OS progress and produce the next governed act
 echo "  lumina observe"
 echo "  lumina state"
 echo "  lumina studio"
+echo ""
+echo "State setup/migration:"
+echo "  bash install/install_lumina.sh --ensure-state"
+echo "  bash install/install_lumina.sh --migrate-state"
 echo ""
 echo "Reset/remove:"
 echo "  bash install/install_lumina.sh --uninstall"

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_doctor.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_doctor.py
@@ -3,7 +3,8 @@
 
 The doctor verifies that the local Lumina bootstrap has the minimum files needed
 to start like a system: host command, Studio CLI/server, runtime runner,
-state browser, capability registry, package inventory, and core docs.
+state browser, capability registry, package inventory, state schema helper,
+and core docs.
 """
 from __future__ import annotations
 
@@ -18,14 +19,21 @@ from typing import Any, Dict, List, Tuple
 
 BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = Path(__file__).resolve().parents[4]
-STATE_ROOT = REPO_ROOT / ".lumina_state" / "ship_of_ethereon_v2"
-STATE_SCHEMA_PATH = STATE_ROOT / "state_schema.json"
-STATE_SCHEMA_VERSION = "lumina-state-v0.1"
+INSTALL_ROOT = BOOTSTRAP_ROOT / "install"
+if str(INSTALL_ROOT) not in sys.path:
+    sys.path.insert(0, str(INSTALL_ROOT))
+
+try:
+    from lumina_state_schema import inspect_state_schema
+except Exception:  # pragma: no cover - doctor reports this through import checks too
+    inspect_state_schema = None
+
 MIN_PYTHON: Tuple[int, int] = (3, 10)
 
 REQUIRED_FILES = [
     "bin/lumina",
     "requirements.txt",
+    "install/lumina_state_schema.py",
     "studio/lumina_cli.py",
     "studio/lumina_cli_psi42_v18.py",
     "studio/lumina_studio_server.py",
@@ -51,6 +59,7 @@ OPTIONAL_FILES = [
 ]
 
 PYTHON_IMPORT_CHECKS = [
+    "install/lumina_state_schema.py",
     "runtime/runtime_runner_r1_merged.py",
     "runtime/runtime_runner_auto_snapshot_psi42_v18_r1.py",
     "studio/lumina_cli.py",
@@ -162,52 +171,17 @@ def capability_registry_check() -> Dict[str, Any]:
         return {"ok": False, "reason": str(exc)}
 
 
-def expected_state_schema_payload() -> Dict[str, Any]:
-    return {
-        "schema_version": STATE_SCHEMA_VERSION,
-        "state_root_owner": "Lumina host/runtime local state",
-        "authority_boundary": "State schema supports install/readiness checks only; runtime governance remains authoritative.",
-        "known_subdirectories": [
-            "runtime receipts",
-            "context bundles",
-            "checkpoints",
-            "governance logs",
-            "studio state browser outputs",
-        ],
-    }
+def state_path_check(*, ensure_state: bool = False, migrate_state: bool = False) -> Dict[str, Any]:
+    if inspect_state_schema is None:
+        return {
+            "ok": False,
+            "compatible": False,
+            "reason": "lumina_state_schema helper unavailable",
+        }
+    return inspect_state_schema(ensure=ensure_state, migrate=migrate_state).to_dict()
 
 
-def ensure_state_schema() -> None:
-    STATE_ROOT.mkdir(parents=True, exist_ok=True)
-    if not STATE_SCHEMA_PATH.exists():
-        STATE_SCHEMA_PATH.write_text(json.dumps(expected_state_schema_payload(), indent=2) + "\n", encoding="utf-8")
-
-
-def state_path_check(*, ensure_state: bool = False) -> Dict[str, Any]:
-    if ensure_state:
-        ensure_state_schema()
-    schema_payload: Dict[str, Any] = {}
-    schema_error = None
-    if STATE_SCHEMA_PATH.exists():
-        try:
-            schema_payload = json.loads(STATE_SCHEMA_PATH.read_text(encoding="utf-8"))
-        except Exception as exc:
-            schema_error = str(exc)
-    return {
-        "state_root": str(STATE_ROOT),
-        "exists": STATE_ROOT.exists(),
-        "writable_parent": os.access(STATE_ROOT.parent if STATE_ROOT.parent.exists() else REPO_ROOT, os.W_OK),
-        "schema_path": str(STATE_SCHEMA_PATH),
-        "schema_exists": STATE_SCHEMA_PATH.exists(),
-        "schema_version": schema_payload.get("schema_version"),
-        "schema_ok": (schema_payload.get("schema_version") == STATE_SCHEMA_VERSION) if schema_payload else not STATE_SCHEMA_PATH.exists(),
-        "schema_error": schema_error,
-        "created_or_verified": ensure_state,
-        "note": "state root is created by runtime cycles or by running doctor with --ensure-state",
-    }
-
-
-def run_doctor(*, ensure_state: bool = False) -> Dict[str, Any]:
+def run_doctor(*, ensure_state: bool = False, migrate_state: bool = False) -> Dict[str, Any]:
     required = [file_check(path, required=True) for path in REQUIRED_FILES]
     optional = [file_check(path, required=False) for path in OPTIONAL_FILES]
     imports = [import_check(path) for path in PYTHON_IMPORT_CHECKS]
@@ -215,7 +189,7 @@ def run_doctor(*, ensure_state: bool = False) -> Dict[str, Any]:
     registry = capability_registry_check()
     python_version = python_version_check()
     dependencies = dependency_inventory_check()
-    state = state_path_check(ensure_state=ensure_state)
+    state = state_path_check(ensure_state=ensure_state, migrate_state=migrate_state)
     missing_required = [item["path"] for item in required if not item["exists"] or not item["is_file"]]
     failed_imports = [item for item in imports if not item["ok"]]
     failed_commands = [item for item in commands if not item["ok"]]
@@ -227,10 +201,10 @@ def run_doctor(*, ensure_state: bool = False) -> Dict[str, Any]:
         and bool(python_version.get("ok"))
         and bool(dependencies.get("ok"))
         and bool(state.get("writable_parent"))
-        and bool(state.get("schema_ok"))
+        and bool(state.get("compatible"))
     )
     return {
-        "schema_version": "lumina-doctor-v0.3",
+        "schema_version": "lumina-doctor-v0.4",
         "ok": ok,
         "bootstrap_root": str(BOOTSTRAP_ROOT),
         "repo_root": str(REPO_ROOT),
@@ -257,7 +231,7 @@ def print_human(payload: Dict[str, Any]) -> None:
     print(f"  dependencies ok: {payload['dependency_inventory'].get('ok')}")
     print(f"  registry ok:     {payload['capability_registry'].get('ok')}")
     print(f"  capability count:{payload['capability_registry'].get('capability_count')}")
-    print(f"  state root:      {payload['state']['state_root']}")
+    print(f"  state root:      {payload['state'].get('state_root')}")
     print(f"  state schema:    {payload['state'].get('schema_version') or 'not created yet'}")
     if payload["missing_required_files"]:
         print("  missing required:")
@@ -282,14 +256,17 @@ def print_human(payload: Dict[str, Any]) -> None:
         print("  studio command:  bin/lumina studio")
     if not payload["state"].get("schema_exists"):
         print("  state setup:     run doctor with --ensure-state to create the local schema marker")
+    if payload["state"].get("migration_required"):
+        print("  state migrate:   run doctor with --migrate-state")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Check local Lumina host readiness.")
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--ensure-state", action="store_true", help="Create the local .lumina_state schema marker if missing.")
+    parser.add_argument("--migrate-state", action="store_true", help="Migrate a known older local state schema marker to the current version.")
     args = parser.parse_args()
-    payload = run_doctor(ensure_state=args.ensure_state)
+    payload = run_doctor(ensure_state=args.ensure_state, migrate_state=args.migrate_state)
     if args.json:
         print(json.dumps(payload, indent=2))
     else:

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_state_schema.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_state_schema.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Lumina local state schema helper.
+
+This helper owns only host-layer state-shape inspection and migration markers.
+It does not own runtime governance, canon lineage, checkpoint legality, or mode law.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import json
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+STATE_ROOT = REPO_ROOT / ".lumina_state" / "ship_of_ethereon_v2"
+STATE_SCHEMA_PATH = STATE_ROOT / "state_schema.json"
+CURRENT_STATE_SCHEMA_VERSION = "lumina-state-v0.1"
+
+KNOWN_SUBDIRECTORIES = [
+    "runtime receipts",
+    "context bundles",
+    "checkpoints",
+    "governance logs",
+    "studio state browser outputs",
+]
+
+
+@dataclass
+class StateSchemaStatus:
+    state_root: str
+    schema_path: str
+    exists: bool
+    schema_exists: bool
+    schema_version: Optional[str]
+    current_schema_version: str
+    writable_parent: bool
+    compatible: bool
+    migration_required: bool
+    created_or_updated: bool
+    errors: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def expected_state_schema_payload() -> Dict[str, Any]:
+    return {
+        "schema_version": CURRENT_STATE_SCHEMA_VERSION,
+        "state_root_owner": "Lumina host/runtime local state",
+        "authority_boundary": "State schema supports install/readiness checks only; runtime governance remains authoritative.",
+        "known_subdirectories": KNOWN_SUBDIRECTORIES,
+        "migration_history": [],
+    }
+
+
+def read_schema_payload(schema_path: Path = STATE_SCHEMA_PATH) -> Optional[Dict[str, Any]]:
+    if not schema_path.exists():
+        return None
+    with schema_path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    return payload if isinstance(payload, dict) else None
+
+
+def write_schema_payload(payload: Dict[str, Any], schema_path: Path = STATE_SCHEMA_PATH) -> None:
+    schema_path.parent.mkdir(parents=True, exist_ok=True)
+    with schema_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+
+
+def migrate_schema_payload(payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not payload:
+        return expected_state_schema_payload()
+    current = dict(payload)
+    prior_version = current.get("schema_version")
+    if prior_version == CURRENT_STATE_SCHEMA_VERSION:
+        return current
+    history = list(current.get("migration_history") or [])
+    history.append(
+        {
+            "from": prior_version,
+            "to": CURRENT_STATE_SCHEMA_VERSION,
+            "reason": "host-layer schema marker normalization",
+        }
+    )
+    current.update(expected_state_schema_payload())
+    current["migration_history"] = history
+    return current
+
+
+def inspect_state_schema(*, ensure: bool = False, migrate: bool = False) -> StateSchemaStatus:
+    errors: List[str] = []
+    created_or_updated = False
+    writable_parent = STATE_ROOT.parent.exists() and STATE_ROOT.parent.is_dir()
+    if not STATE_ROOT.parent.exists():
+        writable_parent = REPO_ROOT.exists()
+    try:
+        writable_parent = bool(writable_parent and (STATE_ROOT.parent if STATE_ROOT.parent.exists() else REPO_ROOT).exists())
+    except Exception:
+        writable_parent = False
+
+    payload: Optional[Dict[str, Any]] = None
+    if STATE_SCHEMA_PATH.exists():
+        try:
+            payload = read_schema_payload()
+        except Exception as exc:
+            errors.append(f"schema read failed: {exc}")
+
+    if ensure and payload is None and not errors:
+        payload = expected_state_schema_payload()
+        try:
+            write_schema_payload(payload)
+            created_or_updated = True
+        except Exception as exc:
+            errors.append(f"schema create failed: {exc}")
+
+    schema_version = payload.get("schema_version") if payload else None
+    migration_required = bool(payload and schema_version != CURRENT_STATE_SCHEMA_VERSION)
+
+    if migrate and migration_required and not errors:
+        try:
+            payload = migrate_schema_payload(payload)
+            write_schema_payload(payload)
+            created_or_updated = True
+            schema_version = payload.get("schema_version")
+            migration_required = False
+        except Exception as exc:
+            errors.append(f"schema migration failed: {exc}")
+
+    compatible = (
+        schema_version in {None, CURRENT_STATE_SCHEMA_VERSION}
+        and not migration_required
+        and not errors
+    )
+
+    return StateSchemaStatus(
+        state_root=str(STATE_ROOT),
+        schema_path=str(STATE_SCHEMA_PATH),
+        exists=STATE_ROOT.exists(),
+        schema_exists=STATE_SCHEMA_PATH.exists(),
+        schema_version=schema_version,
+        current_schema_version=CURRENT_STATE_SCHEMA_VERSION,
+        writable_parent=writable_parent,
+        compatible=compatible,
+        migration_required=migration_required,
+        created_or_updated=created_or_updated,
+        errors=errors,
+    )
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Inspect or create the Lumina local state schema marker.")
+    parser.add_argument("--ensure", action="store_true", help="Create the schema marker if missing.")
+    parser.add_argument("--migrate", action="store_true", help="Migrate a known older schema marker to the current version.")
+    args = parser.parse_args()
+    status = inspect_state_schema(ensure=args.ensure, migrate=args.migrate)
+    print(json.dumps(status.to_dict(), indent=2))
+    return 0 if status.compatible else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_state_browser.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/studio/lumina_state_browser.py
@@ -1,19 +1,30 @@
 #!/usr/bin/env python3
-"""Lumina Studio State Browser v0.3.
+"""Lumina Studio State Browser v0.4.
 
-Read-only helpers for inspecting Lumina runtime receipts and governance events.
-This module does not write state and does not own governance truth. It only
-summarizes files already emitted by the governed runtime runner.
+Read-only helpers for inspecting Lumina runtime receipts, governance events,
+and host-layer state schema status. This module does not write state and does
+not own governance truth. It only summarizes files already emitted by the
+governed runtime runner and host-layer schema helper.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = Path(__file__).resolve().parents[4]
+INSTALL_ROOT = BOOTSTRAP_ROOT / "install"
+if str(INSTALL_ROOT) not in sys.path:
+    sys.path.insert(0, str(INSTALL_ROOT))
+
+try:
+    from lumina_state_schema import inspect_state_schema
+except Exception:  # pragma: no cover - state browser reports unavailable helper
+    inspect_state_schema = None
+
 STATE_ROOT = REPO_ROOT / ".lumina_state" / "ship_of_ethereon_v2"
 DEFAULT_RUNTIME_BASE = STATE_ROOT / "runtime_runner_r1_actiontype_logging"
 
@@ -79,6 +90,18 @@ def _metric_text(label: str, value: Optional[float]) -> Optional[str]:
     if value is None:
         return None
     return f"{label} {value:.2f}"
+
+
+def state_schema_summary() -> Dict[str, Any]:
+    if inspect_state_schema is None:
+        return {
+            "available": False,
+            "compatible": False,
+            "reason": "lumina_state_schema helper unavailable",
+        }
+    status = inspect_state_schema(ensure=False, migrate=False).to_dict()
+    status["available"] = True
+    return status
 
 
 def harmonic_witness_from_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -308,9 +331,10 @@ def state_snapshot(*, base_dir: Path = DEFAULT_RUNTIME_BASE, limit: int = 20) ->
     governance_events = _read_jsonl(governance_log_path, limit=500)
     canon_records = _read_jsonl(canon_lineage_path, limit=50)
     return {
-        "schema_version": "lumina-studio-state-browser-v0.3",
+        "schema_version": "lumina-studio-state-browser-v0.4",
         "read_only": True,
         "state_root": str(STATE_ROOT),
+        "state_schema": state_schema_summary(),
         "runtime_base_dir": str(base_dir),
         "runtime_base_exists": base_dir.exists(),
         "logs_dir": str(base_dir / "logs"),


### PR DESCRIPTION
## Summary

Adds the State Schema / Migration R1 lane on top of the local install hardening work.

This PR adds a small host-layer state schema helper and wires both doctor and state browser to it.

Changed:

- `install/lumina_state_schema.py`
- `install/lumina_doctor.py`
- `install/install_lumina.sh`
- `studio/lumina_state_browser.py`

## What changed

- introduces a shared local state schema marker helper
- adds compatibility and migration-required status for `.lumina_state`
- adds opt-in schema creation through `--ensure-state`
- adds opt-in schema migration through `--migrate-state`
- surfaces state schema status in `lumina state`
- keeps state schema handling host-layer only, not runtime law

## Boundary

This does not change governance, mode legality, canon lineage, promotion rules, checkpoint legality, or capability authority.

The schema helper only records and inspects local host/runtime state shape so future install/update flows have something stable to check.

## Validation

Connector/static validation only in this environment:

- branch created on top of #374 head
- files updated through GitHub contents API
- no local checkout available to execute the doctor or state browser

Expected local validation:

```bash
cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
python install/lumina_state_schema.py --ensure
python install/lumina_state_schema.py --migrate
python install/lumina_doctor.py --ensure-state --json
python install/lumina_doctor.py --migrate-state --json
python studio/lumina_state_browser.py --limit 3
bash install/install_lumina.sh --ensure-state
bash install/install_lumina.sh --migrate-state
```

## Stacking note

This branch is stacked on `drydock/lumina-install-hardening-r1` (#374). After #373 and #374 merge, this PR can be retargeted forward.