### PR TITLE
Fix Lumina registry list output

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_project_registry.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_project_registry.py
@@ -110,7 +110,6 @@ def load_project(slug_or_name: str) -> Dict[str, Any]:
     path = project_file(slug)
     payload = read_json(path)
     if payload is None:
-        # Allow exact name fallback across registry.
         for item in list_projects(include_archived=True):
             if item.get("name") == slug_or_name:
                 payload = read_json(project_file(str(item["slug"])))
@@ -242,7 +241,10 @@ def main() -> int:
         print(json.dumps(payload, indent=2) if args.json else f"Opened Lumina project: {payload['active_project_slug']}")
     elif args.command == "list":
         payload = registry_snapshot(include_archived=args.include_archived)
-        print(json.dumps(payload, indent=2) if args.json else print_project_table(payload["projects"]))
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print_project_table(payload["projects"])
     elif args.command == "active":
         payload = active_project() or {"active_project_slug": None, "active_project_name": None}
         print(json.dumps(payload, indent=2) if args.json else f"Active Lumina project: {payload.get('active_project_slug') or 'none'}")

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_session_registry.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/install/lumina_session_registry.py
@@ -276,7 +276,10 @@ def main() -> int:
         print(json.dumps(payload, indent=2) if args.json else f"Opened Lumina session: {payload['active_session_id']}")
     elif args.command == "list":
         payload = registry_snapshot(project_slug=args.project, include_archived=args.include_archived)
-        print(json.dumps(payload, indent=2) if args.json else print_session_table(payload["sessions"]))
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print_session_table(payload["sessions"])
     elif args.command == "active":
         payload = active_session() or {"active_session_id": None, "active_session_title": None}
         print(json.dumps(payload, indent=2) if args.json else f"Active Lumina session: {payload.get('active_session_id') or 'none'}")


### PR DESCRIPTION
## Summary

Repairs the project and session registry list commands so human-readable output no longer prints a trailing `None`.

Changed:

- `install/lumina_project_registry.py`
- `install/lumina_session_registry.py`

## Repair

Replaces nested `print(... print_table(...))` expressions with explicit JSON versus human-readable branches.

Expected behavior:

```bash
lumina project list
lumina session list
```

now prints only the intended table or empty-state message.

JSON output remains unchanged:

```bash
lumina project list --json
lumina session list --json
```

## Boundary

This is output-contract repair only. It does not alter project/session authority, storage, lifecycle, or runtime governance.