### PR TITLE
Bound Windows return-host artifact paths

### DIFF
--- a/.github/workflows/lumina-drydock-gate.yml
+++ b/.github/workflows/lumina-drydock-gate.yml
@@ -64,6 +64,8 @@ jobs:
         working-directory: LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime
         run: |
           python sea_trials_set_one_r1_merged.py
+          python sea_trials_lumina_return_host_r1.py
+          python sea_trials_windows_return_host_path_budget_r1.py
           python sea_trials_resonant_manifold_r1.py
           python sea_trials_resonant_field_reveal_r1.py
           python sea_trials_resonant_field_reveal_sample_r1.py

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_return_host_repo_native_bridge_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/lumina_return_host_repo_native_bridge_r1.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+import json
 
 try:
     from .project_return_repo_native_r1 import ProjectReturnStore
@@ -10,16 +14,57 @@ except Exception:
     from workspace_host_repo_native_r1 import WorkspaceHostStore
 
 
+PATH_BUDGET = 240
+RESERVED_CHILD_PATH = 96
+COMPACT_NAMESPACE = "return_host"
+
+
+def _digest_token(value: str, length: int = 16) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()[:length]
+
+
+def bounded_storage_root(base_dir: str | Path) -> Path:
+    """Return a deterministic physical root with room for child artifacts.
+
+    Runtime callers may supply a semantically useful namespace containing full
+    session IDs and action labels. Those values remain in receipts, but when the
+    projected child path would exceed the portable budget the physical storage
+    root is compacted beneath the runtime owner directory.
+    """
+
+    requested = Path(base_dir)
+    if len(str(requested)) + RESERVED_CHILD_PATH <= PATH_BUDGET:
+        return requested
+
+    anchor = requested
+    while anchor.parent != anchor and anchor.name != "lumina_return_host_artifacts":
+        anchor = anchor.parent
+    owner_root = anchor.parent if anchor.name == "lumina_return_host_artifacts" else requested.parent
+    return owner_root / COMPACT_NAMESPACE / _digest_token(str(requested))
+
+
+def _checkpoint_storage_label(label: str) -> str:
+    return f"checkpoint-{_digest_token(label)}"
+
+
 @dataclass
 class HostSnapshot:
     snapshot_id: str
 
 
 class ContinuityRestoreStore:
-    """Compatibility bridge that presents the older spike-facing API over the repo-native project return store."""
+    """Compatibility bridge over the repo-native project return store.
+
+    Full semantic identifiers remain inside JSON payloads. Physical storage may
+    use a compact deterministic root and compact checkpoint filename so an
+    installed Windows prefix cannot exhaust the filesystem path budget.
+    """
 
     def __init__(self, base_dir: str | Path):
