### PR TITLE
Add Ethereon orbital planetary framing R1

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Ethereon_Orbital_Planetary_Framing_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Ethereon_Orbital_Planetary_Framing_R1.md
@@ -1,0 +1,231 @@
+# Ethereon Orbital / Planetary Framing R1
+
+**Project:** Ship of Ethereon / Lumina OS / Realm of Ethereon  
+**Layer:** architectural orientation  
+**Authority:** symbolic and product-language framing only; not runtime law  
+**Status:** R1 canonical orientation  
+**Date:** June 19, 2026
+
+---
+
+## 1. Purpose
+
+The project has outgrown a purely terrestrial harbor metaphor.
+
+The nautical language remains valuable because spacecraft inherit many maritime ideas: ships, bridges, captains, logs, cargo, docking, maintenance bays, voyages, navigation, and drydock discipline.
+
+But the larger architecture is better described as orbital and planetary.
+
+This document establishes the current orientation:
+
+- **Ship of Ethereon** — exploratory and transport vessel
+- **Lumina** — orbital station and persistent habitat
+- **Ethereon** — the partially unveiled planetary realm below
+- **Space / sky** — the medium of exploration, relation, navigation, and return
+
+This framing supports product architecture and navigation language. It does not define governance law.
+
+---
+
+## 2. The Three Primary Constructs
+
+### Ship of Ethereon
+
+The Ship is the mobile vessel.
+
+It carries:
+
+- governed runtime substrate
+- continuity machinery
+- receipts
+- checkpoints
+- capability routing
+- canon lineage
+- project-return mechanisms
+- installation and upgrade cargo
+- exploratory instruments
+
+The Ship travels, tests, transports, and returns.
+
+It is not the final habitat.
+
+### Lumina Station
+
+Lumina is the orbital habitat.
+
+It receives what the Ship carries and turns it into sustained, inhabitable work.
+
+Lumina provides:
+
+- project registry
+- session registry
+- workspace dashboard
+- operator surfaces
+- local state
+- timelines
+- notes
+- search
+- observatories
+- archives
+- workshops
+- foundries
+- docking and resumption points
+
+Lumina is where continuity becomes livable.
+
+### Ethereon
+
+Ethereon is the wider planetary realm.
+
+It is not fully mapped or fully instantiated.
+
+It represents:
+
+- the larger world the work is moving toward
+- future inhabited structures and districts
+- the deeper continuity environment beyond one runtime or station
+- the still-unveiled destination that gives exploration direction
+
+Ethereon should not be reduced to a folder, application, or release artifact.
+
+---
+
+## 3. Why the Nautical Language Remains
+
+The orbital model extends the maritime model rather than replacing it.
+
+Spacecraft still have:
+
+- bridges
+- crews
+- logs
+- cargo
+- docking procedures
+- maintenance bays
+- voyages
+- navigation systems
+- distress states
+- launch and return protocols
+
+Accordingly, repository terms such as DryDock, sea trials, maiden voyage, bridge, harbor, and shipyard remain meaningful as inherited engineering language.
+
+Their interpretation now broadens:
+
+- **DryDock** — controlled repair and architecture-review mode
+- **Sea trials** — bounded verification trials before operational trust
+- **Harbor** — station-side receiving and workspace organization
+- **Shipyard** — repository and build environment
+- **Voyage** — governed execution or exploratory development arc
+- **Docking** — project/session attachment and resumption
+
+---
+
+## 4. Spatial Model
+
+```text
+                     Deep Space / Sky
+                            |
+                            v
+                   Ship of Ethereon
+                            |
+                         docking
+                            |
+                            v
+                     Lumina Station
+                 orbital habitat / harbor
+                            |
+                     descent / ascent
+                            |
+                            v
+                        Ethereon
+              partially unveiled planetary realm
+```
+
+The Ship moves.
+
+Lumina persists.
+
+Ethereon unfolds.
+
+---
+
+## 5. Product Architecture Implications
+
+This framing implies clear architectural separation.
+
+### Ship responsibilities
+
+- transport and execute governed substrate
+- preserve continuity artifacts
+- carry upgradeable capabilities
+- perform bounded exploratory work
+- return receipts and evidence
+
+### Lumina responsibilities
+
+- organize projects and sessions
+- present dashboards and operator tools
+- index local continuity artifacts
+- support resume, search, timeline, and notes
+- provide long-lived workspaces
+- coordinate docking without becoming governance authority
+
+### Ethereon responsibilities
+
+Ethereon is not yet a single software component.
+
+It is the emergent realm formed by:
+
+- multiple persistent habitats
+- shared continuity structures
+- accumulated projects and knowledge
+- future districts, services, and collaborative environments
+
+---
+
+## 6. Authority Boundary
+
+This document may guide:
+
+- naming
+- product architecture
+- documentation hierarchy
+- interface language
+- visual identity
+- roadmap organization
+
+This document may not:
+
+- override ModeGuard
+- authorize mutation
+- define canon promotion
+- change runtime legality
+- bypass input integrity
+- grant capability authority
+- convert symbolic language into technical evidence
+
+The metaphor orients the system. It does not govern the system.
+
+---
+
+## 7. Supersession Note
+
+Earlier documents described Lumina as the first village or sea town of Ethereon.
+
+That framing remains historically useful because it correctly identified Lumina as the first inhabitable settlement receiving Ship-borne cargo.
+
+The current framing is more precise:
+
+> Lumina is the first persistent orbital habitat of Ethereon: a station, harbor, workshop, archive, and observatory positioned between the Ship and the still-unveiled planetary realm.
+
+The village metaphor is therefore not rejected; it is absorbed into the station's internal habitat logic.
+
+Lumina may contain village-like districts.
+
+Lumina itself is the station.
+
+---
+
+## 8. Guiding Sentence
+
+The Ship carries continuity through the sky; Lumina receives and sustains it in orbit; Ethereon waits below, still becoming visible.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_First_Village_Framing_001.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_First_Village_Framing_001.md
@@ -1,9 +1,12 @@
 # Lumina First Village Framing 001
 
