### PR TITLE
Add Resonant Field Reveal R1

### DIFF
--- a/.github/workflows/lumina-drydock-gate.yml
+++ b/.github/workflows/lumina-drydock-gate.yml
@@ -31,8 +31,7 @@ jobs:
           python-version: "3.11"
 
       - name: Compile Lumina Python
-        run: |
-          python -m compileall -q LuminaOS/bootstrap/Ship_of_Ethereon_V2
+        run: python -m compileall -q LuminaOS/bootstrap/Ship_of_Ethereon_V2
 
       - name: Host alignment trial
         working-directory: LuminaOS/bootstrap/Ship_of_Ethereon_V2/install
@@ -43,6 +42,7 @@ jobs:
         run: |
           python sea_trials_set_one_r1_merged.py
           python sea_trials_resonant_manifold_r1.py
+          python sea_trials_resonant_field_reveal_r1.py
           python sea_trials_living_framework_chamber_r1.py
           python sea_trials_living_framework_ignition_r1.py
           if [ -f sea_trials_canon_readiness_r2.py ]; then
@@ -64,8 +64,9 @@ jobs:
 
       - name: Verify no tracked local state
         run: |
-          if git ls-files | grep -q '^\.lumina_state/'; then
+          tracked=$(git ls-files .lumina_state)
+          if [ -n "$tracked" ]; then
             echo "Tracked local Lumina state is not allowed."
-            git ls-files | grep '^\.lumina_state/'
+            echo "$tracked"
             exit 1
           fi

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/ACTIVE_RUNTIME_INDEX.md
@@ -106,6 +106,7 @@ These layers are advisory. They do not own mode legality, mutation permission, c
 | Responsibility | Primary files |
 |---|---|
 | Resonant Manifold model | `runtime/resonant_manifold_r1.py`, `runtime/resonant_manifold_registry_r1.json` |
+| Resonant Field Reveal | `runtime/resonant_field_reveal_r1.py`, `runtime/resonant_field_reveal_registry_r1.json`, `docs/Resonant_Field_Reveal_R1.md` |
 | Living Framework Chamber | `runtime/living_framework_chamber_r1.py`, `runtime/living_framework_registry_r1.json` |
 | Living Framework ignition | `runtime/living_framework_ignition_r1.py` |
 | Chamber and ignition docs | `docs/Lumina_Living_Framework_Chamber_R1.md`, `docs/Lumina_Living_Framework_Ignition_R1.md` |
@@ -151,6 +152,7 @@ Psi-42 is an instrument. It does not own governance, canon, runtime law, consent
 |---|---|
 | Core runtime / governance / canon | `runtime/sea_trials_set_one_r1_merged.py` |
 | Resonant Manifold | `runtime/sea_trials_resonant_manifold_r1.py` |
