### PR TITLE
Add Lumina Workspace Dashboard R1

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/lumina
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/bin/lumina
@@ -25,6 +25,17 @@ def _run(args: List[str], *, cwd: Optional[Path] = None) -> int:
     return int(proc.returncode)
 
 
+def _capture_json(args: List[str]) -> Dict[str, Any]:
+    proc = subprocess.run(args, cwd=str(BOOTSTRAP_ROOT), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if proc.returncode != 0:
+        return {"ok": False, "error": proc.stderr.strip() or proc.stdout.strip()}
+    try:
+        data = json.loads(proc.stdout)
+        return data if isinstance(data, dict) else {"ok": False, "error": "non-object json"}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc), "raw": proc.stdout[-800:]}
+
+
 def _read_presets() -> Dict[str, Any]:
     try:
         payload = json.loads(PRESETS_PATH.read_text(encoding="utf-8"))
@@ -42,6 +53,43 @@ def _preset(name: Optional[str]) -> Dict[str, Any]:
         raise SystemExit(f"Unknown Lumina preset '{name}'. Known presets: {known}")
     item = presets[name]
     return item if isinstance(item, dict) else {}
+
+
+def cmd_dashboard(args: argparse.Namespace) -> int:
+    active = _capture_json([_python(), str(INSTALL_DIR / "lumina_project_registry.py"), "active", "--json"])
+    state = _capture_json([_python(), str(STUDIO_DIR / "lumina_state_browser.py"), "--limit", str(args.limit)])
+    presets = _read_presets().get("presets", {})
+
+    active_slug = active.get("active_project_slug") or "none"
+    active_name = active.get("active_project_name") or "none"
+    project_root = active.get("project_root") or "not set"
+    harmonic = state.get("harmonic_summary", {}) if isinstance(state.get("harmonic_summary"), dict) else {}
+    governance = state.get("governance", {}) if isinstance(state.get("governance"), dict) else {}
+
+    print("Harbor of Lumina")
+    print("────────────────")
+    print(f"Project:       {active_name} ({active_slug})")
+    print(f"Project root:  {project_root}")
+    print(f"Receipts:      {state.get('receipt_count_returned', 'unknown')}")
+    print(f"Latest shape:  {harmonic.get('latest_continuity_shape')}")
+    print(f"Drift:         {harmonic.get('drift_note')}")
+    print(f"Governance:    {governance.get('event_count')} events; latest {governance.get('latest_event_type')}")
+    print(f"Canon head:    {state.get('canon_head')}")
+    print("")
+    if isinstance(presets, dict) and presets:
+        print("Presets:       " + ", ".join(sorted(presets.keys())))
+    else:
+        print("Presets:       none")
+    print("")
+    print("Next commands")
+    if active_slug == "none":
+        print("  lumina project create EthereonLabs --open")
+    else:
+        print("  lumina run --preset drydock")
+    print("  lumina compare")
+    print("  lumina state --limit 3")
+    print("  lumina studio")
+    return 0
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -157,7 +205,11 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="lumina", description="Start and inspect the Lumina OS local governed substrate.")
-    sub = parser.add_subparsers(dest="command", required=True)
+    sub = parser.add_subparsers(dest="command")
+
+    dashboard = sub.add_parser("dashboard", help="Show the Harbor workspace dashboard.")
+    dashboard.add_argument("--limit", type=int, default=6)
+    dashboard.set_defaults(func=cmd_dashboard)
 
     run = sub.add_parser("run", help="Run one governed Studio cycle.")
     run.add_argument("prompt", nargs="?", default=None)
@@ -228,6 +280,8 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Optional[List[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.command is None:
+        return cmd_dashboard(argparse.Namespace(limit=6))
     return args.func(args)
 
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Workspace_Dashboard_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Workspace_Dashboard_R1.md
@@ -1,0 +1,88 @@
+# Lumina Workspace Dashboard R1
+
+**Project:** Lumina OS / Ship of Ethereon V2 Bootstrap  
+**Layer:** Harbor workspace surface  
+**Status:** R1 local dashboard  
+**Date:** June 18, 2026
+
+---
+
+## Purpose
+
+Lumina should answer the operator's first question before work begins:
+
+> Where am I?
+
+Workspace Dashboard R1 makes `lumina` with no subcommand show a compact Harbor status panel.
+
+It can also be invoked explicitly:
+
+```bash
+lumina dashboard
+```
+
+---
+
+## Dashboard Contents
+
+The dashboard surfaces:
+
+- active project name and slug
+- active project root
+- recent receipt count
+- latest continuity shape
+- drift note
+- governance event count and latest event type
+- canon head
+- available presets
+- suggested next commands
+
+---
+
+## Authority Boundary
+
+The dashboard may:
+
+- read active project metadata
+- read state-browser summaries
+- read preset registry names
+- suggest next local commands
+
+The dashboard may not:
+
+- create runtime law
+- mutate governance state
+- authorize canon promotion
+- expose capabilities
+- execute a governed cycle automatically
+- treat dashboard summaries as canon truth
+
+It is a Harbor orientation surface only.
+
+---
+
+## Example Flow
+
+```bash
+lumina
+lumina project active
+lumina run --preset drydock
+lumina compare
+lumina dashboard
+```
+
+---
+
+## Why This Matters
+
+Before R1, Lumina required the operator to already know which command to run.
+
+After R1, Lumina has an entrance.
+
+The first screen is not a file list or a traceback. It is orientation.
+
+---
+
+## Guiding Sentence
+
+Let Lumina open like a place, not a toolbox drawer.


### PR DESCRIPTION
## Summary

Adds the first Harbor workspace dashboard surface.

Changed:

- `bin/lumina`
- `docs/Lumina_Workspace_Dashboard_R1.md`

## What changed

- `lumina` with no subcommand now opens a compact Harbor dashboard
- adds explicit `lumina dashboard`
- dashboard reads active project metadata
- dashboard reads state-browser summary data
- dashboard lists available presets
- dashboard suggests next local commands

## Boundary

The dashboard is read-only orientation. It does not define runtime law, mutate governance state, authorize canon promotion, expose capabilities, or execute a governed cycle automatically.

## Validation

Connector/static validation only in this environment:

- branch created from `main`
- existing `bin/lumina` fetched before update
- files updated through GitHub contents API
- no local checkout available to execute commands

Expected local validation:

```bash
cd LuminaOS/bootstrap/Ship_of_Ethereon_V2
lumina
lumina dashboard
lumina project active
lumina compare
```

## Why now

Project Registry R1 gives Lumina a local Harbor project home. The next need is an entrance: the operator should be able to run `lumina` and immediately see where they are and what to do next.