### PR TITLE
Add in-house build preference note

### DIFF
--- a/docs/IN_HOUSE_BUILD_PREFERENCE_R1.md
+++ b/docs/IN_HOUSE_BUILD_PREFERENCE_R1.md
@@ -1,0 +1,48 @@
+# In-House Build Preference R1
+
+**Project:** EthereonLabs  
+**Status:** active operating preference  
+**Scope:** repository work, review flow, and contributor orientation  
+**Authority:** guidance only; not runtime governance law
+
+## Purpose
+
+EthereonLabs should prefer in-house design, drafting, and review whenever practical.
+
+The project may still use external automation or implementation agents, including Codex, but those agents should be treated as bounded mechanical assistants rather than primary architectural authorities.
+
+## Operating Preference
+
+For repository changes, prefer this order:
+
+1. Define the purpose, boundary, expected evidence, and non-claims in-house.
+2. Draft the patch directly in-house when the change is small, textual, structural, or review-sensitive.
+3. Use automation only for narrow implementation tasks where it materially reduces repetitive work.
+4. Review every generated change before merge against repository truth, authority boundaries, receipt scope, and overclaim risk.
+5. Merge only when the evidence produced by the change matches the claims made by the change.
+
+## Codex Boundary
+
+Codex may be useful as a drafting or implementation assistant.
+
+Codex should not be treated as the keeper of Ethereon continuity, governance meaning, canon authority, symbolic boundary discipline, or architectural intent.
+
+When Codex or another automation agent produces work, the review posture is:
+
+- verify changed files directly
+- verify receipts and test evidence directly
+- confirm no field is marked true without proof
+- confirm no documentation overclaims evidence
+- confirm no runtime governance, canon, mode legality, capability authority, identity truth, or primary continuity truth was mutated accidentally
+
+## Preferred Division of Labor
+
+Codex may help weld the plate.
+
+EthereonLabs keeps authority over where the keel goes.
+
+## Authority Boundary
+
+This document records a contributor and operator preference.
+
+It does not alter runtime governance, canon lineage, mode legality, capability exposure, release readiness, identity truth, or primary continuity truth.


### PR DESCRIPTION
## Summary

- Add `docs/IN_HOUSE_BUILD_PREFERENCE_R1.md` as an operating preference for EthereonLabs repository work.
- Record that design, claim scope, evidence expectations, and review posture should be held in-house whenever practical.
- Bound Codex and other automation agents as narrow implementation assistants, not continuity/governance/architecture authorities.

## Boundary

This is contributor/operator guidance only. It does not alter runtime governance, canon lineage, mode legality, capability exposure, release readiness, identity truth, or primary continuity truth.