### PR TITLE
Add Lumina Windows lifecycle verification R1

### DIFF
--- a/.github/workflows/lumina-windows-installer-r1.yml
+++ b/.github/workflows/lumina-windows-installer-r1.yml
@@ -5,13 +5,15 @@ on:
     paths:
       - "deploy/windows_desktop_r1/**"
       - "docs/LUMINA_WINDOWS_GRAPHICAL_INSTALLER_R1.md"
+      - "docs/ACTIVE_SURFACE_REGISTRY_R1.json"
       - ".github/workflows/lumina-windows-installer-r1.yml"
   push:
     branches:
-      - "lumina-graphical-installer-r1c"
+      - "main"
     paths:
       - "deploy/windows_desktop_r1/**"
       - "docs/LUMINA_WINDOWS_GRAPHICAL_INSTALLER_R1.md"
+      - "docs/ACTIVE_SURFACE_REGISTRY_R1.json"
       - ".github/workflows/lumina-windows-installer-r1.yml"
   workflow_dispatch:
 
@@ -66,7 +68,8 @@ jobs:
         run: |
           python deploy/windows_desktop_r1/verify_lumina_desktop_setup_r1.py `
             --setup (Join-Path $env:LUMINA_INSTALLER_ROOT "LuminaDesktopBetaR1-Setup.exe") `
