### PR TITLE
Add Lumina Project Registry R1

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/lumina
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/lumina
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Lumina host entrypoint.
-
-This command provides a single local operator surface for the Lumina OS
-bootstrap substrate. It does not create governance law; it routes to the
-existing runtime, Studio, state browser, and doctor scripts.
-"""
+"""Lumina host entrypoint."""
 from __future__ import annotations
 
 import argparse
@@ -66,16 +61,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         cmd.append("--json")
     if ethereonic_overlay:
         cmd.append("--ethereonic-overlay")
-    if target_mode:
-        cmd.extend(["--target-mode", str(target_mode)])
-    if action_type:
-        cmd.extend(["--action-type", str(action_type)])
-    if focus:
-        cmd.extend(["--focus", str(focus)])
-    if depth:
-        cmd.extend(["--depth", str(depth)])
-    if intent:
-        cmd.extend(["--intent", str(intent)])
+    cmd.extend(["--target-mode", str(target_mode), "--action-type", str(action_type), "--focus", str(focus), "--depth", str(depth), "--intent", str(intent)])
     return _run(cmd, cwd=BOOTSTRAP_ROOT)
 
 
@@ -86,7 +72,6 @@ def cmd_presets(args: argparse.Namespace) -> int:
         print(json.dumps(payload, indent=2))
         return 0
     print("Lumina presets")
-    print("  boundary: presets are operator convenience only; runtime law remains authoritative")
     if not isinstance(presets, dict) or not presets:
         print("  no presets found")
         return 1
@@ -117,35 +102,37 @@ def cmd_compare(args: argparse.Namespace) -> int:
     print(f"  latest shape:   {harmonic.get('latest_continuity_shape')}")
     print(f"  drift:          {harmonic.get('drift_note')}")
     print(f"  recurrence:     {harmonic.get('recurrence_note')}")
-    print(f"  shape counts:   {harmonic.get('recent_shape_counts')}")
     print(f"  governance:     {governance.get('event_count')} events; latest {governance.get('latest_event_type')}")
     print(f"  canon head:     {payload.get('canon_head')}")
-    print(f"  receipt count:  {payload.get('receipt_count_returned')}")
     return 0
 
 
+def cmd_project(args: argparse.Namespace) -> int:
+    cmd = [_python(), str(INSTALL_DIR / "lumina_project_registry.py"), args.project_command]
+    if getattr(args, "name", None):
+        cmd.append(args.name)
+    if getattr(args, "description", None):
+        cmd.extend(["--description", args.description])
+    if getattr(args, "default_mode", None):
+        cmd.extend(["--default-mode", args.default_mode])
+    for tag in getattr(args, "tag", []) or []:
+        cmd.extend(["--tag", tag])
+    if getattr(args, "open", False):
+        cmd.append("--open")
+    if getattr(args, "include_archived", False):
+        cmd.append("--include-archived")
+    if getattr(args, "json", False):
+        cmd.append("--json")
+    return _run(cmd, cwd=BOOTSTRAP_ROOT)
+
+
 def cmd_observe(args: argparse.Namespace) -> int:
-    cmd = [
-        _python(),
-        str(RUNTIME_DIR / "runtime_runner_auto_snapshot_psi42_v18_r1.py"),
-        "--current-mode", "Continuity",
-        "--target-mode", "Observation",
-        "--action", args.action,
-        "--action-type", "audit",
-        "--enable-flag", "ETHEREON_OBSERVATION",
-        "--enable-flag", "ETHEREON_PSI42",
-        "--enable-flag", "ETHEREON_PSI42_V17",
-        "--enable-flag", "ETHEREON_PSI42_V18",
-        "--enable-flag", "ETHEREON_RESONANCE",
-        "--overlay-json", '{"active":true,"anchor_language":["english"],"continuity_phrase":"local observation cycle","harmonic_signature":[],"spiral_reference":null}',
-        "--runtime-config-json", '{"toki_pona_required_for_resume":false,"binary_required_for_transition_validation":false,"light_language_required_for_capability_loading":false,"harmonic_frequency_required_for_mode_legality":false}',
-    ]
+    cmd = [_python(), str(RUNTIME_DIR / "runtime_runner_auto_snapshot_psi42_v18_r1.py"), "--current-mode", "Continuity", "--target-mode", "Observation", "--action", args.action, "--action-type", "audit", "--enable-flag", "ETHEREON_OBSERVATION", "--enable-flag", "ETHEREON_PSI42", "--enable-flag", "ETHEREON_PSI42_V17", "--enable-flag", "ETHEREON_PSI42_V18", "--enable-flag", "ETHEREON_RESONANCE", "--overlay-json", '{"active":true,"anchor_language":["english"],"continuity_phrase":"local observation cycle","harmonic_signature":[],"spiral_reference":null}', "--runtime-config-json", '{"toki_pona_required_for_resume":false,"binary_required_for_transition_validation":false,"light_language_required_for_capability_loading":false,"harmonic_frequency_required_for_mode_legality":false}']
     return _run(cmd, cwd=RUNTIME_DIR)
 
 
 def cmd_state(args: argparse.Namespace) -> int:
-    cmd = [_python(), str(STUDIO_DIR / "lumina_state_browser.py"), "--limit", str(args.limit)]
-    return _run(cmd, cwd=BOOTSTRAP_ROOT)
+    return _run([_python(), str(STUDIO_DIR / "lumina_state_browser.py"), "--limit", str(args.limit)], cwd=BOOTSTRAP_ROOT)
 
 
 def cmd_studio(args: argparse.Namespace) -> int:
@@ -169,15 +156,12 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="lumina",
-        description="Start and inspect the Lumina OS local governed substrate.",
-    )
+    parser = argparse.ArgumentParser(prog="lumina", description="Start and inspect the Lumina OS local governed substrate.")
     sub = parser.add_subparsers(dest="command", required=True)
 
     run = sub.add_parser("run", help="Run one governed Studio cycle.")
     run.add_argument("prompt", nargs="?", default=None)
-    run.add_argument("--preset", default=None, help="Named operator preset from studio/lumina_presets_r1.json.")
+    run.add_argument("--preset", default=None)
     run.add_argument("--target-mode", default=None)
     run.add_argument("--action-type", default=None)
     run.add_argument("--focus", default=None)
@@ -197,6 +181,29 @@ def build_parser() -> argparse.ArgumentParser:
     compare.add_argument("--json", action="store_true")
     compare.set_defaults(func=cmd_compare)
 
+    project = sub.add_parser("project", help="Manage local Lumina projects.")
+    project_sub = project.add_subparsers(dest="project_command", required=True)
+    for name in ["open", "archive", "restore"]:
+        p = project_sub.add_parser(name)
+        p.add_argument("name")
+        p.add_argument("--json", action="store_true")
+        p.set_defaults(func=cmd_project)
+    pcreate = project_sub.add_parser("create")
+    pcreate.add_argument("name")
+    pcreate.add_argument("--description", default="")
+    pcreate.add_argument("--default-mode", default="Observation")
+    pcreate.add_argument("--tag", action="append", default=[])
+    pcreate.add_argument("--open", action="store_true")
+    pcreate.add_argument("--json", action="store_true")
+    pcreate.set_defaults(func=cmd_project)
+    plist = project_sub.add_parser("list")
+    plist.add_argument("--include-archived", action="store_true")
+    plist.add_argument("--json", action="store_true")
+    plist.set_defaults(func=cmd_project)
+    pactive = project_sub.add_parser("active")
+    pactive.add_argument("--json", action="store_true")
+    pactive.set_defaults(func=cmd_project)
+
     observe = sub.add_parser("observe", help="Run a local bounded Observation cycle and emit public/runtime snapshot files.")
     observe.add_argument("--action", default="local_observation_cycle")
     observe.set_defaults(func=cmd_observe)
@@ -215,7 +222,6 @@ def build_parser() -> argparse.ArgumentParser:
     doctor.add_argument("--ensure-state", action="store_true")
     doctor.add_argument("--migrate-state", action="store_true")
     doctor.set_defaults(func=cmd_doctor)
-
     return parser
 
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Project_Registry_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Project_Registry_R1.md
@@ -1,0 +1,108 @@
+# Lumina Project Registry R1
+
+**Project:** Lumina OS / Ship of Ethereon V2 Bootstrap  
+**Layer:** Harbor workspace foundation  
+**Status:** R1 local project registry  
+**Date:** June 18, 2026
+
+---
+
+## Purpose
+
+Lumina needs a Harbor: a place where work is received, organized, resumed, and distributed.
+
+Project Registry R1 makes local projects first-class host/workspace objects.
+
+It introduces:
+
+```bash
+lumina project create EthereonLabs --open
+lumina project list
+lumina project active
+lumina project open EthereonLabs
+lumina project archive EthereonLabs
+lumina project restore EthereonLabs
+```
+
+---
+
+## Storage Shape
+
+Projects live under:
+
+```text
+.lumina_state/ship_of_ethereon_v2/projects/
+```
+
+Each project receives:
+
+```text
+<project>/
+  project.json
+  receipts/
+  bundles/
+  checkpoints/
+  notes/
+  timeline/
+  artifacts/
+```
+
+The active project marker lives at:
+
+```text
+.lumina_state/ship_of_ethereon_v2/active_project.json
+```
+
+---
+
+## Authority Boundary
+
+Project registry may:
+
+- create local workspace folders
+- record project metadata
+- mark one project as active
+- archive and restore project records
+- provide a home for future receipts, notes, bundles, checkpoints, timeline entries, and artifacts
+
+Project registry may not:
+
+- define runtime governance
+- define mode legality
+- authorize mutation
+- authorize canon promotion
+- alter checkpoint legality
+- expose capabilities
+- treat project metadata as canon truth
+
+The registry is Harbor/workspace organization only.
+
+---
+
+## Example Flow
+
+```bash
+lumina project create EthereonLabs --description "Primary Lumina OS / Ship of Ethereon workspace" --tag lumina --tag ethereon --open
+lumina project active
+lumina project list
+lumina run --preset drydock
+lumina compare
+```
+
+---
+
+## Why This Matters
+
+Before R1, Lumina could run governed cycles, but those cycles did not have an explicit local home.
+
+After R1, Lumina can answer a basic habitat question:
+
+> Where am I working?
+
+That is the first Harbor foundation.
+
+---
+
+## Guiding Sentence
+
+Make projects first-class places before adding more rooms to the Harbor.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_project_registry.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_project_registry.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Lumina local project registry helper.
+
+This helper creates and maintains local Harbor/workspace project metadata under
+`.lumina_state/ship_of_ethereon_v2/projects`. It is host-layer workspace
+infrastructure only. It does not own runtime governance, canon lineage, mode
+legality, mutation authority, checkpoint legality, or capability authority.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import argparse
+import json
+import re
+
+BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[4]
+STATE_ROOT = REPO_ROOT / ".lumina_state" / "ship_of_ethereon_v2"
+PROJECTS_ROOT = STATE_ROOT / "projects"
+ACTIVE_PROJECT_PATH = STATE_ROOT / "active_project.json"
+PROJECT_SCHEMA_VERSION = "lumina-project-r1"
+ACTIVE_SCHEMA_VERSION = "lumina-active-project-r1"
+
+PROJECT_SLUG_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+PROJECT_SUBDIRS = ["receipts", "bundles", "checkpoints", "notes", "timeline", "artifacts"]
+
+
+@dataclass
+class ProjectRecord:
+    schema_version: str
+    name: str
+    slug: str
+    status: str
+    created_at: str
+    updated_at: str
+    project_root: str
+    description: str
+    default_mode: str
+    tags: List[str]
+    authority_boundary: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def slugify(name: str) -> str:
+    slug = PROJECT_SLUG_RE.sub("-", name.strip()).strip("-._")
+    return slug or "project"
+
+
+def project_dir(slug: str) -> Path:
+    return PROJECTS_ROOT / slug
+
+
+def project_file(slug: str) -> Path:
+    return project_dir(slug) / "project.json"
+
+
+def read_json(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except Exception:
+        return None
+
+
+def write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def create_project(name: str, *, description: str = "", default_mode: str = "Observation", tags: Optional[List[str]] = None, open_project: bool = False) -> Dict[str, Any]:
+    slug = slugify(name)
+    root = project_dir(slug)
+    path = project_file(slug)
+    if path.exists():
+        raise SystemExit(f"Lumina project already exists: {slug}")
+    stamp = now_iso()
+    root.mkdir(parents=True, exist_ok=True)
+    for subdir in PROJECT_SUBDIRS:
+        (root / subdir).mkdir(parents=True, exist_ok=True)
+    record = ProjectRecord(
+        schema_version=PROJECT_SCHEMA_VERSION,
+        name=name,
+        slug=slug,
+        status="active",
+        created_at=stamp,
+        updated_at=stamp,
+        project_root=str(root),
+        description=description,
+        default_mode=default_mode,
+        tags=tags or [],
+        authority_boundary="Project registry organizes local workspace metadata only; runtime governance remains authoritative.",
+    ).to_dict()
+    write_json(path, record)
+    if open_project:
+        set_active_project(slug)
+    return record
+
+
+def load_project(slug_or_name: str) -> Dict[str, Any]:
+    slug = slugify(slug_or_name)
+    path = project_file(slug)
+    payload = read_json(path)
+    if payload is None:
+        # Allow exact name fallback across registry.
+        for item in list_projects(include_archived=True):
+            if item.get("name") == slug_or_name:
+                payload = read_json(project_file(str(item["slug"])))
+                break
+    if payload is None:
+        raise SystemExit(f"Lumina project not found: {slug_or_name}")
+    return payload
+
+
+def list_projects(*, include_archived: bool = False) -> List[Dict[str, Any]]:
+    if not PROJECTS_ROOT.exists():
+        return []
+    records: List[Dict[str, Any]] = []
+    for path in sorted(PROJECTS_ROOT.glob("*/project.json")):
+        payload = read_json(path)
+        if not payload:
+            continue
+        if payload.get("status") == "archived" and not include_archived:
+            continue
+        records.append(payload)
+    return records
+
+
+def set_active_project(slug_or_name: str) -> Dict[str, Any]:
+    record = load_project(slug_or_name)
+    payload = {
+        "schema_version": ACTIVE_SCHEMA_VERSION,
+        "active_project_slug": record["slug"],
+        "active_project_name": record["name"],
+        "project_root": record["project_root"],
+        "set_at": now_iso(),
+        "authority_boundary": "Active project marker is host workspace orientation only; runtime governance remains authoritative.",
+    }
+    write_json(ACTIVE_PROJECT_PATH, payload)
+    return payload
+
+
+def active_project() -> Optional[Dict[str, Any]]:
+    payload = read_json(ACTIVE_PROJECT_PATH)
+    if not payload:
+        return None
+    slug = payload.get("active_project_slug")
+    if not slug:
+        return payload
+    try:
+        payload["project"] = load_project(str(slug))
+    except SystemExit:
+        payload["project_missing"] = True
+    return payload
+
+
+def archive_project(slug_or_name: str) -> Dict[str, Any]:
+    record = load_project(slug_or_name)
+    record["status"] = "archived"
+    record["updated_at"] = now_iso()
+    write_json(project_file(str(record["slug"])), record)
+    active = active_project()
+    if active and active.get("active_project_slug") == record.get("slug"):
+        ACTIVE_PROJECT_PATH.unlink(missing_ok=True)
+    return record
+
+
+def restore_project(slug_or_name: str) -> Dict[str, Any]:
+    record = load_project(slug_or_name)
+    record["status"] = "active"
+    record["updated_at"] = now_iso()
+    write_json(project_file(str(record["slug"])), record)
+    return record
+
+
+def registry_snapshot(*, include_archived: bool = False) -> Dict[str, Any]:
+    projects = list_projects(include_archived=include_archived)
+    return {
+        "schema_version": "lumina-project-registry-snapshot-r1",
+        "projects_root": str(PROJECTS_ROOT),
+        "project_count": len(projects),
+        "projects": projects,
+        "active": active_project(),
+        "authority_boundary": "Project registry is Harbor/workspace organization only; runtime governance remains authoritative.",
+    }
+
+
+def print_project_table(projects: List[Dict[str, Any]]) -> None:
+    if not projects:
+        print("No Lumina projects yet.")
+        return
+    print("Lumina projects")
+    for record in projects:
+        print(f"  {record.get('slug'):24} {record.get('status'):8} {record.get('name')}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Manage the local Lumina project registry.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create")
+    create.add_argument("name")
+    create.add_argument("--description", default="")
+    create.add_argument("--default-mode", default="Observation")
+    create.add_argument("--tag", action="append", default=[])
+    create.add_argument("--open", action="store_true")
+    create.add_argument("--json", action="store_true")
+
+    open_cmd = sub.add_parser("open")
+    open_cmd.add_argument("name")
+    open_cmd.add_argument("--json", action="store_true")
+
+    list_cmd = sub.add_parser("list")
+    list_cmd.add_argument("--include-archived", action="store_true")
+    list_cmd.add_argument("--json", action="store_true")
+
+    active_cmd = sub.add_parser("active")
+    active_cmd.add_argument("--json", action="store_true")
+
+    archive = sub.add_parser("archive")
+    archive.add_argument("name")
+    archive.add_argument("--json", action="store_true")
+
+    restore = sub.add_parser("restore")
+    restore.add_argument("name")
+    restore.add_argument("--json", action="store_true")
+
+    args = parser.parse_args()
+    if args.command == "create":
+        payload = create_project(args.name, description=args.description, default_mode=args.default_mode, tags=args.tag, open_project=args.open)
+        print(json.dumps(payload, indent=2) if args.json else f"Created Lumina project: {payload['slug']}")
+    elif args.command == "open":
+        payload = set_active_project(args.name)
+        print(json.dumps(payload, indent=2) if args.json else f"Opened Lumina project: {payload['active_project_slug']}")
+    elif args.command == "list":
+        payload = registry_snapshot(include_archived=args.include_archived)
+        print(json.dumps(payload, indent=2) if args.json else print_project_table(payload["projects"]))
+    elif args.command == "active":
+        payload = active_project() or {"active_project_slug": None, "active_project_name": None}
+        print(json.dumps(payload, indent=2) if args.json else f"Active Lumina project: {payload.get('active_project_slug') or 'none'}")
+    elif args.command == "archive":
+        payload = archive_project(args.name)
+        print(json.dumps(payload, indent=2) if args.json else f"Archived Lumina project: {payload['slug']}")
+    elif args.command == "restore":
+        payload = restore_project(args.name)
+        print(json.dumps(payload, indent=2) if args.json else f"Restored Lumina project: {payload['slug']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Starts Harbor R1 by making local Lumina projects first-class workspace objects.

Changed:

- `install/lumina_project_registry.py`
- `bin/lumina`
- `docs/Lumina_Project_Registry_R1.md`

## What changed

- adds `lumina project create <name>`
- adds `lumina project open <name>`
- adds `lumina project list`
- adds `lumina project active`
- adds `lumina project archive <name>`
- adds `lumina project restore <name>`
- creates per-project folders for receipts, bundles, checkpoints, notes, timeline entries, and artifacts
- records the active project under `.lumina_state/ship_of_ethereon_v2/active_project.json`

## Boundary

Project Registry R1 is Harbor/workspace organization only. It does not define runtime governance, mode legality, canon truth, mutation permission, checkpoint legality, or capability authority.

## Validation

Connector/static validation only in this environment:

- branch created from `main`
- files added/updated through GitHub contents API
- no local checkout available to execute commands

Expected local validation:

```bash
cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
lumina project create EthereonLabs --description "Primary Lumina OS workspace" --tag lumina --tag ethereon --open
lumina project active
lumina project list
lumina project list --json
lumina project archive EthereonLabs
lumina project restore EthereonLabs
```

## Why now

The install path, state schema, presets, and compare command made Lumina usable as a command surface. The next threshold is habitat: projects need a local home so future receipts, bundles, notes, sessions, and timelines have a place to belong.