### PR TITLE
Align scheduled Observation with v1.8 runtime truth

### DIFF
--- a/.github/workflows/lumina-observation-cycle.yml
+++ b/.github/workflows/lumina-observation-cycle.yml
@@ -41,6 +41,27 @@ jobs:
             --overlay-json '{"active":true,"anchor_language":["english"],"continuity_phrase":"scheduled observation cycle","harmonic_signature":[],"spiral_reference":null}' \
             --runtime-config-json '{"toki_pona_required_for_resume":false,"binary_required_for_transition_validation":false,"light_language_required_for_capability_loading":false,"harmonic_frequency_required_for_mode_legality":false}'
 
+      - name: Verify v1.8 public witness
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("public/runtime/latest_cycle.json").read_text(encoding="utf-8"))
+          failures = []
+          if payload.get("schema_version") != "lumina-runtime-ui-cycle-v0.4":
+              failures.append("latest cycle is not schema v0.4")
+          if (payload.get("probe") or {}).get("instrument_version") != "v1.8":
+              failures.append("public probe did not execute as Psi-42 v1.8")
+          if "psi42_transceiver_v18" not in (payload.get("capabilities") or []):
+              failures.append("v1.8 capability is absent from the public receipt")
+          if (payload.get("runtime_truth_scope") or {}).get("does_not_override_committed_authority") is not True:
+              failures.append("runtime truth scope does not preserve committed authority")
+          if failures:
+              raise SystemExit("; ".join(failures))
+          print(json.dumps({"status": "pass", "run_id": payload.get("run_id"), "probe_version": "v1.8"}, indent=2))
+          PY
+
       - name: Validate reconciled public truth
         run: |
           python studio/runtime_truth_reconciliation_gate_r1.py

--- a/.github/workflows/lumina-observation-cycle.yml
+++ b/.github/workflows/lumina-observation-cycle.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run bounded Observation cycle
         run: |
           cd LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime
-          python runtime_runner_auto_snapshot_r1.py \
+          python runtime_runner_auto_snapshot_psi42_v18_r1.py \
             --current-mode Continuity \
             --target-mode Observation \
             --action chamber_observation_cycle \
@@ -36,15 +36,24 @@ jobs:
             --enable-flag ETHEREON_OBSERVATION \
             --enable-flag ETHEREON_PSI42 \
             --enable-flag ETHEREON_PSI42_V17 \
+            --enable-flag ETHEREON_PSI42_V18 \
             --enable-flag ETHEREON_RESONANCE \
             --overlay-json '{"active":true,"anchor_language":["english"],"continuity_phrase":"scheduled observation cycle","harmonic_signature":[],"spiral_reference":null}' \
             --runtime-config-json '{"toki_pona_required_for_resume":false,"binary_required_for_transition_validation":false,"light_language_required_for_capability_loading":false,"harmonic_frequency_required_for_mode_legality":false}'
+
+      - name: Validate reconciled public truth
+        run: |
+          python studio/runtime_truth_reconciliation_gate_r1.py
 
       - name: Commit runtime snapshot if changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add public/runtime/latest_cycle.json public/runtime/history
+          git add \
+            public/runtime/latest_cycle.json \
+            public/runtime/runtime_truth_snapshot.json \
+            public/runtime/history \
+            artifacts/runtime_truth/current/observation_*.json
           if git diff --cached --quiet; then
             echo "No runtime artifact changes to commit."
           else

--- a/.github/workflows/runtime-truth-gate.yml
+++ b/.github/workflows/runtime-truth-gate.yml
@@ -6,6 +6,11 @@ on:
       - 'public/runtime/**'
       - 'artifacts/runtime_truth/**'
       - 'studio/runtime_truth_gate_r1.py'
+      - 'studio/runtime_truth_reconciliation_gate_r1.py'
+      - 'LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_public_snapshot_r1.py'
+      - 'LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_ui_snapshot_emitter_r1.py'
+      - 'LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_runner_auto_snapshot_psi42_v18_r1.py'
+      - '.github/workflows/lumina-observation-cycle.yml'
       - '.github/workflows/runtime-truth-gate.yml'
   workflow_dispatch:
 

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_public_snapshot_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/runtime_truth_public_snapshot_r1.py
@@ -14,6 +14,8 @@ REPO_ROOT = infer_repo_root()
 PUBLIC_RUNTIME_DIR = REPO_ROOT / "public" / "runtime"
 LATEST_CYCLE_PATH = PUBLIC_RUNTIME_DIR / "latest_cycle.json"
 SNAPSHOT_PATH = PUBLIC_RUNTIME_DIR / "runtime_truth_snapshot.json"