-            --receipt (Join-Path $env:LUMINA_INSTALLER_ROOT "LuminaDesktopBetaR1-Setup-receipt.json")
+            --receipt (Join-Path $env:LUMINA_INSTALLER_ROOT "LuminaDesktopBetaR1-Setup-receipt.json") `
+            --lifecycle-receipt (Join-Path $env:LUMINA_INSTALLER_ROOT "LuminaDesktopBetaR1-Setup-lifecycle-receipt.json")
 
       - name: Upload diagnostics
         if: failure()
@@ -76,6 +79,9 @@ jobs:
           path: |
             ${{ runner.temp }}/lumina-install.log
             ${{ runner.temp }}/lumina-upgrade.log
+            ${{ runner.temp }}/lumina-uninstall.log
+            ${{ runner.temp }}/lumina-lifecycle.log
+            ${{ runner.temp }}/lumina-installer/LuminaDesktopBetaR1-Setup-lifecycle-receipt.json
           if-no-files-found: ignore
           retention-days: 3
 
@@ -86,5 +92,6 @@ jobs:
           path: |
             ${{ runner.temp }}/lumina-installer/LuminaDesktopBetaR1-Setup.exe
             ${{ runner.temp }}/lumina-installer/LuminaDesktopBetaR1-Setup-receipt.json
+            ${{ runner.temp }}/lumina-installer/LuminaDesktopBetaR1-Setup-lifecycle-receipt.json
           if-no-files-found: error
           retention-days: 14

--- a/deploy/windows_desktop_r1/verify_lumina_desktop_setup_r1.py
+++ b/deploy/windows_desktop_r1/verify_lumina_desktop_setup_r1.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate Lumina desktop installation and upgrade continuity on Windows."""
+"""Validate Lumina desktop installer lifecycle behavior on Windows."""
 from __future__ import annotations
 
 import argparse
@@ -11,7 +11,15 @@ import subprocess
 import traceback
 
 
-TRIAL_ID = "lumina-desktop-setup-r1"
+TRIAL_ID = "lumina-desktop-setup-lifecycle-r1"
+AUTHORITY_BOUNDARY = (
+    "The setup lifecycle trial verifies Windows desktop packaging, upgrade, "
+    "uninstall, and state preservation only; it does not alter runtime "
+    "governance, canon, mode legality, capability authority, identity, or "
+    "primary continuity truth."
+)
+CONTINUITY_MARKER_TEXT = "continuity-held"
+LAUNCHABLE_SUFFIXES = {".bat", ".cmd", ".exe", ".ps1", ".py"}
 
 
 def run_checked(command: list[str]) -> None:
@@ -26,6 +34,13 @@ def run_cmd(path: Path, *arguments: str) -> None:
     run_checked(["cmd.exe", "/d", "/c", str(path), *arguments])
 
 
+def read_json_object(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"expected JSON object receipt: {path}")
+    return payload
+
+
 def sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -34,15 +49,93 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def default_lifecycle_receipt_path(setup_receipt: Path) -> Path:
+    if setup_receipt.name.endswith("-receipt.json"):
+        return setup_receipt.with_name(
+            setup_receipt.name.replace("-receipt.json", "-lifecycle-receipt.json")
+        )
+    return setup_receipt.with_name(f"{setup_receipt.stem}-lifecycle-receipt.json")
+
+
+def write_lifecycle_receipt(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def find_inno_uninstaller(install_root: Path) -> Path:
+    uninstallers = sorted(
+        (candidate for candidate in install_root.glob("unins*.exe") if candidate.is_file()),
+        key=lambda candidate: (candidate.stat().st_mtime, candidate.name),
+        reverse=True,
+    )
+    if not uninstallers:
+        raise RuntimeError(
+            "Inno Setup uninstaller is missing; hosted uninstall cannot be verified"
+        )
+    return uninstallers[0]
+
+
+def assert_marker_text(marker: Path, failure: str) -> None:
+    if not marker.is_file():
+        raise RuntimeError(failure)
+    if marker.read_text(encoding="utf-8").strip() != CONTINUITY_MARKER_TEXT:
+        raise RuntimeError(failure)
+
+
+def assert_replaceable_machinery_removed_or_inactive(install_root: Path) -> None:
+    app_root = install_root / "app"
+    runtime_root = install_root / "runtime"
+    bin_root = install_root / "bin"
+    app_payload_root = app_root / "EthereonLabs"
+    ship_root = app_payload_root / "LuminaOS" / "bootstrap" / "Ship_of_Ethereon_V2"
+
+    expected_active_paths = [
+        bin_root / "lumina.cmd",
+        bin_root / "lumina-bridge.cmd",
+        runtime_root / "python" / "python.exe",
+        ship_root / "bin" / "lumina",
+        ship_root / "bin" / "lumina-bridge",
+        app_payload_root / "deploy" / "windows_desktop_r1" / "launchers" / "lumina.cmd",
+        app_payload_root
+        / "deploy"
+        / "windows_desktop_r1"
+        / "launchers"
+        / "lumina-bridge.cmd",
+        app_payload_root / ".lumina_state",
+    ]
+    remaining_expected = [str(path) for path in expected_active_paths if path.exists()]
+    if remaining_expected:
+        raise RuntimeError(
+            "replaceable installer machinery remains active after uninstall: "
+            + ", ".join(remaining_expected)
+        )
+
+    for root in (app_root, runtime_root, bin_root):
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if path.is_file() and path.suffix.lower() in LAUNCHABLE_SUFFIXES:
+                raise RuntimeError(
+                    "replaceable installer machinery still contains a launchable file "
+                    f"after uninstall: {path}"
+                )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--setup", type=Path, required=True)
     parser.add_argument("--receipt", type=Path, required=True)
+    parser.add_argument("--lifecycle-receipt", type=Path)
     parser.add_argument("--install-root", type=Path)
     args = parser.parse_args()
 
     setup = args.setup.resolve()
     receipt_path = args.receipt.resolve()
+    lifecycle_receipt_path = (
+        args.lifecycle_receipt.resolve()
+        if args.lifecycle_receipt is not None
+        else default_lifecycle_receipt_path(receipt_path)
+    )
     local_app_data = os.environ.get("LOCALAPPDATA")
     if not local_app_data and args.install_root is None:
         raise RuntimeError("LOCALAPPDATA is unavailable")
@@ -52,58 +145,95 @@ def main() -> int:
         else Path(local_app_data) / "Lumina"
     )
 
-    install_log = Path(os.environ.get("RUNNER_TEMP", install_root.parent)) / "lumina-install.log"
-    upgrade_log = Path(os.environ.get("RUNNER_TEMP", install_root.parent)) / "lumina-upgrade.log"
+    diagnostic_root = Path(os.environ.get("RUNNER_TEMP", install_root.parent))
+    install_log = diagnostic_root / "lumina-install.log"
+    upgrade_log = diagnostic_root / "lumina-upgrade.log"
+    uninstall_log = diagnostic_root / "lumina-uninstall.log"
     silent = ["/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-"]
 
-    run_checked([str(setup), *silent, f"/LOG={install_log}"])
-
-    lumina = install_root / "bin" / "lumina.cmd"
-    bridge = install_root / "bin" / "lumina-bridge.cmd"
-    python_executable = install_root / "runtime" / "python" / "python.exe"
-    if not lumina.is_file() or not bridge.is_file() or not python_executable.is_file():
-        raise RuntimeError("required installed launch surfaces are missing")
-
-    run_cmd(lumina, "doctor", "--json")
-    run_cmd(lumina, "project", "create", "Installer Project", "--open", "--json")
-    run_cmd(lumina, "session", "create", "Installer Session", "--open", "--json")
-    run_cmd(bridge, "--help")
-
-    marker = (
-        install_root
-        / "state"
-        / "ship_of_ethereon_v2"
-        / "installer-continuity-marker.txt"
-    )
-    marker.parent.mkdir(parents=True, exist_ok=True)
-    marker.write_text("continuity-held\n", encoding="utf-8")
-
-    run_checked([str(setup), *silent, f"/LOG={upgrade_log}"])
-    if marker.read_text(encoding="utf-8").strip() != "continuity-held":
-        raise RuntimeError("continuity marker did not return after upgrade")
-    run_cmd(lumina, "project", "active", "--json")
-    run_cmd(lumina, "session", "active", "--json")
-
-    receipt = json.loads(receipt_path.read_text(encoding="utf-8-sig"))
-    if receipt.get("installer_sha256") != sha256_file(setup):
-        raise RuntimeError("setup receipt hash does not match")
-    if receipt.get("signed") is not False:
-        raise RuntimeError("developer preview signing claim must remain false")
-    if receipt.get("state_preserved_on_upgrade") is not True:
-        raise RuntimeError("upgrade continuity boundary is missing")
-
-    result = {
+    installer_sha256 = sha256_file(setup)
+    lifecycle_receipt: dict[str, object] = {
+        "schema_version": "lumina-windows-installer-lifecycle-receipt-r1",
         "trial_id": TRIAL_ID,
-        "passed": True,
-        "setup_sha256": sha256_file(setup),
+        "passed": False,
+        "install_validated": False,
+        "upgrade_validated": False,
+        "uninstall_validated": False,
+        "state_preserved_on_upgrade": False,
+        "state_preserved_on_uninstall": False,
+        "replaceable_machinery_removed_or_inactive": False,
+        "signed": None,
+        "installer_sha256": installer_sha256,
         "install_root": str(install_root),
-        "state_preserved_after_upgrade": True,
-        "authority_boundary": (
-            "The setup trial verifies packaging and state preservation only; "
-            "runtime governance remains authoritative."
-        ),
+        "setup_receipt": str(receipt_path),
+        "logs": {
+            "install": str(install_log),
+            "upgrade": str(upgrade_log),
+            "uninstall": str(uninstall_log),
+        },
+        "authority_boundary": AUTHORITY_BOUNDARY,
     }
-    print(json.dumps(result, indent=2))
+
+    try:
+        receipt = read_json_object(receipt_path)
+        lifecycle_receipt["signed"] = receipt.get("signed")
+        if receipt.get("installer_sha256") != installer_sha256:
+            raise RuntimeError("setup receipt hash does not match")
+        if receipt.get("signed") is not False:
+            raise RuntimeError("developer preview signing claim must remain false")
+        if receipt.get("state_preserved_on_upgrade") is not True:
+            raise RuntimeError("upgrade continuity boundary is missing")
+        if receipt.get("state_preserved_on_uninstall_contract") is not True:
+            raise RuntimeError("uninstall state-preservation contract is missing")
+        if receipt.get("uninstall_validated") is not False:
+            raise RuntimeError("build receipt must not claim uninstall validation")
+
+        run_checked([str(setup), *silent, f"/LOG={install_log}"])
+
+        lumina = install_root / "bin" / "lumina.cmd"
+        bridge = install_root / "bin" / "lumina-bridge.cmd"
+        python_executable = install_root / "runtime" / "python" / "python.exe"
+        if not lumina.is_file() or not bridge.is_file() or not python_executable.is_file():
+            raise RuntimeError("required installed launch surfaces are missing")
+
+        run_cmd(lumina, "doctor", "--json")
+        run_cmd(lumina, "project", "create", "Installer Project", "--open", "--json")
+        run_cmd(lumina, "session", "create", "Installer Session", "--open", "--json")
+        run_cmd(bridge, "--help")
+        lifecycle_receipt["install_validated"] = True
+
+        marker = (
+            install_root
+            / "state"
+            / "ship_of_ethereon_v2"
+            / "installer-continuity-marker.txt"
+        )
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(CONTINUITY_MARKER_TEXT + "\n", encoding="utf-8")
+
+        run_checked([str(setup), *silent, f"/LOG={upgrade_log}"])
+        assert_marker_text(marker, "continuity marker did not return after upgrade")
+        lifecycle_receipt["state_preserved_on_upgrade"] = True
+        run_cmd(lumina, "project", "active", "--json")
+        run_cmd(lumina, "session", "active", "--json")
+        lifecycle_receipt["upgrade_validated"] = True
+
+        uninstaller = find_inno_uninstaller(install_root)
+        run_checked([str(uninstaller), *silent, f"/LOG={uninstall_log}"])
+        assert_marker_text(marker, "continuity marker did not remain after uninstall")
+        lifecycle_receipt["state_preserved_on_uninstall"] = True
+        assert_replaceable_machinery_removed_or_inactive(install_root)
+        lifecycle_receipt["replaceable_machinery_removed_or_inactive"] = True
+        lifecycle_receipt["uninstall_validated"] = True
+
+    except Exception as exc:
+        lifecycle_receipt["failure"] = str(exc)
+        write_lifecycle_receipt(lifecycle_receipt_path, lifecycle_receipt)
+        raise
+
+    lifecycle_receipt["passed"] = True
+    write_lifecycle_receipt(lifecycle_receipt_path, lifecycle_receipt)
+    print(json.dumps(lifecycle_receipt, indent=2))
     return 0
 
 
@@ -114,7 +244,7 @@ if __name__ == "__main__":
         raise
     except Exception:
         diagnostic_root = Path(os.environ.get("RUNNER_TEMP", Path.cwd()))
-        diagnostic_path = diagnostic_root / "lumina-upgrade.log"
+        diagnostic_path = diagnostic_root / "lumina-lifecycle.log"
         with diagnostic_path.open("a", encoding="utf-8") as handle:
             handle.write("\n--- Lumina setup sea-trial traceback ---\n")
             handle.write(traceback.format_exc())

--- a/docs/ACTIVE_SURFACE_REGISTRY_R1.json
+++ b/docs/ACTIVE_SURFACE_REGISTRY_R1.json
@@ -75,7 +75,22 @@
       "validation_paths": [
         ".github/workflows/lumina-windows-installer-r1.yml"
       ],
-      "authority_boundary": "Owns desktop packaging, placement, launchers, upgrade behavior, and build receipts. It does not alter runtime governance, canon, capability authority, identity, or primary continuity truth."
+      "lifecycle_receipt": {
+        "artifact_name": "LuminaDesktopBetaR1-Setup-lifecycle-receipt.json",
+        "emitted_by": "deploy/windows_desktop_r1/verify_lumina_desktop_setup_r1.py",
+        "required_fields": [
+          "install_validated",
+          "upgrade_validated",
+          "uninstall_validated",
+          "state_preserved_on_upgrade",
+          "state_preserved_on_uninstall",
+          "signed",
+          "installer_sha256",
+          "authority_boundary"
+        ],
+        "truth_scope": "Hosted Windows installer lifecycle evidence only; it is not a signed release, public-readiness claim, SmartScreen claim, runtime governance claim, canon claim, mode-legality claim, capability-authority claim, identity claim, or primary continuity claim."
+      },
+      "authority_boundary": "Owns desktop packaging, placement, launchers, upgrade/removal behavior, and installer lifecycle receipts. It does not alter runtime governance, canon, capability authority, identity, or primary continuity truth."
     },
     {
       "surface_id": "chamber_public_surface",

--- a/docs/LUMINA_WINDOWS_GRAPHICAL_INSTALLER_R1.md
+++ b/docs/LUMINA_WINDOWS_GRAPHICAL_INSTALLER_R1.md
@@ -13,6 +13,7 @@ It produces:
 ```text
 LuminaDesktopBetaR1-Setup.exe
 LuminaDesktopBetaR1-Setup-receipt.json