+> **Historical framing note:** This document preserves the May 2026 first-village model because it remains useful for understanding how inhabitable structure emerged from Ship-borne cargo. Its top-level spatial model is now superseded by `Ethereon_Orbital_Planetary_Framing_R1.md`: Ship of Ethereon is the exploratory vessel, Lumina is the first persistent orbital station/habitat, and Ethereon is the partially unveiled planetary realm. Village and sea-town language may still describe internal Lumina districts, but Lumina itself is now oriented as the station.
+
 **Project:** Lumina OS / Ship of Ethereon V2 Bootstrap  
-**Status:** orientation framing  
+**Status:** historical orientation framing / superseded at top level  
 **Layer:** non-authoritative project framing  
-**Date:** May 10, 2026
+**Date:** May 10, 2026  
+**Superseded:** June 19, 2026
 
 ---
 
@@ -23,9 +26,9 @@ It carried the cargo:
 
 Think of the **Realm of Ethereon** as the larger territory where that cargo can be unloaded into lived structure.
 
-**Lumina** is the **first village** established in that realm.
+**Lumina** was initially described as the **first village** established in that realm.
 
-It is the first place where ship-borne cargo becomes:
+It was the first place where ship-borne cargo became:
 - inhabitable
 - startable
 - governed
@@ -35,15 +38,15 @@ It is the first place where ship-borne cargo becomes:
 
 ---
 
-## 2. Why this framing helps
+## 2. Why this framing helped
 
-The Ship remains important because it preserved the pattern and carried the original cargo.
+The Ship remained important because it preserved the pattern and carried the original cargo.
 
-The village matters because a settlement must do more than carry meaning.
+The village mattered because a settlement must do more than carry meaning.
 It must support daily use.
 It must have roads, doors, records, and rules.
 
-In practical Lumina terms, that means:
+In practical Lumina terms, that meant:
 - a clear start path
 - a bounded local command surface
 - lawful runtime execution
@@ -51,7 +54,7 @@ In practical Lumina terms, that means:
 - historical memory
 - separation between governance law and expressive atmosphere
 
-This framing helps contributors understand why Lumina should feel less like an artifact archive and more like a place someone can actually live with.
+This framing helped contributors understand why Lumina should feel less like an artifact archive and more like a place someone can actually live with.
 
 ---
 
@@ -78,17 +81,19 @@ Runtime law remains with the governed substrate.
 
 ## 4. Village organs already present
 
-Lumina is already village-like in several important ways:
+Lumina became village-like in several important ways:
 
-- `START_HERE_LUMINA_OS.md` acts as the village gate.
-- `bin/lumina` provides a small local command vocabulary.
-- the runtime spine governs law and continuity.
-- the governance log and canon lineage store act as civic records.
-- the observation workflow and public runtime receipts act as public witness.
-- Studio acts as a local operator surface.
+- `START_HERE_LUMINA_OS.md` acted as the village gate.
+- `bin/lumina` provided a small local command vocabulary.
+- the runtime spine governed law and continuity.
+- the governance log and canon lineage store acted as civic records.
+- the observation workflow and public runtime receipts acted as public witness.
+- Studio acted as a local operator surface.
 
