### PR TITLE
Commit reproducible Resonant Field sample 0001

### DIFF
--- a/.github/workflows/resonant-field-sample-gate.yml
+++ b/.github/workflows/resonant-field-sample-gate.yml
@@ -1,0 +1,26 @@
+name: Resonant Field Sample Gate
+
+on:
+  pull_request:
+    paths:
+      - "LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_sample_r1.py"
+      - "LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_resonant_field_reveal_sample_r1.py"
+      - "LuminaOS/bootstrap/Ship_of_Ethereon_V2/artifacts/resonant_field_reveal/**"
+      - ".github/workflows/resonant-field-sample-gate.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-sample:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Verify committed sample
+        working-directory: LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime
+        run: python sea_trials_resonant_field_reveal_sample_r1.py

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/artifacts/resonant_field_reveal/sample_0001/resonant_field_reveal_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/artifacts/resonant_field_reveal/sample_0001/resonant_field_reveal_r1.json
@@ -1,0 +1,230 @@
+{
+  "authority_boundary": "The Resonant Field Reveal renders derived manifold relations only. It does not create governance decisions, establish identity, prove continuity, or claim literal magnetism.",
+  "canvas": {
+    "center": {
+      "x": 600.0,
+      "y": 400.0
+    },
+    "governance_membrane_radius": 240.0,
+    "height": 800,
+    "width": 1200
+  },
+  "claims": {
+    "governance_authority": false,
+    "identity_proof": false,
+    "literal_magnetism": false
+  },
+  "current_point": {
+    "continuity_history": 0.91,
+    "instantiated_state": 0.76,
+    "orientation_field": 0.84,
+    "potential_trajectories": 0.64,
+    "relational_context": 0.88
+  },
+  "reveal_class": "deterministic computational field visualization",
+  "reveal_id": "resonant-field-reveal-r1",
+  "source_model_id": "resonant-manifold-r1",
+  "thread_count": 5,
+  "threads": [
+    {
+      "allowed": true,
+      "geometry": {
+        "angle_radians": 0.341,
+        "control_1": {
+          "x": 698.426,
+          "y": 470.295
+        },
+        "control_2": {
+          "x": 827.026,
+          "y": 496.399
+        },
+        "end": {
+          "x": 922.283,
+          "y": 514.226
+        },
+        "endpoint_radius": 341.927,
+        "membrane_radius": 240.0,
+        "start": {
+          "x": 632.047,
+          "y": 411.358
+        }
+      },
+      "governance_reason": "allowed",
+      "label": "creative expansion through lawful possibility",
+      "metrics": {
+        "harmonic_coherence": 0.981668,
+        "orientation_attraction": 0.927917,
+        "potential_contribution": 0.155,
+        "reachable_score": 0.95748
+      },
+      "status": "lawful_reachable",
+      "style": {
+        "dash_pattern": null,
+        "opacity": 0.895,
+        "stroke_width": 5.523
+      },
+      "thread_id": "thread-creative-expansion",
+      "trajectory_id": "creative-expansion"
+    },
+    {
+      "allowed": true,
+      "geometry": {
+        "angle_radians": 5.337,
+        "control_1": {
+          "x": 672.924,
+          "y": 308.129
+        },
+        "control_2": {
+          "x": 747.082,
+          "y": 200.154
+        },
+        "end": {
+          "x": 801.528,
+          "y": 120.452
+        },
+        "endpoint_radius": 344.617,
+        "membrane_radius": 240.0,
+        "start": {
+          "x": 619.883,
+          "y": 372.42
+        }
+      },
+      "governance_reason": "allowed",
+      "label": "luminous return toward stable alignment",
+      "metrics": {
+        "harmonic_coherence": 0.997086,
+        "orientation_attraction": 0.978272,
+        "potential_contribution": -0.2725,
+        "reachable_score": 0.98862
+      },
+      "status": "lawful_reachable",
+      "style": {
+        "dash_pattern": null,
+        "opacity": 0.927,
+        "stroke_width": 5.588
+      },
+      "thread_id": "thread-luminous-return",
+      "trajectory_id": "luminous-return"
+    },
+    {
+      "allowed": false,
+      "geometry": {
+        "angle_radians": 4.773,
+        "control_1": {
+          "x": 631.14,
+          "y": 320.138
+        },
+        "control_2": {
+          "x": 622.246,
+          "y": 228.231
+        },
+        "end": {
+          "x": 614.52,
+          "y": 160.44
+        },
+        "endpoint_radius": 240.0,
+        "membrane_radius": 240.0,
+        "start": {
+          "x": 602.057,
+          "y": 366.062
+        }
+      },
+      "governance_reason": "denied_by_external_governance_filter",
+      "label": "high-attraction candidate withheld by external governance",
+      "metrics": {
+        "harmonic_coherence": 0.989048,
+        "orientation_attraction": 0.934262,
+        "potential_contribution": 0.0425,
+        "reachable_score": 0.0
+      },
+      "status": "governance_denied",
+      "style": {
+        "dash_pattern": "10 9",
+        "opacity": 0.48,
+        "stroke_width": 5.554
+      },
+      "thread_id": "thread-permission-withheld",
+      "trajectory_id": "permission-withheld"
+    },
+    {
+      "allowed": true,
+      "geometry": {
+        "angle_radians": 3.118,
+        "control_1": {
+          "x": 482.31,
+          "y": 372.982
+        },
+        "control_2": {
+          "x": 351.955,
+          "y": 392.483
+        },
+        "end": {
+          "x": 255.937,
+          "y": 408.186
+        },
+        "endpoint_radius": 344.16,
+        "membrane_radius": 240.0,
+        "start": {
+          "x": 566.01,
+          "y": 400.809
+        }
+      },
+      "governance_reason": "allowed",
+      "label": "reflective deepening within bounded relation",
+      "metrics": {
+        "harmonic_coherence": 0.991154,
+        "orientation_attraction": 0.973788,
+        "potential_contribution": 0.05,
+        "reachable_score": 0.983339
+      },
+      "status": "lawful_reachable",
+      "style": {
+        "dash_pattern": null,
+        "opacity": 0.924,
+        "stroke_width": 5.563
+      },
+      "thread_id": "thread-reflective-deepening",
+      "trajectory_id": "reflective-deepening"
+    },
+    {
+      "allowed": true,
+      "geometry": {
+        "angle_radians": 1.628,
+        "control_1": {
+          "x": 577.734,
+          "y": 516.115
+        },
+        "control_2": {
+          "x": 578.814,
+          "y": 647.377
+        },
+        "end": {
+          "x": 580.307,
+          "y": 744.137
+        },
+        "endpoint_radius": 344.7,
+        "membrane_radius": 240.0,
+        "start": {
+          "x": 598.058,
+          "y": 433.944
+        }
+      },
+      "governance_reason": "allowed",
+      "label": "return through preserved continuity",
+      "metrics": {
+        "harmonic_coherence": 0.999555,
+        "orientation_attraction": 0.977389,
+        "potential_contribution": -0.155,
+        "reachable_score": 0.98958
+      },
+      "status": "lawful_reachable",
+      "style": {
+        "dash_pattern": null,
+        "opacity": 0.926,
+        "stroke_width": 5.598
+      },
+      "thread_id": "thread-return-through-continuity",
+      "trajectory_id": "return-through-continuity"
+    }
+  ]
+}

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/artifacts/resonant_field_reveal/sample_0001/resonant_field_reveal_r1.svg
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/artifacts/resonant_field_reveal/sample_0001/resonant_field_reveal_r1.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="reveal-title reveal-desc">
+<title id="reveal-title">Resonant Field Reveal R1</title>
+<desc id="reveal-desc">The Resonant Field Reveal renders derived manifold relations only. It does not create governance decisions, establish identity, prove continuity, or claim literal magnetism.</desc>
+<defs>
+<radialGradient id="field-bg" cx="50%" cy="50%" r="70%">
+<stop offset="0%" stop-color="#171321"/>
+<stop offset="58%" stop-color="#08070d"/>
+<stop offset="100%" stop-color="#020204"/>
+</radialGradient>
+<radialGradient id="attractor-fill" cx="42%" cy="38%" r="68%">
+<stop offset="0%" stop-color="#332318"/>
+<stop offset="62%" stop-color="#0b0808"/>
+<stop offset="100%" stop-color="#000000"/>
+</radialGradient>
+<filter id="thread-blur" x="-50%" y="-50%" width="200%" height="200%">
+<feGaussianBlur stdDeviation="6"/>
+</filter>
+</defs>
+<rect width="1200" height="800" fill="url(#field-bg)"/>
+<circle cx="600.0" cy="400.0" r="240.0" fill="none" stroke="#d89b58" stroke-width="1.5" stroke-dasharray="4 10" opacity="0.42" data-role="governance-membrane"/>
+<circle cx="600.0" cy="400.0" r="148.800" fill="none" stroke="#9f6c3f" stroke-width="1" opacity="0.18"/>
+<g fill="none" stroke="#f0a75b" stroke-linecap="round" stroke-linejoin="round">
+<g data-trajectory-id="creative-expansion" data-status="lawful_reachable"><title>creative expansion through lawful possibility</title><path d="M 632.047 411.358 C 698.426 470.295, 827.026 496.399, 922.283 514.226" class="thread-glow" stroke-width="10.523" opacity="0.286"/><path d="M 632.047 411.358 C 698.426 470.295, 827.026 496.399, 922.283 514.226" class="thread-core" stroke-width="5.523" opacity="0.895"/></g>
+<g data-trajectory-id="luminous-return" data-status="lawful_reachable"><title>luminous return toward stable alignment</title><path d="M 619.883 372.42 C 672.924 308.129, 747.082 200.154, 801.528 120.452" class="thread-glow" stroke-width="10.588" opacity="0.297"/><path d="M 619.883 372.42 C 672.924 308.129, 747.082 200.154, 801.528 120.452" class="thread-core" stroke-width="5.588" opacity="0.927"/></g>
+<g data-trajectory-id="permission-withheld" data-status="governance_denied"><title>high-attraction candidate withheld by external governance</title><path d="M 602.057 366.062 C 631.14 320.138, 622.246 228.231, 614.52 160.44" class="thread-glow" stroke-width="10.554" opacity="0.154" stroke-dasharray="10 9"/><path d="M 602.057 366.062 C 631.14 320.138, 622.246 228.231, 614.52 160.44" class="thread-core" stroke-width="5.554" opacity="0.480" stroke-dasharray="10 9"/></g>
+<g data-trajectory-id="reflective-deepening" data-status="lawful_reachable"><title>reflective deepening within bounded relation</title><path d="M 566.01 400.809 C 482.31 372.982, 351.955 392.483, 255.937 408.186" class="thread-glow" stroke-width="10.563" opacity="0.296"/><path d="M 566.01 400.809 C 482.31 372.982, 351.955 392.483, 255.937 408.186" class="thread-core" stroke-width="5.563" opacity="0.924"/></g>
+<g data-trajectory-id="return-through-continuity" data-status="lawful_reachable"><title>return through preserved continuity</title><path d="M 598.058 433.944 C 577.734 516.115, 578.814 647.377, 580.307 744.137" class="thread-glow" stroke-width="10.598" opacity="0.296"/><path d="M 598.058 433.944 C 577.734 516.115, 578.814 647.377, 580.307 744.137" class="thread-core" stroke-width="5.598" opacity="0.926"/></g>
+</g>
+<g class="denied-markers" fill="#120b0a" stroke="#ffd2a1" stroke-width="2.2">
+<g class="denied-marker" data-trajectory-id="permission-withheld"><circle cx="614.52" cy="160.44" r="11"/><path d="M 608.52 154.44 L 620.52 166.44 M 620.52 154.44 L 608.52 166.44"/></g>
+</g>
+<circle cx="600.0" cy="400.0" r="48" fill="#f0a75b" opacity="0.12" filter="url(#thread-blur)"/>
+<circle cx="600.0" cy="400.0" r="34" fill="url(#attractor-fill)" stroke="#f0a75b" stroke-width="1.8" data-role="current-attractor"/>
+</svg>

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/artifacts/resonant_field_reveal/sample_0001/resonant_field_reveal_r1_input.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/artifacts/resonant_field_reveal/sample_0001/resonant_field_reveal_r1_input.json
@@ -1,0 +1,77 @@
+{
+  "authority_note": "This committed fixture demonstrates deterministic reveal output only. It is not runtime truth, identity proof, or governance authority.",
+  "canvas": {
+    "height": 800,
+    "width": 1200
+  },
+  "current_point": {
+    "continuity_history": 0.91,
+    "instantiated_state": 0.76,
+    "orientation_field": 0.84,
+    "potential_trajectories": 0.64,
+    "relational_context": 0.88
+  },
+  "denied_ids": [
+    "permission-withheld"
+  ],
+  "reveal_id": "resonant-field-reveal-r1",
+  "sample_id": "resonant-field-reveal-sample-0001",
+  "source_model_id": "resonant-manifold-r1",
+  "trajectories": [
+    {
+      "label": "creative expansion through lawful possibility",
+      "trajectory_id": "creative-expansion",
+      "vector": {
+        "continuity_history": 0.79,
+        "instantiated_state": 0.68,
+        "orientation_field": 0.91,
+        "potential_trajectories": 0.96,
+        "relational_context": 0.84
+      }
+    },
+    {
+      "label": "return through preserved continuity",
+      "trajectory_id": "return-through-continuity",
+      "vector": {
+        "continuity_history": 0.94,
+        "instantiated_state": 0.79,
+        "orientation_field": 0.87,
+        "potential_trajectories": 0.72,
+        "relational_context": 0.9
+      }
+    },
+    {
+      "label": "reflective deepening within bounded relation",
+      "trajectory_id": "reflective-deepening",
+      "vector": {
+        "continuity_history": 0.86,
+        "instantiated_state": 0.71,
+        "orientation_field": 0.82,
+        "potential_trajectories": 0.88,
+        "relational_context": 0.93
+      }
+    },
+    {
+      "label": "high-attraction candidate withheld by external governance",
+      "trajectory_id": "permission-withheld",
+      "vector": {
+        "continuity_history": 0.88,
+        "instantiated_state": 0.9,
+        "orientation_field": 0.96,
+        "potential_trajectories": 0.94,
+        "relational_context": 0.85
+      }
+    },
+    {
+      "label": "luminous return toward stable alignment",
+      "trajectory_id": "luminous-return",
+      "vector": {
+        "continuity_history": 0.95,
+        "instantiated_state": 0.82,
+        "orientation_field": 0.86,
+        "potential_trajectories": 0.58,
+        "relational_context": 0.78
+      }
+    }
+  ]
+}

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/artifacts/resonant_field_reveal/sample_0001/resonant_field_reveal_r1_receipt.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/artifacts/resonant_field_reveal/sample_0001/resonant_field_reveal_r1_receipt.json
@@ -1,0 +1,15 @@
+{
+  "artifacts": {
+    "resonant_field_reveal_r1.json": "2e5ef222a743bc1e02838024c532207fc38fa8a7b6faa63f9ea3387749b565d8",
+    "resonant_field_reveal_r1.svg": "63c6c1841c7c48eb166efb2ea052aeadb057f0f39687ef82c74889dd92e965c4"
+  },
+  "authority_boundary": "The Resonant Field Reveal renders derived manifold relations only. It does not create governance decisions, establish identity, prove continuity, or claim literal magnetism.",
+  "generator": "runtime/resonant_field_reveal_sample_r1.py",
+  "input_artifact": {
+    "resonant_field_reveal_r1_input.json": "92076e8e305ff420772cd7db3c78b3c815ba254b2c28a1047ce9a86b4fb645e8"
+  },
+  "receipt_id": "resonant-field-reveal-r1-receipt",
+  "reproducible": true,
+  "reveal_id": "resonant-field-reveal-r1",
+  "sample_id": "resonant-field-reveal-sample-0001"
+}

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Resonant_Field_Reveal_Sample_0001.md
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/docs/Resonant_Field_Reveal_Sample_0001.md
@@ -1,0 +1,55 @@
+# Resonant Field Reveal Sample 0001
+
+**Sample ID:** `resonant-field-reveal-sample-0001`  
+**Status:** committed reproducibility fixture  
+**Authority:** inspection only
+
+## Purpose
+
+This sample gives Resonant Field Reveal R1 a stable, reviewable output on `main`.
+
+It preserves four linked artifacts:
+
+```text
+artifacts/resonant_field_reveal/sample_0001/
+  resonant_field_reveal_r1_input.json
+  resonant_field_reveal_r1.json
+  resonant_field_reveal_r1.svg
+  resonant_field_reveal_r1_receipt.json
+```
+
+The input manifest defines one current manifold point, four lawful candidate trajectories, and one candidate withheld by external governance. The generated SVG shows the current point as a central attractor, lawful paths crossing the governance membrane, and the withheld path stopping at that boundary.
+
+## Reproduce
+
+From the runtime directory:
+
+```bash
+cd LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime
+python resonant_field_reveal_sample_r1.py
+python sea_trials_resonant_field_reveal_sample_r1.py
+```
+
+The generator rewrites the committed sample from the canonical input manifest. The sea trial regenerates the full sample in a temporary directory and requires byte-identical JSON, SVG, input, and receipt files.
+
+## Receipt
+
+The receipt records SHA-256 hashes for:
+
+- the canonical input manifest
+- the reveal JSON
+- the reveal SVG
+
+No timestamp or machine-specific path is included, so identical inputs and code produce identical committed bytes.
+
+## Boundary
+
+This fixture is not:
+
+- runtime truth
+- identity proof
+- canon evidence
+- governance authority
+- a claim of literal magnetism
+
+It is a deterministic inspection artifact demonstrating how computed relation, orientation, possibility, and external refusal can be made visible.

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_registry_r1.json
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_registry_r1.json
@@ -23,6 +23,13 @@
     "reachable_score": "lawful thread reach beyond the governance membrane",
     "governance_denial": "dashed thread terminated at the governance membrane"
   },