+LuminaDesktopBetaR1-Setup-lifecycle-receipt.json
 ```
 
 The setup executable installs Lumina, the pinned embedded Python runtime, command launchers, and Start Menu entries without requiring repository knowledge or a separate Python installation.
@@ -39,7 +40,9 @@ Continuity state lives beneath:
 
 The hosted sea trial proves that an in-place upgrade preserves the continuity marker, active project, and Harbor session.
 
-The setup definition also marks the state tree as persistent during normal application removal. That removal path is configured but not yet covered by the automated sea trial. The build receipt records this honestly with an explicit contract field and `uninstall_validated: false`.
+The hosted lifecycle sea trial also runs the generated Inno Setup uninstaller, proves the expected app/runtime/bin launch machinery is removed or no longer active, and proves the continuity marker remains under the state tree after normal application removal.
+
+The build receipt remains a build receipt and keeps `uninstall_validated: false`. The lifecycle receipt is the artifact that may record `install_validated`, `upgrade_validated`, `uninstall_validated`, `state_preserved_on_upgrade`, and `state_preserved_on_uninstall` after the verifier proves those fields in hosted Windows CI.
 
 A directory junction preserves compatibility with components that still resolve the historical repository-local `.lumina_state` path.
 
@@ -73,9 +76,13 @@ build bundled release payload
   -> upgrade in place
   -> prove project, session, and marker return
   -> verify setup SHA-256 receipt
+  -> uninstall with the generated Inno Setup uninstaller
+  -> prove app/runtime/bin launch machinery is removed or inactive
+  -> prove the continuity marker remains after uninstall
+  -> emit lifecycle receipt
 ```
 