+PUBLIC_HISTORY_DIR = PUBLIC_RUNTIME_DIR / "history"
+PUBLIC_HISTORY_INDEX = PUBLIC_HISTORY_DIR / "index.json"
 ARTIFACT_DIR = REPO_ROOT / "artifacts" / "runtime_truth" / "current"
 POST_PROMOTION_PATH = ARTIFACT_DIR / "post_promotion_verification_0001.json"
 PROMOTION_RECEIPT_PATH = ARTIFACT_DIR / "promotion_receipt_0001.json"
@@ -21,6 +23,7 @@ GOVERNANCE_CHAIN_PATH = ARTIFACT_DIR / "governance_chain_0001.jsonl"
 CANON_LINEAGE_PATH = ARTIFACT_DIR / "canon_lineage_0001.jsonl"
 LATEST_CYCLE_SCHEMA_VERSION = "lumina-runtime-ui-cycle-v0.4"
 PUBLIC_SNAPSHOT_SCHEMA_VERSION = "lumina-runtime-truth-public-snapshot-v0.2"
+PUBLIC_HISTORY_LIMIT = 25
 
 
 def _read_json(path: Path) -> Dict[str, Any]:
@@ -31,7 +34,25 @@ def _read_json(path: Path) -> Dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def _read_json_list(path: Path) -> list[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+
+
 def _write_json(path: Path, payload: Dict[str, Any]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+    return _repo_relative(path)
+
+
+def _write_json_list(path: Path, payload: list[Dict[str, Any]]) -> str:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)
@@ -178,6 +199,44 @@ def _normalize_latest_cycle_contract(latest: Dict[str, Any], runtime_truth: Dict
     return normalized
 
 
+def _history_archive_name(snapshot: Dict[str, Any]) -> Optional[str]:
+    run_id = snapshot.get("run_id")
+    timestamp = snapshot.get("timestamp")
+    if not run_id or not timestamp:
+        return None
+    safe_run = str(run_id).replace("/", "-").replace(":", "-")
+    safe_timestamp = str(timestamp).replace(":", "-").replace("+", "_")
+    return f"{safe_timestamp}_{safe_run}.json"
+
+
+def _sync_public_history(snapshot: Dict[str, Any]) -> Optional[str]:
+    archive_name = _history_archive_name(snapshot)
+    if archive_name is None:
+        return None
+
+    archive_path = PUBLIC_HISTORY_DIR / archive_name
+    _write_json(archive_path, snapshot)
+
+    probe = snapshot.get("probe", {}) if isinstance(snapshot.get("probe"), dict) else {}
+    status = snapshot.get("status", {}) if isinstance(snapshot.get("status"), dict) else {}
+    mode = snapshot.get("mode", {}) if isinstance(snapshot.get("mode"), dict) else {}
+    entry = {
+        "timestamp": snapshot.get("timestamp"),
+        "run_id": snapshot.get("run_id"),
+        "status": status.get("label"),
+        "mode": mode.get("current"),
+        "file": f"/runtime/history/{archive_name}",
+        "probe_instrument_version": probe.get("instrument_version"),
+        "hybrid_continuity_coherence": probe.get("hybrid_continuity_coherence"),
+    }
+
+    index = _read_json_list(PUBLIC_HISTORY_INDEX)
+    run_id = snapshot.get("run_id")
+    index = [entry] + [item for item in index if item.get("run_id") != run_id]
+    _write_json_list(PUBLIC_HISTORY_INDEX, index[:PUBLIC_HISTORY_LIMIT])
+    return _repo_relative(archive_path)
+
+
 def build_public_runtime_truth_snapshot(
     *,
     latest_cycle_path: Optional[str | Path] = None,
@@ -191,26 +250,35 @@ def build_public_runtime_truth_snapshot(
     artifact_map = observation.get("artifacts", {})
     runtime_truth = _truth_payload_from_artifacts(artifact_map)
     latest = _read_json(latest_path)
+    normalized_latest = _normalize_latest_cycle_contract(latest, runtime_truth) if latest else {}
+    history_receipt_path = None
+
+    if normalized_latest:
+        _write_json(latest_path, normalized_latest)
+        if latest_path.resolve() == LATEST_CYCLE_PATH.resolve():
+            history_receipt_path = _sync_public_history(normalized_latest)
+
+    source_latest = normalized_latest or latest
+    public_artifact_paths = {
+        **artifact_map,
+        **runtime_truth["committed_authority"]["evidence_paths"],
+    }
+    if history_receipt_path:
+        public_artifact_paths["history_receipt"] = history_receipt_path
+
     public_snapshot = {
         "schema_version": PUBLIC_SNAPSHOT_SCHEMA_VERSION,
         "source_latest_cycle": _repo_relative(latest_path),
-        "latest_cycle_run_id": latest.get("run_id"),
-        "latest_cycle_timestamp": latest.get("timestamp"),
-        "mode": latest.get("mode", {}),
-        "action_type": latest.get("action_type"),
+        "latest_cycle_run_id": source_latest.get("run_id"),
+        "latest_cycle_timestamp": source_latest.get("timestamp"),
+        "mode": source_latest.get("mode", {}),
+        "action_type": source_latest.get("action_type"),
         "runtime_truth_scope": _scope_payload(),
         "runtime_truth": runtime_truth,
-        "artifact_paths": {
-            **artifact_map,
-            **runtime_truth["committed_authority"]["evidence_paths"],
-        },
+        "artifact_paths": public_artifact_paths,
         "authority_boundary": "Public runtime truth summary only; does not authorize action, alter governance, mutate canon, change mode legality, expose capabilities, or execute tools.",
     }
     _write_json(out_path, public_snapshot)
-
-    if latest:
-        _write_json(latest_path, _normalize_latest_cycle_contract(latest, runtime_truth))
-
     return public_snapshot
 
 

--- a/studio/runtime_truth_reconciliation_gate_r1.py
+++ b/studio/runtime_truth_reconciliation_gate_r1.py
@@ -23,6 +23,7 @@ from governance_integrity_r1 import GovernanceIntegrityChain  # noqa: E402
 from canon_lineage_store_r1 import CanonLineageStore  # noqa: E402
 
 
+EXPECTED_LATEST_SCHEMA = "lumina-runtime-ui-cycle-v0.4"
 PATHS = {
     "governance_chain": ROOT / "artifacts/runtime_truth/current/governance_chain_0001.jsonl",
     "canon_lineage": ROOT / "artifacts/runtime_truth/current/canon_lineage_0001.jsonl",
@@ -30,6 +31,7 @@ PATHS = {
     "post_promotion": ROOT / "artifacts/runtime_truth/current/post_promotion_verification_0001.json",
     "public_snapshot": ROOT / "public/runtime/runtime_truth_snapshot.json",
     "latest_cycle": ROOT / "public/runtime/latest_cycle.json",
+    "history_index": ROOT / "public/runtime/history/index.json",
     "capability_registry": RUNTIME_DIR / "capability_registry_r1.json",
     "active_runtime_index": ROOT / "LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md",
     "seed_plan": ROOT / "docs/GOVERNANCE_CANON_SEED_PLAN.md",
@@ -44,6 +46,14 @@ def read_json(path: Path) -> Dict[str, Any]:
     return payload
 
 
+def read_json_list(path: Path) -> list[Dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, list):
+        raise ValueError(f"expected JSON list: {path}")
+    return [item for item in payload if isinstance(item, dict)]
+
+
 def contains_absolute_workspace_path(node: Any) -> bool:
     if isinstance(node, dict):
         return any(contains_absolute_workspace_path(value) for value in node.values())
@@ -52,6 +62,18 @@ def contains_absolute_workspace_path(node: Any) -> bool:
     if isinstance(node, str):
         return "/home/runner/" in node or "/workspace/" in node
     return False
+
+
+def public_history_receipt_path(entry: Dict[str, Any]) -> Path | None:
+    file_reference = entry.get("file")
+    if not isinstance(file_reference, str) or not file_reference.startswith("/runtime/history/"):
+        return None
+    candidate = (ROOT / "public" / file_reference.lstrip("/")).resolve()
+    try:
+        candidate.relative_to((ROOT / "public").resolve())
+    except ValueError:
+        return None
+    return candidate
 
 
 def run_gate() -> Tuple[bool, Dict[str, bool], Dict[str, Any]]:
@@ -65,9 +87,15 @@ def run_gate() -> Tuple[bool, Dict[str, bool], Dict[str, Any]]:
     post = read_json(PATHS["post_promotion"])
     snapshot = read_json(PATHS["public_snapshot"])
     latest = read_json(PATHS["latest_cycle"])
+    history_index = read_json_list(PATHS["history_index"])
     registry = read_json(PATHS["capability_registry"])
     index_text = PATHS["active_runtime_index"].read_text(encoding="utf-8")
     seed_text = PATHS["seed_plan"].read_text(encoding="utf-8")
+
+    latest_history_entry = history_index[0] if history_index else {}
+    history_receipt_path = public_history_receipt_path(latest_history_entry)
+    history_receipt_exists = history_receipt_path is not None and history_receipt_path.exists()
+    history_receipt = read_json(history_receipt_path) if history_receipt_exists and history_receipt_path else {}
 
     truth = snapshot.get("runtime_truth", {}) or {}
     public_governance = truth.get("governance_chain", {}) or {}
@@ -106,6 +134,7 @@ def run_gate() -> Tuple[bool, Dict[str, bool], Dict[str, Any]]:
         ),
         "snapshot_scope_prevents_override": scope.get("does_not_override_committed_authority") is True,
         "latest_scope_prevents_override": latest_scope.get("does_not_override_committed_authority") is True,
+        "latest_cycle_schema_is_current": latest.get("schema_version") == EXPECTED_LATEST_SCHEMA,
         "latest_canon_matches_committed": (
             latest_canon.get("current_head") == canon.get("current_head")
             and latest_canon.get("record_count") == canon.get("record_count")
@@ -115,9 +144,27 @@ def run_gate() -> Tuple[bool, Dict[str, bool], Dict[str, Any]]:
             (latest_truth.get("canon_lineage") or {}).get("current_head") == canon.get("current_head")
             and (latest_truth.get("governance_chain") or {}).get("event_count") == governance.get("event_count")
         ),
+        "snapshot_source_run_matches_latest": snapshot.get("latest_cycle_run_id") == latest.get("run_id"),
+        "snapshot_source_timestamp_matches_latest": snapshot.get("latest_cycle_timestamp") == latest.get("timestamp"),
+        "history_index_not_empty": bool(history_index),
+        "history_index_latest_run_matches_latest": latest_history_entry.get("run_id") == latest.get("run_id"),
+        "history_index_latest_timestamp_matches_latest": latest_history_entry.get("timestamp") == latest.get("timestamp"),
+        "history_receipt_path_is_valid": history_receipt_path is not None,
+        "history_receipt_exists": history_receipt_exists,
+        "history_receipt_run_matches_latest": history_receipt.get("run_id") == latest.get("run_id"),
+        "history_receipt_timestamp_matches_latest": history_receipt.get("timestamp") == latest.get("timestamp"),
+        "history_receipt_schema_matches_latest": history_receipt.get("schema_version") == latest.get("schema_version"),
+        "history_receipt_canon_matches_latest": history_receipt.get("canon") == latest.get("canon"),
+        "history_receipt_scope_matches_latest": history_receipt.get("runtime_truth_scope") == latest.get("runtime_truth_scope"),
+        "history_receipt_runtime_truth_matches_latest": history_receipt.get("runtime_truth") == latest.get("runtime_truth"),
+        "history_receipt_probe_version_matches_latest": (
+            (history_receipt.get("probe") or {}).get("instrument_version")
+            == (latest.get("probe") or {}).get("instrument_version")
+        ),
         "capability_count_matches_registry": (truth.get("capability_registry") or {}).get("capability_count") == capability_count,
         "public_artifacts_are_repo_relative": not contains_absolute_workspace_path(snapshot),
         "latest_cycle_is_repo_relative": not contains_absolute_workspace_path(latest),
+        "history_receipt_is_repo_relative": not contains_absolute_workspace_path(history_receipt),
         "active_index_names_reconciliation_gate": "runtime_truth_reconciliation_gate_r1.py" in index_text,
         "active_index_names_v18": "psi42_transceiver_v1_8.py" in index_text,
         "active_index_names_correlation": "continuity_correlation" in index_text,
@@ -132,6 +179,11 @@ def run_gate() -> Tuple[bool, Dict[str, bool], Dict[str, Any]]:
         "public_scope": scope,
         "observed_scope": observed.get("scope"),
         "capability_count": capability_count,
+        "latest_run_id": latest.get("run_id"),
+        "snapshot_source_run_id": snapshot.get("latest_cycle_run_id"),
+        "history_index_run_id": latest_history_entry.get("run_id"),
+        "history_receipt_path": str(history_receipt_path) if history_receipt_path else None,
+        "history_receipt_run_id": history_receipt.get("run_id"),
     }
     return all(checks.values()), checks, details
 


### PR DESCRIPTION
## Summary

Repairs the drift between Lumina's active Psi-42 v1.8 host path and the scheduled/public Observation ledger.

The scheduled workflow now uses the same v1.8 auto-snapshot runner as `lumina observe`, and the public-truth projection now normalizes the matching history receipt before reconciliation. The gate verifies that latest-cycle, public truth, history index, and history receipt all describe the same run.

## Root cause

Three sequencing and ownership gaps had accumulated:

1. `.github/workflows/lumina-observation-cycle.yml` still invoked the base auto-snapshot runner and enabled flags only through Psi-42 v1.7.
2. `runtime_ui_snapshot_emitter_r1.py` archived the raw v0.3 receipt before `runtime_truth_public_snapshot_r1.py` normalized `latest_cycle.json` to v0.4 and projected committed canon truth.
3. The reconciliation gate compared canon and governance facts but did not verify source run/timestamp freshness or the corresponding history receipt.

This allowed one run to exist as a v0.4 latest receipt with `canon-0001` and as a v0.3 history receipt with no canon head, while `runtime_truth_snapshot.json` could remain tied to an older run.

## Changes

### Scheduled Observation

- routes through `runtime_runner_auto_snapshot_psi42_v18_r1.py`
- enables `ETHEREON_PSI42_V18`
- explicitly requires the generated public receipt to expose Psi-42 v1.8
- runs the reconciliation gate before committing generated state
- commits `runtime_truth_snapshot.json` and Observation-scoped truth receipts alongside latest/history

### Public receipt normalization

- normalizes `latest_cycle.json` before public snapshot emission
- rewrites the matching history receipt under the same run ID and timestamp
- refreshes the bounded 25-entry history index without duplicate run IDs
- records the synchronized history receipt in public truth artifact paths
- leaves custom/non-default latest-cycle paths isolated from the public history ledger

### Reconciliation gate

Adds executable checks for:

- latest schema v0.4
- public snapshot run and timestamp matching latest cycle
- newest history index entry matching latest cycle
- corresponding history receipt existence and safe path resolution
- matching run ID, timestamp, schema, canon, truth scope, runtime truth, and probe version
- absence of absolute workspace paths in the history receipt

### CI ownership

- expands Runtime Truth Gate path filters so changes to the generator, reconciliation gate, v1.8 snapshot runner, or Observation workflow trigger validation

## Validation

Expected checks:

```bash
python studio/runtime_truth_gate_r1.py
python LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_runtime_runner_psi42_v18_wiring_r1.py
```

The scheduled workflow additionally validates that its emitted public receipt contains:

- `schema_version: lumina-runtime-ui-cycle-v0.4`
- `probe.instrument_version: v1.8`
- exposed capability `psi42_transceiver_v18`
- explicit preservation of committed runtime authority

## Authority boundary

This PR does not:

- alter mode legality, mutation permission, promotion gates, checkpoint legality, or canon lineage
- create `canon-0002`
- remove Psi-42 v1.6 or v1.7 fallback behavior
- collapse the adapter stack
- wire Meaning Metabolism or reflective autonomy into the default runner
- change Chamber from a read-only witness surface