-        self._store = ProjectReturnStore(base_dir)
+        self.requested_base_dir = Path(base_dir)
+        self.storage_base_dir = bounded_storage_root(self.requested_base_dir)
+        self.storage_root_compacted = self.storage_base_dir != self.requested_base_dir
+        self._store = ProjectReturnStore(self.storage_base_dir)
 
     def create_session(
         self,
@@ -42,17 +87,41 @@ class ContinuityRestoreStore:
         self._store.save_session(session)
 
     def write_checkpoint(self, session_id: str, label: str):
-        return self._store.write_checkpoint(session_id, label)
+        storage_label = _checkpoint_storage_label(label)
+        path = self._store.write_checkpoint(session_id, storage_label)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["checkpoint_label"] = label
+        payload["storage_label"] = storage_label
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return path
 
     def project_return_payload(self, project_id: str) -> dict:
-        return self._store.project_return_payload(project_id)
+        payload = self._store.project_return_payload(project_id)
+        local_host_bundle = self.storage_base_dir / "host_bundles" / f"{WorkspaceHostStore._safe_slug(project_id)}.json"
+        if local_host_bundle.exists():
+            host_bundle = json.loads(local_host_bundle.read_text(encoding="utf-8"))
+            payload["host_bundle"] = host_bundle
+            payload["return_strategy"] = "checkpoint_plus_host"
+            latest_restore = payload.get("latest_restore")
+            if isinstance(latest_restore, dict):
+                latest_restore["linked_host_bundle"] = str(local_host_bundle)
+        payload["storage"] = {
+            "requested_base_dir": str(self.requested_base_dir),
+            "storage_base_dir": str(self.storage_base_dir),
+            "storage_root_compacted": self.storage_root_compacted,
+            "path_budget": PATH_BUDGET,
+        }
+        return payload
 
 
 class LuminaWorkspaceHost:
-    """Compatibility bridge that presents the older spike-facing host API over the repo-native workspace host store."""
+    """Compatibility bridge over the repo-native workspace host store."""
 
     def __init__(self, base_dir: str | Path):
-        self._store = WorkspaceHostStore(base_dir)
+        self.requested_base_dir = Path(base_dir)
+        self.storage_base_dir = bounded_storage_root(self.requested_base_dir)
+        self.storage_root_compacted = self.storage_base_dir != self.requested_base_dir
+        self._store = WorkspaceHostStore(self.storage_base_dir)
 
     def create_host_session(
         self,
@@ -159,4 +228,11 @@ class LuminaWorkspaceHost:
     def emit_host_bundle(self, project_id: str) -> dict:
         path = self._store._bundle_path(project_id)
         with path.open("r", encoding="utf-8") as f:
-            return __import__("json").load(f)
+            payload = json.load(f)
+        payload["storage"] = {
+            "requested_base_dir": str(self.requested_base_dir),
+            "storage_base_dir": str(self.storage_base_dir),
+            "storage_root_compacted": self.storage_root_compacted,
+            "path_budget": PATH_BUDGET,
+        }
+        return payload

--- a/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_windows_return_host_path_budget_r1.py
+++ b/LuminaOS/bootstrap/Ship_of_Ethereon_V2/runtime/sea_trials_windows_return_host_path_budget_r1.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable
+import json
+import shutil
+import tempfile
+
+try:
+    from .runtime_runner_r1_merged import RuntimeRunner
+    from .lumina_return_host_repo_native_bridge_r1 import PATH_BUDGET
+except Exception:
+    from runtime_runner_r1_merged import RuntimeRunner
+    from lumina_return_host_repo_native_bridge_r1 import PATH_BUDGET
+
+
+TARGET_WINDOWS_RUNTIME_BASE_LENGTH = 123
+DEFAULT_STUDIO_ACTION = "studio_runtime_cycle_v0_3_2"
+DEFAULT_STUDIO_PROJECT = "lumina-os"
+
+
+def _windows_prefix_length_base(test_root: Path) -> Path:
+    prefix = test_root / "installed_windows_runtime"
+    padding_length = max(1, TARGET_WINDOWS_RUNTIME_BASE_LENGTH - len(str(prefix)) - 1)
+    return prefix / ("x" * padding_length)
+
+
+def _nested_values(node: Any, key: str) -> Iterable[Any]:
+    if isinstance(node, dict):
+        for item_key, value in node.items():
+            if item_key == key:
+                yield value
+            yield from _nested_values(value, key)
+    elif isinstance(node, list):
+        for value in node:
+            yield from _nested_values(value, key)
+
+
+def main() -> Dict[str, Any]:
+    test_root = Path(tempfile.gettempdir()) / "lumina_windows_return_host_path_budget_r1"
+    if test_root.exists():
+        shutil.rmtree(test_root)
+    test_root.mkdir(parents=True, exist_ok=True)
+
+    runtime_base = _windows_prefix_length_base(test_root)
+    runtime_base.mkdir(parents=True, exist_ok=True)
+
+    legacy_projected_sessions_path = (
+        runtime_base
+        / "lumina_return_host_artifacts"
+        / "4c7a7a99-640c-4b2e-a7f0-2c90a1904e4a"
+        / f"{DEFAULT_STUDIO_PROJECT}_{DEFAULT_STUDIO_ACTION}_Observation"
+        / "sessions"
+    )
+
+    runner = RuntimeRunner(
+        base_dir=runtime_base,
+        registry_path=Path(__file__).with_name("capability_registry_r1.json"),
+    )
+    result = runner.run_cycle(
+        current_mode="Continuity",
+        target_mode="Observation",
+        requested_action=DEFAULT_STUDIO_ACTION,
+        action_type="audit",
+        enabled_feature_flags=["ETHEREON_CONTINUITY_RESTORE", "ETHEREON_LUMINA_HOST"],
+        runtime_config={
+            "toki_pona_required_for_resume": False,
+            "binary_required_for_transition_validation": False,
+            "light_language_required_for_capability_loading": False,
+            "harmonic_frequency_required_for_mode_legality": False,
+        },
+        raw_user_input="Review Lumina OS progress and produce the next governed action receipt.",
+        project_id=DEFAULT_STUDIO_PROJECT,
+    )
+    payload = result.to_dict()
+
+    return_host = payload.get("lumina_return_host_artifacts") or {}
+    checkpoint_only = return_host.get("checkpoint_only") or {}
+    checkpoint_plus_host = return_host.get("checkpoint_plus_host") or {}
+    checkpoint_only_payload = checkpoint_only.get("payload") or {}
+    checkpoint_plus_payload = checkpoint_plus_host.get("payload") or {}
+    storage = checkpoint_plus_payload.get("storage") or checkpoint_only_payload.get("storage") or {}
+
+    storage_base_dir = Path(str(storage.get("storage_base_dir", "")))
+    written_paths = [
+        Path(payload["checkpoint_path"]),
+        Path(payload["session_path"]),
+        Path(payload["log_path"]),
+        Path(payload["governance_log_path"]),
+        Path(str(checkpoint_only.get("checkpoint_path", ""))),
+        Path(str(checkpoint_plus_host.get("checkpoint_path", ""))),
+    ]
+    written_paths.extend(path for path in storage_base_dir.rglob("*") if path.is_file())
+    written_paths = [path for path in written_paths if str(path) not in {"", "."}]
+
+    missing_paths = [str(path) for path in written_paths if not path.exists()]
+    path_lengths = {str(path): len(str(path)) for path in written_paths}
+    longest_path = max(path_lengths, key=path_lengths.get) if path_lengths else None
+    longest_path_length = path_lengths.get(longest_path, 0) if longest_path else 0
+
+    full_session_ids = list(_nested_values(checkpoint_plus_payload, "session_id"))
+    checks = {
+        "simulated_runtime_base_matches_physical_length": len(str(runtime_base)) >= TARGET_WINDOWS_RUNTIME_BASE_LENGTH,
+        "legacy_projection_reproduces_windows_boundary": len(str(legacy_projected_sessions_path)) >= 248,
+        "cycle_completed": payload.get("halted") is False and bool(payload.get("run_id")),
+        "final_receipt_written": Path(payload["log_path"]).is_file(),
+        "runtime_checkpoint_written": Path(payload["checkpoint_path"]).is_file(),
+        "return_host_checkpoint_only_written": Path(str(checkpoint_only.get("checkpoint_path", ""))).is_file(),
+        "return_host_checkpoint_plus_host_written": Path(str(checkpoint_plus_host.get("checkpoint_path", ""))).is_file(),
+        "checkpoint_plus_host_resolved": checkpoint_plus_payload.get("return_strategy") == "checkpoint_plus_host",
+        "storage_root_compacted": storage.get("storage_root_compacted") is True,
+        "storage_root_is_bounded": storage_base_dir.is_dir() and len(str(storage_base_dir)) < len(str(legacy_projected_sessions_path)),
+        "all_recorded_paths_exist": not missing_paths,
+        "all_written_paths_within_budget": longest_path_length <= PATH_BUDGET,
+        "full_session_identifier_preserved_in_payload": any(isinstance(value, str) and len(value) == 36 for value in full_session_ids),
+        "governance_reached_checkpoint": payload.get("governance_chain_status", {}).get("valid") is True,
+    }
+
+    summary = {
+        "suite": "Windows Return / Host Path Budget Sea Trial R1",
+        "passed": all(checks.values()),
+        "path_budget": PATH_BUDGET,
+        "simulated_runtime_base": str(runtime_base),
+        "simulated_runtime_base_length": len(str(runtime_base)),
+        "legacy_projected_sessions_path": str(legacy_projected_sessions_path),
+        "legacy_projected_sessions_path_length": len(str(legacy_projected_sessions_path)),
+        "storage_base_dir": str(storage_base_dir),
+        "storage_base_dir_length": len(str(storage_base_dir)),
+        "longest_written_path": longest_path,
+        "longest_written_path_length": longest_path_length,
+        "missing_paths": missing_paths,
+        "checks": checks,
+        "run_id": payload.get("run_id"),
+        "governance_log_path": payload.get("governance_log_path"),
+    }
+
+    report_path = test_root / "sea_trials_windows_return_host_path_budget_r1_report.json"
+    report_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    if not summary["passed"]:
+        raise SystemExit(json.dumps(summary, indent=2))
+
+    return {"summary_path": str(report_path), "summary": summary}
+
+
+if __name__ == "__main__":
+    print(json.dumps(main(), indent=2))


### PR DESCRIPTION
## Summary

Repairs the physical Windows Studio failure recorded in #412.

The return/host compatibility bridge now:

- preserves the full semantic runtime namespace in receipts
- compacts only the physical storage root when the projected child path would exceed a portable 240-character budget
- uses a deterministic compact checkpoint storage label while retaining the full checkpoint label inside JSON
- exposes requested-versus-physical storage metadata in return/host payloads
- resolves the local host bundle from the shared compact storage root

## Validation added

- restores the existing Lumina return/host handshake trial to the DryDock gate
- adds `sea_trials_windows_return_host_path_budget_r1.py`
- reproduces the observed 248-character legacy `sessions` boundary using the default Studio project/action labels
- performs a real governed runtime cycle under a simulated 123-character installed Windows runtime prefix
- requires checkpoint-only and checkpoint-plus-host artifacts, final receipt, valid governance chain, preserved full session identifiers, and all written paths within budget

## Physical evidence

The repair responds to two exact physical-PC failures:

- `[WinError 206]` at the 248-character `sessions` directory
- `[Errno 2]` at the 260-character session JSON path after shortening operator labels

## Validation result

All triggered checks pass on the PR head:

- Lumina DryDock Gate
- Lumina Runtime Sea Trial
- Lumina Orchestration Continuity Sea Trial
- Netlify deploy preview

## Follow-up

Named Studio runtime error codes and bounded operator diagnostics are tracked separately in #414 so storage portability and error-surface work remain reviewable as distinct changes.

## Authority boundary

No mode legality, mutation permission, promotion gate, canon lineage, capability authority, identity truth, or primary continuity truth changes.

Closes #412