-The successful setup executable and receipt are uploaded as temporary workflow artifacts.
+The successful setup executable, build receipt, and lifecycle receipt are uploaded as temporary workflow artifacts.
 
 ## Signing boundary
 
@@ -85,12 +92,12 @@ Code signing requires a separate publisher identity and signing credential decis
 
 ## Authority boundary
 
-The installer owns desktop file placement, launchers, upgrade behavior, removal configuration, and packaging receipts.
+The installer owns desktop file placement, launchers, upgrade behavior, removal behavior, and packaging/lifecycle receipts.
 
 It does not own runtime governance, mode legality, capability authority, canon promotion, identity declaration, or primary continuity truth.
 
 ## Next threshold
 
-The next technical gates are automated removal verification, first-run configuration, repair, backup and restore, release signing, and a clean physical-PC receipt.
+The next technical gates are first-run configuration, repair, backup and restore, release signing, and a clean physical-PC lifecycle receipt.
 
 > The door may become simple without making the vessel simplistic.


### PR DESCRIPTION
## Summary

- Run the Windows installer workflow on relevant pushes to `main` while keeping scoped PR filters and manual dispatch.
- Extend the Windows setup verifier from install/upgrade evidence into lifecycle evidence by adding uninstall verification, replaceable machinery removal/inactivity checks, state preservation checks, and a bounded lifecycle receipt.
- Update the Windows installer documentation and active surface registry to describe only the evidence-backed lifecycle receipt scope.

## Validation

- `python3 -m json.tool docs/ACTIVE_SURFACE_REGISTRY_R1.json`
- `python3 -m py_compile deploy/windows_desktop_r1/verify_lumina_desktop_setup_r1.py scripts/repository_truth_reconciliation_gate_r1.py`
- `python3 scripts/repository_truth_reconciliation_gate_r1.py`
- Applicable Lumina DryDock gate commands run locally on macOS: compileall, host alignment, core runtime sea trials, bridge sea trials, and CLI smoke checks
- `git diff --check`
- `python3 deploy/windows_desktop_r1/verify_lumina_desktop_setup_r1.py --help`

## Boundary

This remains an unsigned Windows developer-preview lifecycle verification path. It does not claim signed release readiness, ordinary-user public readiness, frictionless SmartScreen behavior, runtime governance authority, canon authority, mode legality changes, capability authority changes, identity truth, or primary continuity truth.

Closes #409