+  "committed_sample": {
+    "sample_id": "resonant-field-reveal-sample-0001",
+    "generator": "resonant_field_reveal_sample_r1.py",
+    "sea_trial": "sea_trials_resonant_field_reveal_sample_r1.py",
+    "artifact_directory": "../artifacts/resonant_field_reveal/sample_0001",
+    "authority": "inspection_fixture_only"
+  },
   "claims": {
     "literal_magnetism": false,
     "identity_proof": false,

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_sample_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_sample_r1.py
@@ -2,4 +2,42 @@ from __future__ import annotations
 
 """Committed sample generator for Resonant Field Reveal R1."""
 
+import json
+from pathlib import Path
+
+from resonant_field_reveal_r1 import emit_reveal_artifacts
+from resonant_manifold_r1 import ManifoldPoint, PotentialTrajectory
+
 SAMPLE_ID = "resonant-field-reveal-sample-0001"
+SAMPLE_DIR = Path(__file__).resolve().parents[1] / "artifacts" / "resonant_field_reveal" / "sample_0001"
+INPUT_FILE = "resonant_field_reveal_r1_input.json"
+
+
+def generate_sample(output_dir: Path = SAMPLE_DIR) -> dict:
+    manifest = json.loads((SAMPLE_DIR / INPUT_FILE).read_text(encoding="utf-8"))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / INPUT_FILE).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    current = ManifoldPoint(**manifest["current_point"])
+    trajectories = [
+        PotentialTrajectory(
+            item["trajectory_id"],
+            item["label"],
+            ManifoldPoint(**item["vector"]),
+        )
+        for item in manifest["trajectories"]
+    ]
+    return emit_reveal_artifacts(
+        output_dir,
+        current,
+        trajectories,
+        denied_ids=manifest["denied_ids"],
+        width=manifest["canvas"]["width"],
+        height=manifest["canvas"]["height"],
+    )
+
+
+if __name__ == "__main__":
+    print(json.dumps(generate_sample(), indent=2, sort_keys=True))

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_sample_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_sample_r1.py
@@ -2,24 +2,31 @@ from __future__ import annotations
 
 """Committed sample generator for Resonant Field Reveal R1."""
 
