### PR TITLE
Validate governed Studio cycles in Windows installer CI

### DIFF
--- a/.github/workflows/lumina-windows-installer-r1.yml
+++ b/.github/workflows/lumina-windows-installer-r1.yml
@@ -3,6 +3,7 @@ name: Lumina Windows Installer R1
 on:
   pull_request:
     paths:
+      - "LuminaOS/bootstrap/Ship_of_Ethereon_V2/**"
       - "deploy/windows_desktop_r1/**"
       - "docs/LUMINA_WINDOWS_GRAPHICAL_INSTALLER_R1.md"
       - "docs/ACTIVE_SURFACE_REGISTRY_R1.json"
@@ -11,6 +12,7 @@ on:
     branches:
       - "main"
     paths:
+      - "LuminaOS/bootstrap/Ship_of_Ethereon_V2/**"
       - "deploy/windows_desktop_r1/**"
       - "docs/LUMINA_WINDOWS_GRAPHICAL_INSTALLER_R1.md"
       - "docs/ACTIVE_SURFACE_REGISTRY_R1.json"

--- a/.github/workflows/lumina-windows-release-r1.yml
+++ b/.github/workflows/lumina-windows-release-r1.yml
@@ -3,6 +3,14 @@ name: Lumina Windows Release R1
 on:
   pull_request:
     paths:
+      - "LuminaOS/bootstrap/Ship_of_Ethereon_V2/**"
+      - "deploy/windows_desktop_r1/**"
+      - ".github/workflows/lumina-windows-release-r1.yml"
+  push:
+    branches:
+      - "main"
+    paths:
+      - "LuminaOS/bootstrap/Ship_of_Ethereon_V2/**"
       - "deploy/windows_desktop_r1/**"
       - ".github/workflows/lumina-windows-release-r1.yml"
   workflow_dispatch:

--- a/deploy/windows_desktop_r1/verify_lumina_desktop_setup_r1.py
+++ b/deploy/windows_desktop_r1/verify_lumina_desktop_setup_r1.py
@@ -13,13 +13,16 @@ import traceback
 
 TRIAL_ID = "lumina-desktop-setup-lifecycle-r1"
 AUTHORITY_BOUNDARY = (
-    "The setup lifecycle trial verifies Windows desktop packaging, upgrade, "
-    "uninstall, and state preservation only; it does not alter runtime "
-    "governance, canon, mode legality, capability authority, identity, or "
-    "primary continuity truth."
+    "The setup lifecycle trial verifies Windows desktop packaging, installed "
+    "Studio execution, upgrade, uninstall, and state preservation only; it does "
+    "not alter runtime governance, canon, mode legality, capability authority, "
+    "identity, or primary continuity truth."
 )
 CONTINUITY_MARKER_TEXT = "continuity-held"
 LAUNCHABLE_SUFFIXES = {".bat", ".cmd", ".exe", ".ps1", ".py"}
+STUDIO_PROMPT = "Review Lumina OS progress and produce the next governed action receipt."
+STUDIO_PROJECT_ID = "lumina-os"
+STUDIO_ACTION = "studio_runtime_cycle_v0_3_2"
 
 
 def run_checked(command: list[str]) -> None:
@@ -28,6 +31,30 @@ def run_checked(command: list[str]) -> None:
         raise RuntimeError(
             f"command failed with exit code {completed.returncode}: {command[0]}"
         )
