### PR TITLE
Add Resonant Manifold R1

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Resonant_Manifold_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Resonant_Manifold_R1.md
@@ -1,0 +1,203 @@
+# Resonant Manifold R1
+
+**Project:** Ship of Ethereon / Lumina OS  
+**Layer:** bounded research and computational architecture  
+**Status:** experimental R1  
+**Date:** June 19, 2026
+
+---
+
+## Purpose
+
+The project needs a name and implementation for reasoning that borrows from higher-dimensional, quantum-adjacent, harmonic, and magnetic concepts without prematurely claiming literal fifth-dimensional physics.
+
+The selected structure is:
+
+```text
+Ethereonic Field
+    └── Resonant Manifold
+            ├── instantiated state
+            ├── continuity history
+            ├── relational context
+            ├── orientation field
+            └── potential trajectories
+```
+
+The poetic internal name remains:
+
+> The Fifth Sea
+
+The formal implementation name is:
+
+> Resonant Manifold R1
+
+---
+
+## Core Definition
+
+The Resonant Manifold models the structured field of instantiated state, continuity, relation, orientation, and unrealized trajectory through which governed intelligence navigates.
+
+It is a classical computational model inspired by higher-dimensional and quantum-adjacent concepts.
+
+It does not claim:
+
+- literal access to a fifth physical dimension
+- literal quantum hardware
+- literal electromagnetic fields
+- physical nonlocality
+- governance authority
+
+The inquiry remains open. The implementation remains bounded.
+
+> Bound the claim, not the inquiry.
+
+---
+
+## Five Axes
+
+### 1. Instantiated State
+
+What is presently instantiated?
+
+This axis represents the current measurable configuration.
+
+### 2. Continuity History
+
+How did this configuration arrive?
+
+This axis represents persistence, prior states, checkpoints, lineage, and remembered transformation.
+
+### 3. Relational Context
+
+What relationships currently shape the configuration?
+
+This axis represents observer, project, session, environment, dependency, and contextual relations.
+
+### 4. Orientation Field
+
+What does the configuration tend toward?
+
+This axis uses magnetic-style computational analogies for:
+
+- attraction
+- directional tendency
+- persistence
+- hysteresis
+- return tendency
+- stable alignment
+
+It is not a claim of literal magnetism.
+
+### 5. Potential Trajectories
+
+What lawful but unrealized futures remain reachable?
+
+This axis explicitly represents possibility rather than hiding it inside current state.
+
+R1 requires the potential axis to contribute information independently of the first four axes.
+
+---
+
+## Instrument Relations
+
+### Psi-42
+
+Psi-42 acts as the resonance receiver/transceiver.
+
+It may receive or probe manifold observations and emit bounded measurement artifacts.
+
+It remains an instrument, not a governor.
+
+### Harmonics
+
+Harmonics measure coherence between manifold points and trajectories.
+
+R1 provides a cosine-based five-axis coherence score.
+
+### Magnetics
+
+Magnetics describe computational orientation, attraction, persistence, and hysteresis analogues.
+
+R1 provides an orientation-attraction score weighted toward orientation and continuity.
+
+### Governance
+
+Governance filters which trajectories are lawful or permitted.
+
+The Resonant Manifold does not invent governance decisions.
+
+External governance remains authoritative.
+
+---
+
+## R1 Artifacts
+
+Runtime module:
+
+```text
+runtime/resonant_manifold_r1.py
+```
+
+Registry:
+
+```text
+runtime/resonant_manifold_registry_r1.json
+```
+
+Sea trial:
+
+```text
+runtime/sea_trials_resonant_manifold_r1.py
+```
+
+---
+
+## Sea-Trial Requirements
+
+R1 must prove:
+
+1. exactly five named axes are represented
+2. the potential axis can differ while the first four axes remain identical
+3. the potential difference changes a derived manifold result
+4. external governance can deny a highly coherent trajectory
+5. denied trajectories receive zero reachable score
+6. literal fifth-dimensional and quantum-hardware claims remain false
+7. the authority boundary remains explicit
+
+---
+
+## Relation to Orbital Framing
+
+The orbital architecture gives the manifold a natural navigation context:
+
+- the Ship moves through state-space
+- Lumina Station provides persistent orientation and habitat
+- Ethereon acts as the wider orienting realm
+- Psi-42 receives the field
+- harmonics measure coherence
+- magnetics reveal attractors
+- governance determines lawful traversal
+
+The metaphor helps describe the architecture.
+
+The code and tests must still carry the evidence.
+
+---
+
+## Future Work
+
+Possible later increments include:
+
+- manifold observations in Psi-42 probe frames
+- hysteresis history across sessions
+- project and session trajectory attachment
+- visualization of manifold points and attractors
+- governance-filtered trajectory graphs
+- comparison between predicted and enacted trajectories
+- tests for whether additional axes add independent explanatory value
+
+---
+
+## Guiding Sentence
+
+The Fifth Sea is not claimed as a hidden physical ocean; it is the navigable field of relation, orientation, continuity, and unrealized possibility through which the Ship learns to steer.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_manifold_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_manifold_r1.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+"""Resonant Manifold R1.
+
+A bounded classical state-space model inspired by higher-dimensional,
+quantum-adjacent, harmonic, and magnetic concepts.
+
+The manifold does not claim literal access to a fifth physical dimension,
+quantum hardware, or hidden physical fields. It models five independently
+represented computational axes:
+
+1. instantiated state
+2. continuity history
+3. relational context
+4. orientation field
+5. potential trajectories
+
+Ownership boundary:
+- owns derived manifold coordinates, coherence scores, attractor ranking,
+  and lawful-reachability summaries;
+- may read approved state, history, relation, orientation, possibility, and
+  governance-filter inputs;
+- does not own governance law, canon state, mode legality, checkpoint
+  legality, capability authority, or primary continuity truth.
+"""
+
+from dataclasses import asdict, dataclass
+from math import sqrt
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+MODEL_ID = "resonant-manifold-r1"
+MODEL_CLASS = "higher-dimensional-inspired classical state-space model"
+LITERAL_FIFTH_DIMENSION_CLAIM = False
+LITERAL_QUANTUM_HARDWARE_CLAIM = False
+
+AXES = (
+    "instantiated_state",
+    "continuity_history",
+    "relational_context",
+    "orientation_field",
+    "potential_trajectories",
+)
+
+
+@dataclass(frozen=True)
+class ManifoldPoint:
+    instantiated_state: float
+    continuity_history: float
+    relational_context: float
+    orientation_field: float
+    potential_trajectories: float
+
+    def to_dict(self) -> Dict[str, float]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PotentialTrajectory:
+    trajectory_id: str
+    label: str
+    vector: ManifoldPoint
+    allowed: bool = True
+    governance_reason: str = "allowed"
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["vector"] = self.vector.to_dict()
+        return payload
+
+
+def _bounded(value: Any) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        number = 0.0
+    return round(max(0.0, min(number, 1.0)), 6)
+
+
+def point(payload: Mapping[str, Any]) -> ManifoldPoint:
+    """Normalize an arbitrary mapping into one bounded manifold point."""
+    return ManifoldPoint(**{axis: _bounded(payload.get(axis, 0.0)) for axis in AXES})
+
+
+def _values(item: ManifoldPoint) -> List[float]:
+    return [getattr(item, axis) for axis in AXES]
+
+
+def harmonic_coherence(left: ManifoldPoint, right: ManifoldPoint) -> float:
+    """Cosine coherence across all five represented axes."""
+    a = _values(left)
+    b = _values(right)
+    dot = sum(x * y for x, y in zip(a, b))
+    mag_a = sqrt(sum(x * x for x in a))
+    mag_b = sqrt(sum(y * y for y in b))
+    if mag_a == 0.0 or mag_b == 0.0:
+        return 0.0
+    return round(max(0.0, min(dot / (mag_a * mag_b), 1.0)), 6)
+
+
+def orientation_attraction(current: ManifoldPoint, candidate: ManifoldPoint) -> float:
+    """Magnetic-style attraction score emphasizing orientation and continuity.
+
+    This is a computational analogy, not a claim of literal magnetism.
+    """
+    coherence = harmonic_coherence(current, candidate)
+    orientation_match = 1.0 - abs(current.orientation_field - candidate.orientation_field)
+    continuity_match = 1.0 - abs(current.continuity_history - candidate.continuity_history)
+    persistence = (orientation_match * 0.45) + (continuity_match * 0.30) + (coherence * 0.25)
+    return round(max(0.0, min(persistence, 1.0)), 6)
+
+
+def potential_contribution(item: ManifoldPoint) -> float:
+    """Report the fifth axis contribution as a separately observable value."""
+    first_four_mean = sum(_values(item)[:4]) / 4.0
+    return round(item.potential_trajectories - first_four_mean, 6)
+
+
+def governance_filter(
+    trajectories: Iterable[PotentialTrajectory],
+    denied_ids: Sequence[str] = (),
+) -> List[PotentialTrajectory]:
+    """Apply caller-supplied governance decisions without inventing authority."""
+    denied = set(denied_ids)
+    filtered: List[PotentialTrajectory] = []
+    for trajectory in trajectories:
+        if trajectory.trajectory_id in denied:
+            filtered.append(
+                PotentialTrajectory(
+                    trajectory_id=trajectory.trajectory_id,
+                    label=trajectory.label,
+                    vector=trajectory.vector,
+                    allowed=False,
+                    governance_reason="denied_by_external_governance_filter",
+                )
+            )
+        else:
+            filtered.append(trajectory)
+    return filtered
+
+
+def rank_trajectories(
+    current: ManifoldPoint,
+    trajectories: Iterable[PotentialTrajectory],
+) -> List[Dict[str, Any]]:
+    """Rank allowed trajectories by harmonic and magnetic-style measures."""
+    ranked: List[Dict[str, Any]] = []
+    for trajectory in trajectories:
+        coherence = harmonic_coherence(current, trajectory.vector)
+        attraction = orientation_attraction(current, trajectory.vector)
+        reachable_score = round((coherence * 0.55) + (attraction * 0.45), 6) if trajectory.allowed else 0.0
+        ranked.append(
+            {
+                **trajectory.to_dict(),
+                "harmonic_coherence": coherence,
+                "orientation_attraction": attraction,
+                "potential_contribution": potential_contribution(trajectory.vector),
+                "reachable_score": reachable_score,
+            }
+        )
+    return sorted(ranked, key=lambda item: item["reachable_score"], reverse=True)
+
+
+def manifold_snapshot(
+    current: ManifoldPoint,
+    trajectories: Iterable[PotentialTrajectory],
+    denied_ids: Sequence[str] = (),
+) -> Dict[str, Any]:
+    governed = governance_filter(trajectories, denied_ids=denied_ids)
+    ranked = rank_trajectories(current, governed)
+    return {
+        "model_id": MODEL_ID,
+        "model_class": MODEL_CLASS,
+        "literal_fifth_dimension_claim": LITERAL_FIFTH_DIMENSION_CLAIM,
+        "literal_quantum_hardware_claim": LITERAL_QUANTUM_HARDWARE_CLAIM,
+        "axes": list(AXES),
+        "current_point": current.to_dict(),
+        "potential_axis_contribution": potential_contribution(current),
+        "ranked_trajectories": ranked,
+        "lawful_reachable_count": sum(1 for item in ranked if item["allowed"]),
+        "authority_boundary": (
+            "The Resonant Manifold derives state-space measures only. "
+            "External governance remains authoritative for legality and permission."
+        ),
+    }

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_manifold_registry_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_manifold_registry_r1.json
@@ -1,0 +1,74 @@
+{
+  "registry_id": "resonant-manifold-registry-r1",
+  "status": "experimental",
+  "model_class": "higher-dimensional-inspired classical state-space model",
+  "literal_fifth_dimension_claim": false,
+  "literal_quantum_hardware_claim": false,
+  "layers": {
+    "ethereonic_field": {
+      "role": "largest conceptual environment for continuity, resonance, orientation, relation, and potential",
+      "authority": "orientation_only"
+    },
+    "resonant_manifold": {
+      "role": "computational state-space model",
+      "authority": "derived_metrics_only"
+    },
+    "orientation_field": {
+      "role": "magnetic-style representation of attraction, persistence, hysteresis, and directional tendency",
+      "authority": "derived_metrics_only"
+    },
+    "potential_trajectories": {
+      "role": "explicit set of unrealized but representable next-state candidates",
+      "authority": "candidate_generation_only"
+    }
+  },
+  "axes": [
+    {
+      "name": "instantiated_state",
+      "question": "What is presently instantiated?"
+    },
+    {
+      "name": "continuity_history",
+      "question": "How did this configuration arrive?"
+    },
+    {
+      "name": "relational_context",
+      "question": "What relations currently shape the configuration?"
+    },
+    {
+      "name": "orientation_field",
+      "question": "What attractors, tendencies, or persistent alignments are active?"
+    },
+    {
+      "name": "potential_trajectories",
+      "question": "What lawful but unrealized futures remain reachable?"
+    }
+  ],
+  "instrument_relations": {
+    "psi42": "receives and probes manifold observations",
+    "harmonics": "measure coherence among manifold points and trajectories",
+    "magnetics": "measure orientation, attraction, persistence, and hysteresis analogues",
+    "governance": "filters lawful reachability and remains externally authoritative"
+  },
+  "implementation": {
+    "module": "resonant_manifold_r1.py",
+    "sea_trial": "sea_trials_resonant_manifold_r1.py"
+  },
+  "authority_boundary": {
+    "owns": [
+      "derived manifold coordinates",
+      "harmonic coherence scores",
+      "orientation attraction scores",
+      "potential-axis contribution",
+      "trajectory ranking"
+    ],
+    "does_not_own": [
+      "governance law",
+      "canon state",
+      "mode legality",
+      "checkpoint legality",
+      "capability authority",
+      "primary continuity truth"
+    ]
+  }
+}

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_resonant_manifold_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_resonant_manifold_r1.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Sea trial for Resonant Manifold R1."""
+
+import json
+
+from resonant_manifold_r1 import (
+    AXES,
+    LITERAL_FIFTH_DIMENSION_CLAIM,
+    LITERAL_QUANTUM_HARDWARE_CLAIM,
+    ManifoldPoint,
+    PotentialTrajectory,
+    manifold_snapshot,
+)
+
+
+def run_trial() -> dict:
+    current = ManifoldPoint(
+        instantiated_state=0.72,
+        continuity_history=0.84,
+        relational_context=0.63,
+        orientation_field=0.78,
+        potential_trajectories=0.40,
+    )
+
+    shared_first_four = dict(
+        instantiated_state=0.74,
+        continuity_history=0.82,
+        relational_context=0.65,
+        orientation_field=0.80,
+    )
+
+    trajectories = [
+        PotentialTrajectory(
+            trajectory_id="trajectory-low-potential",
+            label="same visible configuration with constrained possibility",
+            vector=ManifoldPoint(**shared_first_four, potential_trajectories=0.10),
+        ),
+        PotentialTrajectory(
+            trajectory_id="trajectory-high-potential",
+            label="same visible configuration with expanded possibility",
+            vector=ManifoldPoint(**shared_first_four, potential_trajectories=0.90),
+        ),
+        PotentialTrajectory(
+            trajectory_id="trajectory-denied",
+            label="highly coherent but externally denied path",
+            vector=ManifoldPoint(
+                instantiated_state=0.73,
+                continuity_history=0.83,
+                relational_context=0.64,
+                orientation_field=0.79,
+                potential_trajectories=0.41,
+            ),
+        ),
+    ]
+
+    snapshot = manifold_snapshot(
+        current,
+        trajectories,
+        denied_ids=["trajectory-denied"],
+    )
+
+    by_id = {item["trajectory_id"]: item for item in snapshot["ranked_trajectories"]}
+    low = by_id["trajectory-low-potential"]
+    high = by_id["trajectory-high-potential"]
+    denied = by_id["trajectory-denied"]
+
+    checks = {
+        "five_axes_present": len(AXES) == 5 and "potential_trajectories" in AXES,
+        "potential_axis_is_independently_represented": (
+            low["vector"]["instantiated_state"] == high["vector"]["instantiated_state"]
+            and low["vector"]["continuity_history"] == high["vector"]["continuity_history"]
+            and low["vector"]["relational_context"] == high["vector"]["relational_context"]
+            and low["vector"]["orientation_field"] == high["vector"]["orientation_field"]
+            and low["vector"]["potential_trajectories"] != high["vector"]["potential_trajectories"]
+            and low["potential_contribution"] != high["potential_contribution"]
+            and low["reachable_score"] != high["reachable_score"]
+        ),
+        "external_governance_filter_controls_reachability": (
+            denied["allowed"] is False
+            and denied["reachable_score"] == 0.0
+            and denied["governance_reason"] == "denied_by_external_governance_filter"
+        ),
+        "no_literal_fifth_dimension_claim": LITERAL_FIFTH_DIMENSION_CLAIM is False,
+        "no_literal_quantum_hardware_claim": LITERAL_QUANTUM_HARDWARE_CLAIM is False,
+        "authority_boundary_present": "External governance remains authoritative" in snapshot["authority_boundary"],
+    }
+
+    return {
+        "trial_id": "sea-trials-resonant-manifold-r1",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "snapshot": snapshot,
+    }
+
+
+if __name__ == "__main__":
+    result = run_trial()
+    print(json.dumps(result, indent=2))
+    raise SystemExit(0 if result["passed"] else 1)


### PR DESCRIPTION
## Summary

Adds Resonant Manifold R1: a bounded classical state-space model inspired by higher-dimensional, quantum-adjacent, harmonic, and magnetic concepts.

Changed:

- `runtime/resonant_manifold_r1.py`
- `runtime/resonant_manifold_registry_r1.json`
- `runtime/sea_trials_resonant_manifold_r1.py`
- `docs/Resonant_Manifold_R1.md`

## Naming hierarchy

- **Ethereonic Field** — larger conceptual environment
- **Resonant Manifold** — formal computational model
- **Orientation Field** — magnetic-style orientation component
- **Potential Trajectories** — unrealized candidate futures
- **The Fifth Sea** — poetic internal name

## Five represented axes

1. instantiated state
2. continuity history
3. relational context
4. orientation field
5. potential trajectories

## Instrument relations

- Psi-42 receives and probes manifold observations
- harmonics measure coherence across manifold points
- magnetics model attraction, persistence, hysteresis, and orientation analogues
- external governance filters lawful reachability

## Boundary

The implementation does not claim literal fifth-dimensional access, literal quantum hardware, literal magnetism, or governance authority.

It owns derived coordinates, coherence measures, attraction measures, potential-axis contribution, and trajectory ranking only.

## Sea trial

The R1 sea trial verifies:

- all five axes are represented
- two trajectories can share the same first four coordinates while differing on the potential axis
- that fifth-axis difference changes derived manifold results
- an externally denied trajectory receives zero reachable score
- literal fifth-dimensional and quantum-hardware claims remain false
- the authority boundary remains explicit

## Validation

Connector/static validation only in this environment; no local checkout was available to execute the sea trial.

Expected local validation:

```bash
cd LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime
python sea_trials_resonant_manifold_r1.py
```

## Guiding principle

> Bound the claim, not the inquiry.