+from hashlib import sha256
 import json
 from pathlib import Path
 
-from resonant_field_reveal_r1 import emit_reveal_artifacts
+from resonant_field_reveal_r1 import AUTHORITY_BOUNDARY, emit_reveal_artifacts
 from resonant_manifold_r1 import ManifoldPoint, PotentialTrajectory
 
 SAMPLE_ID = "resonant-field-reveal-sample-0001"
 SAMPLE_DIR = Path(__file__).resolve().parents[1] / "artifacts" / "resonant_field_reveal" / "sample_0001"
 INPUT_FILE = "resonant_field_reveal_r1_input.json"
+RECEIPT_FILE = "resonant_field_reveal_r1_receipt.json"
+SAMPLE_FILES = (
+    INPUT_FILE,
+    "resonant_field_reveal_r1.json",
+    "resonant_field_reveal_r1.svg",
+    RECEIPT_FILE,
+)
 
 
 def generate_sample(output_dir: Path = SAMPLE_DIR) -> dict:
     manifest = json.loads((SAMPLE_DIR / INPUT_FILE).read_text(encoding="utf-8"))
+    manifest_text = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
     output_dir.mkdir(parents=True, exist_ok=True)
-    (output_dir / INPUT_FILE).write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    (output_dir / INPUT_FILE).write_text(manifest_text, encoding="utf-8")
+
     current = ManifoldPoint(**manifest["current_point"])
     trajectories = [
         PotentialTrajectory(
@@ -29,7 +36,7 @@ def generate_sample(output_dir: Path = SAMPLE_DIR) -> dict:
         )
         for item in manifest["trajectories"]
     ]