+
+
+def run_json_checked(command: list[str]) -> dict[str, object]:
+    completed = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise RuntimeError(
+            f"command failed with exit code {completed.returncode}: {command[0]}: {detail}"
+        )
+    try:
+        payload = json.loads(completed.stdout)
+    except Exception as exc:
+        raise RuntimeError(
+            f"command did not emit a JSON object: {command[0]}: {completed.stdout[-1200:]}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"command emitted non-object JSON: {command[0]}")
+    return payload
 
 
 def run_cmd(path: Path, *arguments: str) -> None:
@@ -80,6 +107,73 @@ def assert_marker_text(marker: Path, failure: str) -> None:
         raise RuntimeError(failure)
     if marker.read_text(encoding="utf-8").strip() != CONTINUITY_MARKER_TEXT:
         raise RuntimeError(failure)
+
+
+def validate_installed_studio_cycle(
+    *,
+    python_executable: Path,
+    app_payload_root: Path,
+    action: str,
+) -> dict[str, object]:
+    studio_cli = (
+        app_payload_root
+        / "LuminaOS"
+        / "bootstrap"
+        / "Ship_of_Ethereon_V2"
+        / "studio"
+        / "lumina_cli.py"
+    )
+    if not studio_cli.is_file():
+        raise RuntimeError(f"installed Studio CLI is missing: {studio_cli}")
+
+    receipt = run_json_checked(
+        [
+            str(python_executable),
+            str(studio_cli),
+            STUDIO_PROMPT,
+            "--current-mode",
+            "Continuity",
+            "--target-mode",
+            "Observation",
+            "--action-type",
+            "audit",
+            "--action",
+            action,
+            "--project-id",
+            STUDIO_PROJECT_ID,
+            "--focus",
+            "continuity",
+            "--depth",
+            "structural",
+            "--intent",
+            "verify",
+            "--receipt-json",
+        ]
+    )
+
+    if receipt.get("halted") is not False:
+        raise RuntimeError(f"installed Studio cycle halted: {receipt.get('halt_reason')}")
+    if receipt.get("governance_chain_valid") is not True:
+        raise RuntimeError("installed Studio cycle did not return a valid governance chain")
+    if receipt.get("lumina_project_id") != STUDIO_PROJECT_ID:
+        raise RuntimeError("installed Studio cycle did not preserve the requested project ID")
+
+    checkpoint_path = Path(str(receipt.get("checkpoint_path", "")))
+    log_path = Path(str(receipt.get("log_path", "")))
+    if not checkpoint_path.is_file():
+        raise RuntimeError(f"installed Studio cycle checkpoint is missing: {checkpoint_path}")
+    if not log_path.is_file():
+        raise RuntimeError(f"installed Studio cycle receipt is missing: {log_path}")
+
+    capabilities = set(receipt.get("exposed_capability_ids") or [])
+    required_capabilities = {"continuity_restore_store", "lumina_workspace_host"}
+    if not required_capabilities.issubset(capabilities):
+        raise RuntimeError(
+            "installed Studio cycle did not expose the return/host capabilities: "
+            + ", ".join(sorted(required_capabilities - capabilities))
+        )
+
+    return receipt
 
 
 def assert_replaceable_machinery_removed_or_inactive(install_root: Path) -> None:
@@ -157,11 +251,14 @@ def main() -> int:
         "trial_id": TRIAL_ID,
         "passed": False,
         "install_validated": False,
+        "studio_cycle_validated": False,
         "upgrade_validated": False,
+        "studio_upgrade_cycle_validated": False,
         "uninstall_validated": False,
         "state_preserved_on_upgrade": False,
         "state_preserved_on_uninstall": False,
         "replaceable_machinery_removed_or_inactive": False,
+        "studio_cycle_receipts": {},
         "signed": None,
         "installer_sha256": installer_sha256,
         "install_root": str(install_root),
@@ -193,6 +290,7 @@ def main() -> int:
         lumina = install_root / "bin" / "lumina.cmd"
         bridge = install_root / "bin" / "lumina-bridge.cmd"
         python_executable = install_root / "runtime" / "python" / "python.exe"
+        app_payload_root = install_root / "app" / "EthereonLabs"
         if not lumina.is_file() or not bridge.is_file() or not python_executable.is_file():
             raise RuntimeError("required installed launch surfaces are missing")
 
@@ -201,6 +299,14 @@ def main() -> int:
         run_cmd(lumina, "session", "create", "Installer Session", "--open", "--json")
         run_cmd(bridge, "--help")
         lifecycle_receipt["install_validated"] = True
+
+        install_studio_receipt = validate_installed_studio_cycle(
+            python_executable=python_executable,
+            app_payload_root=app_payload_root,
+            action=STUDIO_ACTION,
+        )
+        lifecycle_receipt["studio_cycle_receipts"]["install"] = install_studio_receipt
+        lifecycle_receipt["studio_cycle_validated"] = True
 
         marker = (
             install_root
@@ -217,6 +323,14 @@ def main() -> int:
         run_cmd(lumina, "project", "active", "--json")
         run_cmd(lumina, "session", "active", "--json")
         lifecycle_receipt["upgrade_validated"] = True
+
+        upgrade_studio_receipt = validate_installed_studio_cycle(
+            python_executable=python_executable,
+            app_payload_root=app_payload_root,
+            action=f"{STUDIO_ACTION}_upgrade",
+        )
+        lifecycle_receipt["studio_cycle_receipts"]["upgrade"] = upgrade_studio_receipt
+        lifecycle_receipt["studio_upgrade_cycle_validated"] = True
 
         uninstaller = find_inno_uninstaller(install_root)
         run_checked([str(uninstaller), *silent, f"/LOG={uninstall_log}"])


### PR DESCRIPTION
## Summary

Closes the validation gap recorded in #415.

The hosted Windows lifecycle trial now executes the installed `studio/lumina_cli.py` with the same default project/action values used by Lumina Studio v0.3.2. It requires:

- a non-halted governed cycle
- valid governance chain
- preserved `lumina-os` project ID
- return/host capabilities exposed
- checkpoint file present
- final runtime receipt present

The trial repeats the governed Studio cycle after in-place upgrade and records both compact receipts in the lifecycle receipt.

## Workflow alignment

Both Windows installer and bundled-release workflows now trigger when the packaged `LuminaOS/bootstrap/Ship_of_Ethereon_V2/**` payload changes. The installer continues to run on pushes to `main`, so a merged runtime repair produces a fresh setup artifact for physical-PC retesting.

## Why

The prior hosted lifecycle trial validated Doctor, project/session creation, Bridge, upgrade, and uninstall but never crossed the installed Studio runtime path. That allowed the Windows return/host path-budget defect from #412 to escape CI.

## Validation result

All triggered checks pass:

- Lumina DryDock Gate
- Lumina Windows Host R1
- Lumina Windows Release R1
- Lumina Windows Installer R1

The generated lifecycle receipt records:

- `passed: true`
- `studio_cycle_validated: true`
- `studio_upgrade_cycle_validated: true`
- install and upgrade Studio receipts both non-halted with valid governance chains
- checkpoint and final runtime receipt paths present
- return/host capabilities exposed
- upgrade and uninstall state preservation retained

Validated setup SHA-256: `9d274f35f42eb15728e2eda8e301e0328820a66edc3817a888bc455ffeb48749`

## Authority boundary

This changes packaged execution validation and workflow coverage only. It does not alter mode legality, mutation permission, promotion gates, canon lineage, capability authority, identity truth, or primary continuity truth.

Closes #415