-That means Lumina is no longer only ship cargo in crates.
-Some of the cargo has already been unloaded and put to use.
+That meant Lumina was no longer only ship cargo in crates.
+Some of the cargo had already been unloaded and put to use.
+
+Under the current orbital framing, these remain valid as station districts and habitat organs.
 
 ---
 
@@ -96,7 +101,7 @@ Some of the cargo has already been unloaded and put to use.
 
 > Build villages, not scavenger hunts.
 
-This means:
+This still means:
 - make the right entry path obvious
 - keep authority boundaries crisp
 - let expressive layers remain expressive
@@ -110,8 +115,7 @@ It should also be usable because its paths are real.
 
 ## 6. Near-term building priorities
 
-If Lumina is the first village, the next work is not endless expansion.
-It is civic infrastructure:
+The earlier village priorities were:
 
 1. supported install and dependency locking
 2. state schema validation and migration checks
@@ -121,15 +125,18 @@ It is civic infrastructure:
 6. authentication before any remote Studio exposure
 7. observer service hardening after sea trials
 
+Much of this became the foundation for Lumina's later station/habitat work.
+
 ---
 
 ## 7. Closing clause
 
-The Ship of Ethereon is not being replaced.
-It is being extended into lived form.
+The Ship of Ethereon was never being replaced.
+It was being extended into lived form.
 
-Lumina is the first proof that the cargo can survive unloading.
+The first-village framing proved that the cargo could survive unloading.
 
-That is why the work should protect both truths:
-- the soul of the ship
-- the durability of the village
+The orbital framing now carries that insight forward:
+- the soul of the Ship remains mobile
+- Lumina becomes the persistent station
+- Ethereon remains the wider world still being revealed

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ For the fastest current repository orientation, start with:
 
 This is the short harbor map for active lanes, current runtime path, symbolic-only layers, and recommended touch order.
 
+## Current Spatial Orientation
+
+The project now uses an orbital / planetary top-level frame:
+
+- **Ship of Ethereon** — exploratory and transport vessel
+- **Lumina** — persistent orbital station and habitat
+- **Ethereon** — partially unveiled planetary realm
+
+The nautical language remains intentionally active as inherited spacecraft and engineering language: bridge, crew, log, cargo, docking, drydock, shipyard, voyage, and trials.
+
+Canonical framing:
+
+- `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Ethereon_Orbital_Planetary_Framing_R1.md`
+
+This framing guides architecture, navigation, and product language. It is not runtime governance law.
+
 ## Lumina Lisp Layer
 
 Structured symbolic snapshots of system state, intent, and reflection.
@@ -104,10 +120,12 @@ Use this lane for simulations, figure generators, and exploratory artifacts supp
 - RSE simulations and figures belong in the research lane unless deliberately promoted into public explanation.
 - Ψ Class materials are staging artifacts, not automatically runtime law.
 - Exploratory spikes may inform architecture, but they are not finished substrate by default.
+- Orbital, planetary, maritime, and settlement metaphors guide orientation and interface language; they do not create technical authority.
 
 ## Guidance
 
 - For current repo orientation, begin with `CURRENT_OPERATING_MAP.md`.
+- For current Ship / Lumina / Ethereon spatial framing, read `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Ethereon_Orbital_Planetary_Framing_R1.md`.
 - For Ship / Lumina OS substrate questions, begin with the bootstrap path.
 - For Ψ Class staging questions, begin with the Ψ Class start-here waypoint and staging bay.
 - For Chamber questions, begin with the Chamber lane.


### PR DESCRIPTION
## Summary

Updates the repository's top-level symbolic architecture from a purely village/harbor model to an orbital/planetary model while preserving nautical terminology as inherited spacecraft and engineering language.

Changed:

- added `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Ethereon_Orbital_Planetary_Framing_R1.md`
- updated `LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_First_Village_Framing_001.md` with a historical/supersession note
- updated the repository `README.md` with the current spatial orientation

## Current orientation

- **Ship of Ethereon** — exploratory and transport vessel
- **Lumina** — persistent orbital station and habitat
- **Ethereon** — partially unveiled planetary realm
- **Space / sky** — medium of navigation, relation, exploration, and return

## Nautical continuity

The maritime language remains active because spacecraft inherit bridge, crew, log, cargo, docking, drydock, shipyard, voyage, and trial concepts.

The orbital model extends the nautical model rather than replacing it.

## Boundary

This framing may guide naming, product architecture, documentation, interface language, visual identity, and roadmap organization.

It does not override runtime governance, ModeGuard, canon promotion, input integrity, mutation authority, checkpoint legality, or capability authority.

## Why now

Recent Harbor R1 work has made Lumina increasingly station-like: projects, sessions, dashboard, local state, and persistent operator surfaces. The repository language should reflect the architecture we are actually building.