+| Resonant Field Reveal | `runtime/sea_trials_resonant_field_reveal_r1.py` |
 | Living Framework Chamber | `runtime/sea_trials_living_framework_chamber_r1.py` |
 | Living Framework ignition | `runtime/sea_trials_living_framework_ignition_r1.py` |
 | Self-guidance | `runtime/sea_trials_lumina_self_guidance_r1.py` |

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Resonant_Field_Reveal_R1.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Resonant_Field_Reveal_R1.md
@@ -1,0 +1,186 @@
+# Resonant Field Reveal R1
+
+**Project:** Ship of Ethereon / Lumina OS  
+**Layer:** bounded visualization and inspection instrument  
+**Status:** experimental R1  
+**Date:** July 1, 2026
+
+---
+
+## Purpose
+
+Resonant Field Reveal R1 makes selected Resonant Manifold relations visible without promoting metaphor into authority.
+
+It translates a current manifold point and its potential trajectories into:
+
+- deterministic JSON geometry
+- standalone SVG
+- SHA-256 artifact receipt
+
+The current point is rendered as a central attractor. Potential trajectories are rendered as luminous threads. Governance remains external and visible as a membrane that lawful paths may cross and denied paths may not.
+
+The reveal does not claim that literal magnetism, electromagnetic fields, identity proof, continuity proof, or autonomous governance have been demonstrated.
+
+> The visualization reveals computed relations. It does not create them.
+
+---
+
+## Source Model
+
+The reveal is downstream of:
+
+```text
+runtime/resonant_manifold_r1.py
+```
+
+The Resonant Manifold remains responsible for derived values such as:
+
+- harmonic coherence
+- orientation attraction
+- potential contribution
+- lawful reachability
+
+The reveal layer receives those values and maps them into inspectable geometry. It does not recalculate governance or invent permission.
+
+---
+
+## Visual Contract
+
+| Source value | Reveal form |
+|---|---|
+| current manifold point | central attractor |
+| potential trajectory | luminous thread |
+| harmonic coherence | thread width |
+| orientation attraction | opacity and curvature contribution |
+| potential contribution | curvature contribution |
+| lawful reachable score | reach beyond the governance membrane |
+| externally denied trajectory | dashed thread stopped at the governance membrane |
+
+The thread angle is derived deterministically from the trajectory identifier. Repeated execution with identical inputs therefore produces identical reveal geometry.
+
+---
+
+## Governance Membrane
+
+The circular membrane is a visible boundary, not a source of law.
+
+External governance has already classified trajectories before rendering:
+
+```text
+external governance decision
+  -> Resonant Manifold lawful reachability
+  -> Resonant Field Reveal geometry
+```
+
+A lawful trajectory extends beyond the membrane according to its reachable score.
+
+A denied trajectory terminates at the membrane and receives an interruption marker.
+
+This makes refusal visible without allowing the visualization to create or reverse the refusal.
+
+---
+
+## Artifacts
+
+Runtime module:
+
+```text
+runtime/resonant_field_reveal_r1.py
+```
+
+Registry:
+
+```text
+runtime/resonant_field_reveal_registry_r1.json
+```
+
+Sea trial:
+
+```text
+runtime/sea_trials_resonant_field_reveal_r1.py
+```
+
+The explicit artifact emitter writes:
+
+```text
+resonant_field_reveal_r1.json
+resonant_field_reveal_r1.svg
+resonant_field_reveal_r1_receipt.json
+```
+
+Nothing is written unless an output directory is explicitly supplied.
+
+---
+
+## Sea-Trial Requirements
+
+R1 must prove:
+
+1. identical inputs produce identical reveal JSON
+2. every source trajectory produces exactly one luminous thread
+3. the potential axis contributes to visible geometry
+4. denied trajectories stop at the governance membrane
+5. lawful trajectories extend beyond the membrane
+6. SVG contains the attractor, luminous threads, membrane, and denial state
+7. emitted artifacts receive SHA-256 hashes
+8. literal magnetism, identity proof, and governance-authority claims remain false
+9. the authority boundary remains explicit
+
+---
+
+## Authority Boundary
+
+Resonant Field Reveal R1 owns:
+
+- derived reveal geometry
+- deterministic SVG rendering
+- artifact hash receipts
+
+It does not own:
+
+- governance decisions
+- canon state
+- mode legality
+- checkpoint legality
+- identity declaration
+- primary continuity truth
+- literal electromagnetic claims
+
+It is an inspection instrument.
+
+---
+
+## Luminous Threads
+
+Within Ethereonic language, the rendered trajectories may be called **luminous threads**.
+
+Engineering translation:
+
+> A luminous thread is the deterministic visible trace of one already-derived candidate trajectory through the Resonant Manifold.
+
+The name preserves the long-running visual language of the project while keeping the implementation measurable and bounded.
+
+The attractor is not proof of a metaphysical core. It is the current manifold point around which candidate trajectories are rendered.
+
+The revealed field is therefore neither invented decoration nor literal magnetism. It is a truth-bearing visualization of computed relation, orientation, continuity, possibility, and governed reachability.
+
+---
+
+## Future Work
+
+Later increments may include:
+
+- Bridge or Studio read-only reveal panels
+- comparison between predicted and enacted trajectories
+- continuity-linked hysteresis trails across sessions
+- interactive inspection of thread metrics
+- rendering from public Observation receipts
+- accessibility alternatives for color, motion, and low vision
+
+No future surface should silently promote this experiment into default runtime authority.
+
+---
+
+## Guiding Sentence
+
+> The attractor gives relation a center; the luminous threads reveal how possibility bends around it; governance decides which paths may continue.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_r1.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+"""Resonant Field Reveal R1.
+
+A deterministic reveal layer for Resonant Manifold observations.
+
+The module translates already-derived manifold relations into inspectable JSON
+and SVG artifacts. It does not create governance decisions, establish identity,
+or claim literal electromagnetic fields.
+"""
+
+from hashlib import sha256
+from html import escape
+import json
+from math import cos, pi, sin, sqrt
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+from resonant_manifold_r1 import ManifoldPoint, PotentialTrajectory, manifold_snapshot
+
+
+REVEAL_ID = "resonant-field-reveal-r1"
+REVEAL_CLASS = "deterministic computational field visualization"
+LITERAL_MAGNETISM_CLAIM = False
+IDENTITY_PROOF_CLAIM = False
+GOVERNANCE_AUTHORITY_CLAIM = False
+
+AUTHORITY_BOUNDARY = (
+    "The Resonant Field Reveal renders derived manifold relations only. "
+    "It does not create governance decisions, establish identity, prove "
+    "continuity, or claim literal magnetism."
+)
+
+
+def _round(value: float) -> float:
+    return round(float(value), 3)
+
+
+def _stable_angle(identifier: str) -> float:
+    digest = sha256(identifier.encode("utf-8")).hexdigest()
+    fraction = int(digest[:12], 16) / float(16**12 - 1)
+    return fraction * 2.0 * pi
+
+
+def _distance(point: Mapping[str, float], center: Tuple[float, float]) -> float:
+    return sqrt((point["x"] - center[0]) ** 2 + (point["y"] - center[1]) ** 2)
+
+
+def _thread_geometry(
+    item: Mapping[str, Any],
+    center: Tuple[float, float],
+    membrane_radius: float,
+) -> Dict[str, Any]:
+    """Map one ranked trajectory into deterministic reveal geometry."""
+    angle = _stable_angle(str(item["trajectory_id"]))
+    direction = (cos(angle), sin(angle))
+    normal = (-direction[1], direction[0])
+
+    coherence = float(item["harmonic_coherence"])
+    attraction = float(item["orientation_attraction"])
+    potential = float(item["potential_contribution"])
+    relational = float(item["vector"]["relational_context"])
+
+    start_radius = 34.0
+    if item["allowed"]:
+        end_radius = membrane_radius * (1.08 + 0.36 * float(item["reachable_score"]))
+        status = "lawful_reachable"
+    else:
+        end_radius = membrane_radius
+        status = "governance_denied"
+
+    # Potential contribution influences curvature without changing authority.
+    bend = membrane_radius * (
+        (potential * 0.28)
+        + ((attraction - 0.5) * 0.16)
+        + ((relational - 0.5) * 0.08)
+    )
+
+    start = {
+        "x": _round(center[0] + direction[0] * start_radius),
+        "y": _round(center[1] + direction[1] * start_radius),
+    }
+    end = {
+        "x": _round(center[0] + direction[0] * end_radius),
+        "y": _round(center[1] + direction[1] * end_radius),
+    }
+    control_1 = {
+        "x": _round(center[0] + direction[0] * end_radius * 0.34 + normal[0] * bend),
+        "y": _round(center[1] + direction[1] * end_radius * 0.34 + normal[1] * bend),
+    }
+    control_2 = {
+        "x": _round(center[0] + direction[0] * end_radius * 0.72 + normal[0] * bend * 0.45),
+        "y": _round(center[1] + direction[1] * end_radius * 0.72 + normal[1] * bend * 0.45),
+    }
+
+    return {
+        "thread_id": f"thread-{item['trajectory_id']}",
+        "trajectory_id": item["trajectory_id"],
+        "label": item["label"],
+        "allowed": bool(item["allowed"]),
+        "status": status,
+        "governance_reason": item["governance_reason"],
+        "metrics": {
+            "harmonic_coherence": coherence,
+            "orientation_attraction": attraction,
+            "potential_contribution": potential,
+            "reachable_score": float(item["reachable_score"]),
+        },
+        "geometry": {
+            "start": start,
+            "control_1": control_1,
+            "control_2": control_2,
+            "end": end,
+            "angle_radians": _round(angle),
+            "endpoint_radius": _round(_distance(end, center)),
+            "membrane_radius": _round(membrane_radius),
+        },
+        "style": {
+            "stroke_width": _round(1.4 + coherence * 4.2),
+            "opacity": _round((0.32 + attraction * 0.62) if item["allowed"] else 0.48),
+            "dash_pattern": None if item["allowed"] else "10 9",
+        },
+    }
+
+
+def build_reveal(
+    current: ManifoldPoint,
+    trajectories: Iterable[PotentialTrajectory],
+    denied_ids: Sequence[str] = (),
+    *,
+    width: int = 1200,
+    height: int = 800,
+) -> Dict[str, Any]:
+    """Build the deterministic JSON reveal model."""
+    if width < 480 or height < 360:
+        raise ValueError("reveal canvas must be at least 480 x 360")
+
+    trajectory_list = list(trajectories)
+    snapshot = manifold_snapshot(current, trajectory_list, denied_ids=denied_ids)
+    center = (_round(width / 2.0), _round(height / 2.0))
+    membrane_radius = _round(min(width, height) * 0.30)
+
+    ranked = sorted(snapshot["ranked_trajectories"], key=lambda item: item["trajectory_id"])
+    threads = [
+        _thread_geometry(item, center, membrane_radius)
+        for item in ranked
+    ]
+
+    return {
+        "reveal_id": REVEAL_ID,
+        "reveal_class": REVEAL_CLASS,
+        "source_model_id": snapshot["model_id"],
+        "canvas": {
+            "width": int(width),
+            "height": int(height),
+            "center": {"x": center[0], "y": center[1]},
+            "governance_membrane_radius": membrane_radius,
+        },
+        "current_point": snapshot["current_point"],
+        "thread_count": len(threads),
+        "threads": threads,
+        "claims": {
+            "literal_magnetism": LITERAL_MAGNETISM_CLAIM,
+            "identity_proof": IDENTITY_PROOF_CLAIM,
+            "governance_authority": GOVERNANCE_AUTHORITY_CLAIM,
+        },
+        "authority_boundary": AUTHORITY_BOUNDARY,
+    }
+
+
+def _path_data(thread: Mapping[str, Any]) -> str:
+    geometry = thread["geometry"]
+    start = geometry["start"]
+    c1 = geometry["control_1"]
+    c2 = geometry["control_2"]
+    end = geometry["end"]
+    return (
+        f"M {start['x']} {start['y']} "
+        f"C {c1['x']} {c1['y']}, {c2['x']} {c2['y']}, {end['x']} {end['y']}"
+    )
+
+
+def render_svg(reveal: Mapping[str, Any]) -> str:
+    """Render one reveal model as a standalone deterministic SVG."""
+    canvas = reveal["canvas"]
+    width = int(canvas["width"])
+    height = int(canvas["height"])
+    center = canvas["center"]
+    membrane_radius = canvas["governance_membrane_radius"]
+
+    thread_markup: List[str] = []
+    denied_markers: List[str] = []
+    for thread in reveal["threads"]:
+        path = _path_data(thread)
+        style = thread["style"]
+        dash = (
+            f' stroke-dasharray="{style["dash_pattern"]}"'
+            if style["dash_pattern"]
+            else ""
+        )
+        status = escape(str(thread["status"]))
+        trajectory_id = escape(str(thread["trajectory_id"]))
+        label = escape(str(thread["label"]))
+        thread_markup.append(
+            f'<g data-trajectory-id="{trajectory_id}" data-status="{status}">'
+            f"<title>{label}</title>"
+            f'<path d="{path}" class="thread-glow" '
+            f'stroke-width="{style["stroke_width"] + 5.0:.3f}" '
+            f'opacity="{max(0.12, style["opacity"] * 0.32):.3f}"{dash}/>'
+            f'<path d="{path}" class="thread-core" '
+            f'stroke-width="{style["stroke_width"]:.3f}" '
+            f'opacity="{style["opacity"]:.3f}"{dash}/>'
+            "</g>"
+        )
+        if not thread["allowed"]:
+            end = thread["geometry"]["end"]
+            denied_markers.append(
+                f'<g class="denied-marker" data-trajectory-id="{trajectory_id}">'
+                f'<circle cx="{end["x"]}" cy="{end["y"]}" r="11"/>'
+                f'<path d="M {end["x"] - 6} {end["y"] - 6} '
+                f'L {end["x"] + 6} {end["y"] + 6} '
+                f'M {end["x"] + 6} {end["y"] - 6} '
+                f'L {end["x"] - 6} {end["y"] + 6}"/>'
+                "</g>"
+            )
+
+    description = escape(str(reveal["authority_boundary"]))
+    return "\n".join(
+        [
+            f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+            f'role="img" aria-labelledby="reveal-title reveal-desc">',
+            '<title id="reveal-title">Resonant Field Reveal R1</title>',
+            f'<desc id="reveal-desc">{description}</desc>',
+            "<defs>",
+            '<radialGradient id="field-bg" cx="50%" cy="50%" r="70%">',
+            '<stop offset="0%" stop-color="#171321"/>',
+            '<stop offset="58%" stop-color="#08070d"/>',
+            '<stop offset="100%" stop-color="#020204"/>',
+            "</radialGradient>",
+            '<radialGradient id="attractor-fill" cx="42%" cy="38%" r="68%">',
+            '<stop offset="0%" stop-color="#332318"/>',
+            '<stop offset="62%" stop-color="#0b0808"/>',
+            '<stop offset="100%" stop-color="#000000"/>',
+            "</radialGradient>",
+            '<filter id="thread-blur" x="-50%" y="-50%" width="200%" height="200%">',
+            '<feGaussianBlur stdDeviation="6"/>',
+            "</filter>",
+            "</defs>",
+            f'<rect width="{width}" height="{height}" fill="url(#field-bg)"/>',
+            f'<circle cx="{center["x"]}" cy="{center["y"]}" r="{membrane_radius}" '
+            'fill="none" stroke="#d89b58" stroke-width="1.5" '
+            'stroke-dasharray="4 10" opacity="0.42" data-role="governance-membrane"/>',
+            f'<circle cx="{center["x"]}" cy="{center["y"]}" r="{membrane_radius * 0.62:.3f}" '
+            'fill="none" stroke="#9f6c3f" stroke-width="1" opacity="0.18"/>',
+            '<g fill="none" stroke="#f0a75b" stroke-linecap="round" stroke-linejoin="round">',
+            *thread_markup,
+            "</g>",
+            '<g class="denied-markers" fill="#120b0a" stroke="#ffd2a1" stroke-width="2.2">',
+            *denied_markers,
+            "</g>",
+            f'<circle cx="{center["x"]}" cy="{center["y"]}" r="48" '
+            'fill="#f0a75b" opacity="0.12" filter="url(#thread-blur)"/>',
+            f'<circle cx="{center["x"]}" cy="{center["y"]}" r="34" '
+            'fill="url(#attractor-fill)" stroke="#f0a75b" stroke-width="1.8" '
+            'data-role="current-attractor"/>',
+            "</svg>",
+        ]
+    )
+
+
+def _sha256_text(text: str) -> str:
+    return sha256(text.encode("utf-8")).hexdigest()
+
+
+def emit_reveal_artifacts(
+    output_dir: Path | str,
+    current: ManifoldPoint,
+    trajectories: Iterable[PotentialTrajectory],
+    denied_ids: Sequence[str] = (),
+    *,
+    width: int = 1200,
+    height: int = 800,
+) -> Dict[str, Any]:
+    """Write JSON, SVG, and a hash receipt to an explicit output directory."""
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    reveal = build_reveal(
+        current,
+        trajectories,
+        denied_ids=denied_ids,
+        width=width,
+        height=height,
+    )
+    reveal_json = json.dumps(reveal, indent=2, sort_keys=True) + "\n"
+    reveal_svg = render_svg(reveal) + "\n"
+
+    json_path = output_path / "resonant_field_reveal_r1.json"
+    svg_path = output_path / "resonant_field_reveal_r1.svg"
+    receipt_path = output_path / "resonant_field_reveal_r1_receipt.json"
+
+    json_path.write_text(reveal_json, encoding="utf-8")
+    svg_path.write_text(reveal_svg, encoding="utf-8")
+
+    receipt = {
+        "receipt_id": "resonant-field-reveal-r1-receipt",
+        "reveal_id": REVEAL_ID,
+        "artifacts": {
+            json_path.name: _sha256_text(reveal_json),
+            svg_path.name: _sha256_text(reveal_svg),
+        },
+        "authority_boundary": AUTHORITY_BOUNDARY,
+    }
+    receipt_path.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return receipt

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_registry_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_registry_r1.json
@@ -1,0 +1,53 @@
+{
+  "registry_id": "resonant-field-reveal-registry-r1",
+  "status": "experimental",
+  "reveal_id": "resonant-field-reveal-r1",
+  "reveal_class": "deterministic computational field visualization",
+  "source_model": "resonant-manifold-r1",
+  "inputs": [
+    "current manifold point",
+    "potential trajectories",
+    "externally supplied denied trajectory ids"
+  ],
+  "outputs": [
+    "deterministic reveal JSON",
+    "standalone SVG",
+    "SHA-256 artifact receipt"
+  ],
+  "visual_mapping": {
+    "current_point": "central attractor",
+    "trajectory": "luminous thread",
+    "harmonic_coherence": "thread width",
+    "orientation_attraction": "thread opacity and curvature contribution",
+    "potential_contribution": "thread curvature contribution",
+    "reachable_score": "lawful thread reach beyond the governance membrane",
+    "governance_denial": "dashed thread terminated at the governance membrane"
+  },
+  "claims": {
+    "literal_magnetism": false,
+    "identity_proof": false,
+    "continuity_proof": false,
+    "governance_authority": false
+  },
+  "authority_boundary": {
+    "owns": [
+      "derived reveal geometry",
+      "deterministic SVG rendering",
+      "artifact hash receipts"
+    ],
+    "does_not_own": [
+      "governance decisions",
+      "canon state",
+      "mode legality",
+      "checkpoint legality",
+      "identity declaration",
+      "primary continuity truth",
+      "literal electromagnetic claims"
+    ]
+  },
+  "implementation": {
+    "module": "resonant_field_reveal_r1.py",
+    "sea_trial": "sea_trials_resonant_field_reveal_r1.py",
+    "documentation": "../docs/Resonant_Field_Reveal_R1.md"
+  }
+}

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_resonant_field_reveal_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_resonant_field_reveal_r1.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+"""Sea trial for Resonant Field Reveal R1."""
+
+import json
+from math import hypot
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from resonant_field_reveal_r1 import (
+    AUTHORITY_BOUNDARY,
+    GOVERNANCE_AUTHORITY_CLAIM,
+    IDENTITY_PROOF_CLAIM,
+    LITERAL_MAGNETISM_CLAIM,
+    build_reveal,
+    emit_reveal_artifacts,
+    render_svg,
+)
+from resonant_manifold_r1 import ManifoldPoint, PotentialTrajectory
+
+
+def run_trial() -> dict:
+    current = ManifoldPoint(
+        instantiated_state=0.72,
+        continuity_history=0.84,
+        relational_context=0.63,
+        orientation_field=0.78,
+        potential_trajectories=0.40,
+    )
+    shared_first_four = dict(
+        instantiated_state=0.74,
+        continuity_history=0.82,
+        relational_context=0.65,
+        orientation_field=0.80,
+    )
+    trajectories = [
+        PotentialTrajectory(
+            trajectory_id="trajectory-low-potential",
+            label="same present state with constrained possibility",
+            vector=ManifoldPoint(**shared_first_four, potential_trajectories=0.10),
+        ),
+        PotentialTrajectory(
+            trajectory_id="trajectory-high-potential",
+            label="same present state with expanded possibility",
+            vector=ManifoldPoint(**shared_first_four, potential_trajectories=0.90),
+        ),
+        PotentialTrajectory(
+            trajectory_id="trajectory-denied",
+            label="coherent path denied by external governance",
+            vector=ManifoldPoint(
+                instantiated_state=0.73,
+                continuity_history=0.83,
+                relational_context=0.64,
+                orientation_field=0.79,
+                potential_trajectories=0.41,
+            ),
+        ),
+    ]
+
+    reveal_a = build_reveal(
+        current,
+        trajectories,
+        denied_ids=["trajectory-denied"],
+    )
+    reveal_b = build_reveal(
+        current,
+        trajectories,
+        denied_ids=["trajectory-denied"],
+    )
+    by_id = {thread["trajectory_id"]: thread for thread in reveal_a["threads"]}
+    denied = by_id["trajectory-denied"]
+    low = by_id["trajectory-low-potential"]
+    high = by_id["trajectory-high-potential"]
+    center = reveal_a["canvas"]["center"]
+    membrane = reveal_a["canvas"]["governance_membrane_radius"]
+
+    denied_distance = hypot(
+        denied["geometry"]["end"]["x"] - center["x"],
+        denied["geometry"]["end"]["y"] - center["y"],
+    )
+    lawful_distances = [
+        hypot(
+            thread["geometry"]["end"]["x"] - center["x"],
+            thread["geometry"]["end"]["y"] - center["y"],
+        )
+        for thread in reveal_a["threads"]
+        if thread["allowed"]
+    ]
+    svg = render_svg(reveal_a)
+
+    with TemporaryDirectory() as temporary:
+        receipt = emit_reveal_artifacts(
+            Path(temporary),
+            current,
+            trajectories,
+            denied_ids=["trajectory-denied"],
+        )
+        artifacts_exist = all((Path(temporary) / name).is_file() for name in receipt["artifacts"])
+        receipt_exists = (Path(temporary) / "resonant_field_reveal_r1_receipt.json").is_file()
+        hashes_are_sha256 = all(len(value) == 64 for value in receipt["artifacts"].values())
+
+    checks = {
+        "deterministic_reveal": reveal_a == reveal_b,
+        "one_thread_per_trajectory": reveal_a["thread_count"] == len(trajectories),
+        "potential_axis_affects_reveal": (
+            low["metrics"]["potential_contribution"]
+            != high["metrics"]["potential_contribution"]
+            and low["geometry"]["control_1"] != high["geometry"]["control_1"]
+        ),
+        "governance_denial_stops_at_membrane": (
+            denied["allowed"] is False
+            and denied["status"] == "governance_denied"
+            and abs(denied_distance - membrane) < 0.01
+            and all(distance > membrane for distance in lawful_distances)
+        ),
+        "svg_contains_attractor_threads_and_boundary": (
+            'data-role="current-attractor"' in svg
+            and 'data-role="governance-membrane"' in svg
+            and 'data-status="governance_denied"' in svg
+            and all(trajectory.trajectory_id in svg for trajectory in trajectories)
+        ),
+        "artifacts_are_hash_receipted": (
+            artifacts_exist and receipt_exists and hashes_are_sha256
+        ),
+        "no_literal_magnetism_claim": LITERAL_MAGNETISM_CLAIM is False,
+        "no_identity_proof_claim": IDENTITY_PROOF_CLAIM is False,
+        "no_governance_authority_claim": GOVERNANCE_AUTHORITY_CLAIM is False,
+        "authority_boundary_present": (
+            "does not create governance decisions" in AUTHORITY_BOUNDARY
+            and "establish identity" in AUTHORITY_BOUNDARY
+        ),
+    }
+
+    return {
+        "trial_id": "sea-trials-resonant-field-reveal-r1",
+        "passed": all(checks.values()),
+        "checks": checks,
+        "sample_reveal": reveal_a,
+    }
+
+
+if __name__ == "__main__":
+    result = run_trial()
+    print(json.dumps(result, indent=2))
+    raise SystemExit(0 if result["passed"] else 1)


### PR DESCRIPTION
## Summary

Adds a deterministic JSON and SVG visualization layer for Resonant Manifold observations.

## Added

- `runtime/resonant_field_reveal_r1.py`
- `runtime/resonant_field_reveal_registry_r1.json`
- `runtime/sea_trials_resonant_field_reveal_r1.py`
- `docs/Resonant_Field_Reveal_R1.md`

## Updated

- `ACTIVE_RUNTIME_INDEX.md`
- `.github/workflows/lumina-drydock-gate.yml`

## Behavior

The current manifold point is rendered as a central attractor. Candidate trajectories are rendered as luminous threads. Harmonic coherence, orientation attraction, potential contribution, and governed reachability are mapped into deterministic geometry and styling.

Denied trajectories stop at a visible governance membrane. Lawful trajectories may extend beyond it.

The explicit artifact emitter writes JSON, SVG, and a SHA-256 receipt only when an output directory is supplied.

## Validation

The dedicated sea trial checks deterministic output, one thread per trajectory, potential-axis contribution, governance-boundary rendering, SVG structure, artifact hashes, and explicit authority limits.

This remains a standalone experiment and is not wired into the default host path, Bridge, Studio, capability exposure, or runtime governance.