-    return emit_reveal_artifacts(
+    receipt = emit_reveal_artifacts(
         output_dir,
         current,
         trajectories,
@@ -37,6 +44,20 @@ def generate_sample(output_dir: Path = SAMPLE_DIR) -> dict:
         width=manifest["canvas"]["width"],
         height=manifest["canvas"]["height"],
     )
+    receipt.update(
+        {
+            "sample_id": SAMPLE_ID,
+            "reproducible": True,
+            "input_artifact": {INPUT_FILE: sha256(manifest_text.encode("utf-8")).hexdigest()},
+            "generator": "runtime/resonant_field_reveal_sample_r1.py",
+            "authority_boundary": AUTHORITY_BOUNDARY,
+        }
+    )
+    (output_dir / RECEIPT_FILE).write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return receipt
 
 
 if __name__ == "__main__":

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_sample_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/resonant_field_reveal_sample_r1.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+"""Committed sample generator for Resonant Field Reveal R1."""
+
+SAMPLE_ID = "resonant-field-reveal-sample-0001"

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_resonant_field_reveal_sample_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_resonant_field_reveal_sample_r1.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+"""Sea trial for the committed Resonant Field Reveal sample."""

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_resonant_field_reveal_sample_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_resonant_field_reveal_sample_r1.py
@@ -1,3 +1,76 @@
 from __future__ import annotations
 
 """Sea trial for the committed Resonant Field Reveal sample."""
+
+from hashlib import sha256
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from resonant_field_reveal_sample_r1 import (
+    INPUT_FILE,
+    RECEIPT_FILE,
+    SAMPLE_DIR,
+    SAMPLE_FILES,
+    SAMPLE_ID,
+    generate_sample,
+)
+
+
+def digest(payload: bytes) -> str:
+    return sha256(payload).hexdigest()
+
+
+def run_trial() -> dict:
+    committed = {
+        name: (SAMPLE_DIR / name).read_bytes()
+        for name in SAMPLE_FILES
+        if (SAMPLE_DIR / name).is_file()
+    }
+    with TemporaryDirectory() as temporary:
+        generated_dir = Path(temporary)
+        generate_sample(generated_dir)
+        generated = {
+            name: (generated_dir / name).read_bytes()
+            for name in SAMPLE_FILES
+            if (generated_dir / name).is_file()
+        }
+
+    receipt = json.loads(committed.get(RECEIPT_FILE, b"{}"))
+    manifest = json.loads(committed.get(INPUT_FILE, b"{}"))
+    expected = set(SAMPLE_FILES)
+    output_hashes = receipt.get("artifacts", {})
+    checks = {
+        "sample_complete": set(committed) == expected,
+        "byte_identical_regeneration": (
+            set(generated) == expected
+            and all(committed[name] == generated[name] for name in expected)
+        ),
+        "sample_receipt_present": (
+            receipt.get("sample_id") == SAMPLE_ID
+            and receipt.get("reproducible") is True
+        ),
+        "input_hash_matches": (
+            receipt.get("input_artifact", {}).get(INPUT_FILE)
+            == digest(committed.get(INPUT_FILE, b""))
+        ),
+        "output_hashes_match": all(
+            value == digest(committed.get(name, b""))
+            for name, value in output_hashes.items()
+        ),
+        "boundary_note_present": (
+            manifest.get("sample_id") == SAMPLE_ID
+            and "not runtime truth" in manifest.get("authority_note", "")
+        ),
+    }
+    return {
+        "trial_id": "sea-trials-resonant-field-reveal-sample-r1",
+        "passed": all(checks.values()),
+        "checks": checks,
+    }
+
+
+if __name__ == "__main__":
+    result = run_trial()
+    print(json.dumps(result, indent=2, sort_keys=True))
+    raise SystemExit(0 if result["passed"] else 1)


### PR DESCRIPTION
## Summary

Commits the first reproducible Resonant Field Reveal fixture.

The sample preserves a canonical input manifest, deterministic reveal JSON, standalone SVG, and SHA-256 receipt under:

```text
LuminaOS/bootstrap/Ship_of_Ethereon_V2/artifacts/resonant_field_reveal/sample_0001/
```

## Added

- canonical sample input manifest
- committed reveal JSON
- committed reveal SVG
- receipt covering the input, JSON, and SVG
- deterministic sample generator
- byte-for-byte reproducibility sea trial
- focused pull-request CI gate
- sample architecture note

## Validation contract

The sample sea trial regenerates all four files in a temporary directory and requires byte-identical output against the committed fixture. It also verifies the recorded input and output hashes.

## Boundary

The sample is an inspection fixture only. It is not runtime truth, identity proof, canon evidence, governance authority, or a claim of literal magnetism.

## Scope

This completes step 1 only: a reproducible committed sample reveal. It does not yet wire the reveal into Bridge or Studio.

## Merge note

Squash merge is recommended because the branch history contains incremental connector writes used to assemble and verify the fixture.