### PR TITLE
Add manual Lumina DryDock dispatch

### DIFF
--- a/.github/workflows/lumina-drydock-gate.yml
+++ b/.github/workflows/lumina-drydock-gate.yml
@@ -1,6 +1,7 @@
 name: Lumina DryDock Gate
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "LuminaOS/bootstrap/Ship_of_Ethereon_V2/**"


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` to the existing Lumina DryDock Gate so the full governed validation suite can be launched directly without nudging documentation or unrelated runtime files.

## DryDock finding

The gate already covered pull requests and scoped pushes to `main`, but it had no manual launch surface. A fresh inspection therefore had to rerun a prior PR job rather than start the current branch cleanly.

## Scope

- workflow trigger only
- no runtime, governance, canon, capability, deployment, or public-claim behavior changes
- the existing compile, reconciliation, host-alignment, core sea-trial, Bridge, smoke-check, and local-state checks remain unchanged

## Validation

Opening this PR itself triggers the full Lumina DryDock Gate against current `main` plus this one-line workflow repair.