### PR TITLE
Add Lumina continuity correlation R1

### DIFF
--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Continuity_Correlation_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Lumina_Continuity_Correlation_R1.md
@@ -1,0 +1,59 @@
+# Lumina Continuity Correlation R1
+
+## Purpose
+
+Lumina currently creates several valid but distinct references during one work episode:
+
+- a persistent Harbor project
+- a persistent Harbor session
+- a governed runtime session
+- a continuity-restore session
+- a workspace-host session
+
+These references must be linked without being collapsed into one object.
+
+## Correlation Envelope
+
+```text
+project_slug
+harbor_session_id
+runtime_session_id
+restore_session_id
+host_session_id
+correlation_id
+```
+
+The Harbor session is the primary human-facing work episode.
+
+The runtime, restore, and host references describe specialized instances attached to that episode.
+
+## Resolution Rule
+
+Project resolution should proceed in this order:
+
+1. explicit project argument
+2. active Harbor project marker
+3. active Harbor session project
+4. clearly labeled projectless execution or halt
+
+Raw prompt text should not silently become a project identifier.
+
+## Mismatch Rule
+
+If the active project marker and active session marker name different projects, correlation must fail rather than guessing.
+
+## Authority Boundary
+
+Correlation coordinates references only.
+
+It does not transfer:
+
+- governance authority
+- canon authority
+- checkpoint legality
+- mode legality
+- capability authority
+
+## Next Integration
+
+A later runner bridge should emit the correlation envelope into runtime receipts and active-session receipt storage.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/continuity_correlation_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/continuity_correlation_r1.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+import json
+import uuid
+
+SCHEMA_VERSION = "lumina-continuity-correlation-r1"
+
+
+def read_marker(path: Path) -> Dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+@dataclass(frozen=True)
+class ContinuityCorrelation:
+    schema_version: str
+    correlation_id: str
+    project_slug: Optional[str]
+    harbor_session_id: Optional[str]
+    runtime_session_id: Optional[str]
+    restore_session_id: Optional[str]
+    host_session_id: Optional[str]
+    authority_boundary: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def active_workspace(state_root: Path) -> Dict[str, Optional[str]]:
+    project = read_marker(state_root / "active_project.json")
+    session = read_marker(state_root / "active_session.json")
+    project_slug = project.get("active_project_slug")
+    session_project = session.get("project_slug")
+    if project_slug and session_project and project_slug != session_project:
+        raise ValueError("active project and session markers disagree")
+    return {
+        "project_slug": str(project_slug or session_project) if (project_slug or session_project) else None,
+        "harbor_session_id": str(session.get("active_session_id")) if session.get("active_session_id") else None,
+    }
+
+
+def create_correlation(
+    *,
+    state_root: Optional[Path] = None,
+    project_slug: Optional[str] = None,
+    harbor_session_id: Optional[str] = None,
+    runtime_session_id: Optional[str] = None,
+    restore_session_id: Optional[str] = None,
+    host_session_id: Optional[str] = None,
+    correlation_id: Optional[str] = None,
+) -> ContinuityCorrelation:
+    if state_root is not None:
+        active = active_workspace(state_root)
+        project_slug = project_slug or active["project_slug"]
+        harbor_session_id = harbor_session_id or active["harbor_session_id"]
+    if not any([harbor_session_id, runtime_session_id, restore_session_id, host_session_id]):
+        raise ValueError("at least one session reference is required")
+    return ContinuityCorrelation(
+        schema_version=SCHEMA_VERSION,
+        correlation_id=correlation_id or f"lumina-{uuid.uuid4().hex}",
+        project_slug=project_slug,
+        harbor_session_id=harbor_session_id,
+        runtime_session_id=runtime_session_id,
+        restore_session_id=restore_session_id,
+        host_session_id=host_session_id,
+        authority_boundary="Correlation does not transfer governance, canon, checkpoint, or capability authority.",
+    )

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/continuity_correlation_registry_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/continuity_correlation_registry_r1.json
@@ -1,0 +1,22 @@
+{
+  "registry_id": "lumina-continuity-correlation-registry-r1",
+  "status": "experimental-active",
+  "primary_human_facing_reference": "harbor_session_id",
+  "typed_references": [
+    "project_slug",
+    "harbor_session_id",
+    "runtime_session_id",
+    "restore_session_id",
+    "host_session_id",
+    "correlation_id"
+  ],
+  "semantics": {
+    "project_slug": "persistent Harbor project reference",
+    "harbor_session_id": "persistent human-facing work episode",
+    "runtime_session_id": "governed execution instance",
+    "restore_session_id": "continuity reconstruction record",
+    "host_session_id": "workspace layout and tool-surface instance",
+    "correlation_id": "stable link across one coordinated work episode"
+  },
+  "authority_boundary": "Correlation links typed references only and does not transfer governance, canon, checkpoint, or capability authority."
+}


### PR DESCRIPTION
## Summary

Adds the first typed correlation contract across Lumina's project and session layers.

Changed:

- `runtime/continuity_correlation_r1.py`
- `runtime/continuity_correlation_registry_r1.json`
- `docs/Lumina_Continuity_Correlation_R1.md`

## What it defines

- Harbor session = persistent human-facing work episode
- runtime session = governed execution instance
- restore session = continuity reconstruction record
- host session = workspace layout/tool-surface instance
- correlation ID = stable link across the coordinated episode

## Guardrail

The resolver rejects an active project marker and active session marker that refer to different projects rather than guessing.

## Project resolution doctrine

1. explicit project argument
2. active Harbor project marker
3. active Harbor session project
4. clearly labeled projectless execution or halt

Raw prompt text should not silently become a project identifier.

## Boundary

Correlation links typed references only. It does not transfer governance, canon, checkpoint, mode, or capability authority.

## Scope

This PR establishes the identity/correlation spine contract and executable helper. Runner receipt integration is intentionally reserved for the next bridge after this contract is reviewed.